### PR TITLE
feat: rename distribution to lifeos-cli

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,16 +82,16 @@ jobs:
           import pathlib
 
           dist_dir = pathlib.Path("dist")
-          wheels = sorted(dist_dir.glob("lifeos-*.whl"))
-          sdists = sorted(dist_dir.glob("lifeos-*.tar.gz"))
+          wheels = sorted(dist_dir.glob("lifeos_cli-*.whl"))
+          sdists = sorted(dist_dir.glob("lifeos_cli-*.tar.gz"))
           if len(wheels) != 1:
               raise SystemExit(f"Expected exactly one wheel in dist/, found {len(wheels)}")
           if len(sdists) != 1:
               raise SystemExit(f"Expected exactly one sdist in dist/, found {len(sdists)}")
           wheel = wheels[0].name
           sdist = sdists[0].name
-          version = wheel.removeprefix("lifeos-").split("-py3", 1)[0]
-          sdist_version = sdist.removeprefix("lifeos-").removesuffix(".tar.gz")
+          version = wheel.removeprefix("lifeos_cli-").split("-py3", 1)[0]
+          sdist_version = sdist.removeprefix("lifeos_cli-").removesuffix(".tar.gz")
           tag = os.environ["RELEASE_TAG"].removeprefix("v")
           if version != tag:
               raise SystemExit(f"Wheel version {version!r} does not match tag {tag!r}")

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,6 @@ repos:
     hooks:
       - id: mypy
         name: mypy
-        entry: uv run mypy src/lifeos tests
+        entry: uv run mypy src/lifeos_cli tests
         language: system
         pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Contributing
 
-Thanks for contributing to `lifeos`.
+Thanks for contributing to `lifeos-cli`.
 
-This repository is a Python project for personal operating system workflows, tools, and automation. Changes should keep package metadata, CI behavior, security expectations, and release workflows aligned.
+This repository ships the `lifeos-cli` distribution and the `lifeos` command-line entrypoint. Changes should keep package metadata, CLI behavior, CI, security expectations, and release workflows aligned.
 
 ## Before You Start
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# lifeos
+# lifeos-cli
 
-`lifeos` is a Python project for building personal operating system workflows, tools, and automation.
+`lifeos-cli` is the command-line package for LifeOS workflows, tools, and automation.
 
 ## Development
 
@@ -16,6 +16,14 @@
    ```bash
    bash ./scripts/doctor.sh
    ```
+
+## CLI
+
+Install the package and run:
+
+```bash
+lifeos --help
+```
 
 ## Tooling
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,9 @@ requires = ["setuptools>=77", "setuptools-scm[toml]>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "lifeos"
+name = "lifeos-cli"
 dynamic = ["version"]
-description = "Personal operating system workflows, tools, and automation."
+description = "Command-line tooling for personal operating system workflows, tools, and automation."
 readme = "README.md"
 requires-python = ">=3.10"
 license = "Apache-2.0"
@@ -23,6 +23,9 @@ classifiers = [
 ]
 dependencies = []
 
+[project.scripts]
+lifeos = "lifeos.cli:main"
+
 [project.optional-dependencies]
 dev = [
     "mypy>=1.18,<2.0",
@@ -33,9 +36,9 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/liujuanjuan1984/lifeos"
-Repository = "https://github.com/liujuanjuan1984/lifeos"
-Issues = "https://github.com/liujuanjuan1984/lifeos/issues"
+Homepage = "https://github.com/liujuanjuan1984/lifeos-cli"
+Repository = "https://github.com/liujuanjuan1984/lifeos-cli"
+Issues = "https://github.com/liujuanjuan1984/lifeos-cli/issues"
 
 [tool.ruff]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 dependencies = []
 
 [project.scripts]
-lifeos = "lifeos.cli:main"
+lifeos = "lifeos_cli.cli:main"
 
 [project.optional-dependencies]
 dev = [
@@ -60,7 +60,7 @@ package-dir = { "" = "src" }
 where = ["src"]
 
 [tool.setuptools.package-data]
-lifeos = ["py.typed"]
+lifeos_cli = ["py.typed"]
 
 [tool.setuptools_scm]
 fallback_version = "0+unknown"
@@ -68,7 +68,7 @@ tag_regex = "^v?(?P<version>.+)$"
 
 [tool.mypy]
 python_version = "3.10"
-files = ["src/lifeos", "tests"]
+files = ["src/lifeos_cli", "tests"]
 show_error_codes = true
 pretty = true
 warn_redundant_casts = true

--- a/src/lifeos/cli.py
+++ b/src/lifeos/cli.py
@@ -1,0 +1,31 @@
+"""CLI entrypoint for the lifeos package."""
+
+from __future__ import annotations
+
+import argparse
+from importlib.metadata import PackageNotFoundError, version
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the top-level CLI parser."""
+    parser = argparse.ArgumentParser(prog="lifeos", description="LifeOS command-line interface")
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {get_version()}",
+    )
+    return parser
+
+
+def get_version() -> str:
+    """Return the installed distribution version when available."""
+    try:
+        return version("lifeos-cli")
+    except PackageNotFoundError:
+        return "0+unknown"
+
+
+def main() -> int:
+    """Run the CLI."""
+    build_parser().parse_args()
+    return 0

--- a/src/lifeos_cli/__init__.py
+++ b/src/lifeos_cli/__init__.py
@@ -1,4 +1,4 @@
-"""Top-level package for lifeos."""
+"""Top-level package for lifeos_cli."""
 
 from .core import get_app_name
 

--- a/src/lifeos_cli/cli.py
+++ b/src/lifeos_cli/cli.py
@@ -1,4 +1,4 @@
-"""CLI entrypoint for the lifeos package."""
+"""CLI entrypoint for the lifeos_cli package."""
 
 from __future__ import annotations
 

--- a/src/lifeos_cli/core.py
+++ b/src/lifeos_cli/core.py
@@ -1,6 +1,6 @@
-"""Core helpers for the lifeos package."""
+"""Core helpers for the lifeos_cli package."""
 
 
 def get_app_name() -> str:
     """Return the canonical package name."""
-    return "lifeos"
+    return "lifeos_cli"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,4 @@
-from lifeos.cli import build_parser
+from lifeos_cli.cli import build_parser
 
 
 def test_cli_parser_uses_lifeos_command_name() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,7 @@
+from lifeos.cli import build_parser
+
+
+def test_cli_parser_uses_lifeos_command_name() -> None:
+    parser = build_parser()
+
+    assert parser.prog == "lifeos"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,5 @@
-from lifeos import get_app_name
+from lifeos_cli import get_app_name
 
 
 def test_get_app_name() -> None:
-    assert get_app_name() == "lifeos"
+    assert get_app_name() == "lifeos_cli"

--- a/uv.lock
+++ b/uv.lock
@@ -341,7 +341,7 @@ wheels = [
 ]
 
 [[package]]
-name = "lifeos"
+name = "lifeos-cli"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## 变更概览
- 将仓库名统一为 `lifeos-cli`
- 将 PyPI 分发名统一调整为 `lifeos-cli`
- 将源码 import 包路径统一调整为 `lifeos_cli`
- 保持 CLI 命令入口为 `lifeos`
- 同步更新发布工件校验、质量门禁配置、仓库链接与基础文档

## 模块变更
### 包与入口
- `[project].name` 改为 `lifeos-cli`
- 新增 `lifeos = "lifeos_cli.cli:main"` 控制台入口
- 源码目录从 `src/lifeos` 调整为 `src/lifeos_cli`
- 测试导入与包内文案同步切换到 `lifeos_cli`

### 发布与构建
- `publish` workflow 的 wheel/sdist 工件匹配改为 `lifeos_cli-*`
- `uv.lock` 同步更新分发名
- `pre-commit` 中的 mypy 检查路径改为 `src/lifeos_cli`
- 项目链接切换到新仓库 `liujuanjuan1984/lifeos-cli`

### 文档
- README 与 CONTRIBUTING 同步调整为 `lifeos-cli` 分发名 + `lifeos` 命令组合

## 验证
- `bash ./scripts/doctor.sh`
- `uv run lifeos --help`
- `uv build --no-sources`

Closes #7
