### PR TITLE
feat: add habit, event, timelog, and people links

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Today the primary delivered slice is:
 - database connectivity checks and migrations
 - note capture, listing, search, inspection, and batch editing
 - initial `area`, `tag`, `people`, `vision`, and `task` domain foundations
+- full `habit` and `habit-action` foundations with generated daily action records
 
 The event and time-tracking domains still need additional naming cleanup before they are migrated.
 
@@ -60,7 +61,15 @@ uv tool install lifeos-cli
    lifeos task add "Draft release checklist" --vision-id <vision-id>
    ```
 
-5. Run a batch delete operation when needed:
+5. Create and inspect a habit:
+
+   ```bash
+   lifeos habit add "Daily Exercise" --start-date 2026-04-09 --duration-days 21
+   lifeos habit list --with-stats
+   lifeos habit-action list --action-date 2026-04-09
+   ```
+
+6. Run a batch delete operation when needed:
 
    ```bash
    lifeos task batch delete --ids <task-id-1> <task-id-2>

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Today the primary delivered slice is:
 - database connectivity checks and migrations
 - note capture, listing, search, inspection, and batch editing
 - initial `area`, `tag`, `people`, `vision`, and `task` domain foundations
+- planned schedule `event` workflows
+- actual time-record `timelog` workflows
 - full `habit` and `habit-action` foundations with generated daily action records
-
-The event and time-tracking domains still need additional naming cleanup before they are migrated.
 
 ## Install
 
@@ -61,7 +61,14 @@ uv tool install lifeos-cli
    lifeos task add "Draft release checklist" --vision-id <vision-id>
    ```
 
-5. Create and inspect a habit:
+5. Create an event and a timelog:
+
+   ```bash
+   lifeos event add "Doctor appointment" --start-time 2026-04-10T09:00:00-04:00
+   lifeos timelog add "Deep work" --start-time 2026-04-10T13:00:00-04:00 --end-time 2026-04-10T14:30:00-04:00
+   ```
+
+6. Create and inspect a habit:
 
    ```bash
    lifeos habit add "Daily Exercise" --start-date 2026-04-09 --duration-days 21
@@ -69,7 +76,7 @@ uv tool install lifeos-cli
    lifeos habit-action list --action-date 2026-04-09
    ```
 
-6. Run a batch delete operation when needed:
+7. Run a batch delete operation when needed:
 
    ```bash
    lifeos task batch delete --ids <task-id-1> <task-id-2>

--- a/alembic/versions/20260409_1300_create_habit_tables.py
+++ b/alembic/versions/20260409_1300_create_habit_tables.py
@@ -1,0 +1,144 @@
+"""Create habit and habit_action tables."""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260409_1300"
+down_revision = "20260409_1200"
+branch_labels = None
+depends_on = None
+
+
+def _schema_name() -> str:
+    context = op.get_context()
+    return context.version_table_schema or "lifeos"
+
+
+def upgrade() -> None:
+    schema_name = _schema_name()
+
+    op.create_table(
+        "habits",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("title", sa.String(length=200), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("start_date", sa.Date(), nullable=False),
+        sa.Column("duration_days", sa.Integer(), nullable=False),
+        sa.Column("status", sa.String(length=20), nullable=False),
+        sa.Column("task_id", sa.Uuid(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["task_id"],
+            [f"{schema_name}.tasks.id"],
+            name=op.f("fk_habits_task_id_tasks"),
+            ondelete="SET NULL",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_habits")),
+        schema=schema_name,
+    )
+    op.create_index(op.f("ix_habits_title"), "habits", ["title"], unique=False, schema=schema_name)
+    op.create_index(
+        op.f("ix_habits_start_date"),
+        "habits",
+        ["start_date"],
+        unique=False,
+        schema=schema_name,
+    )
+    op.create_index(
+        op.f("ix_habits_status"),
+        "habits",
+        ["status"],
+        unique=False,
+        schema=schema_name,
+    )
+    op.create_index(
+        op.f("ix_habits_task_id"),
+        "habits",
+        ["task_id"],
+        unique=False,
+        schema=schema_name,
+    )
+
+    op.create_table(
+        "habit_actions",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("habit_id", sa.Uuid(), nullable=False),
+        sa.Column("action_date", sa.Date(), nullable=False),
+        sa.Column("status", sa.String(length=20), nullable=False),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["habit_id"],
+            [f"{schema_name}.habits.id"],
+            name=op.f("fk_habit_actions_habit_id_habits"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_habit_actions")),
+        schema=schema_name,
+    )
+    op.create_index(
+        op.f("ix_habit_actions_habit_id"),
+        "habit_actions",
+        ["habit_id"],
+        unique=False,
+        schema=schema_name,
+    )
+    op.create_index(
+        op.f("ix_habit_actions_action_date"),
+        "habit_actions",
+        ["action_date"],
+        unique=False,
+        schema=schema_name,
+    )
+    op.create_index(
+        op.f("ix_habit_actions_status"),
+        "habit_actions",
+        ["status"],
+        unique=False,
+        schema=schema_name,
+    )
+    op.create_index(
+        "uq_habit_actions_habit_id_action_date_active",
+        "habit_actions",
+        ["habit_id", "action_date"],
+        unique=True,
+        schema=schema_name,
+        postgresql_where=sa.text("deleted_at IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    schema_name = _schema_name()
+    op.drop_index(
+        "uq_habit_actions_habit_id_action_date_active",
+        table_name="habit_actions",
+        schema=schema_name,
+    )
+    op.drop_index(
+        op.f("ix_habit_actions_status"),
+        table_name="habit_actions",
+        schema=schema_name,
+    )
+    op.drop_index(
+        op.f("ix_habit_actions_action_date"),
+        table_name="habit_actions",
+        schema=schema_name,
+    )
+    op.drop_index(
+        op.f("ix_habit_actions_habit_id"),
+        table_name="habit_actions",
+        schema=schema_name,
+    )
+    op.drop_table("habit_actions", schema=schema_name)
+
+    op.drop_index(op.f("ix_habits_task_id"), table_name="habits", schema=schema_name)
+    op.drop_index(op.f("ix_habits_status"), table_name="habits", schema=schema_name)
+    op.drop_index(op.f("ix_habits_start_date"), table_name="habits", schema=schema_name)
+    op.drop_index(op.f("ix_habits_title"), table_name="habits", schema=schema_name)
+    op.drop_table("habits", schema=schema_name)

--- a/alembic/versions/20260409_1400_create_event_and_timelog_tables.py
+++ b/alembic/versions/20260409_1400_create_event_and_timelog_tables.py
@@ -1,0 +1,228 @@
+"""Create event, timelog, and person association tables."""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260409_1400"
+down_revision = "20260409_1300"
+branch_labels = None
+depends_on = None
+
+
+def _schema_name() -> str:
+    context = op.get_context()
+    return context.version_table_schema or "lifeos"
+
+
+def upgrade() -> None:
+    schema_name = _schema_name()
+
+    op.create_table(
+        "person_associations",
+        sa.Column("entity_type", sa.String(length=50), nullable=False),
+        sa.Column("entity_id", sa.Uuid(), nullable=False),
+        sa.Column("person_id", sa.Uuid(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["person_id"],
+            [f"{schema_name}.people.id"],
+            name=op.f("fk_person_associations_person_id_people"),
+            ondelete="CASCADE",
+        ),
+        sa.UniqueConstraint(
+            "entity_type",
+            "entity_id",
+            "person_id",
+            name="uq_person_associations_entity_person",
+        ),
+        schema=schema_name,
+    )
+    op.create_index(
+        "ix_person_associations_entity",
+        "person_associations",
+        ["entity_type", "entity_id"],
+        unique=False,
+        schema=schema_name,
+    )
+    op.create_index(
+        "ix_person_associations_person_id",
+        "person_associations",
+        ["person_id"],
+        unique=False,
+        schema=schema_name,
+    )
+
+    op.create_table(
+        "events",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("title", sa.String(length=200), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("start_time", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("end_time", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("priority", sa.Integer(), nullable=False),
+        sa.Column("status", sa.String(length=20), nullable=False),
+        sa.Column("is_all_day", sa.Boolean(), nullable=False),
+        sa.Column("area_id", sa.Uuid(), nullable=True),
+        sa.Column("task_id", sa.Uuid(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["area_id"],
+            [f"{schema_name}.areas.id"],
+            name=op.f("fk_events_area_id_areas"),
+            ondelete="SET NULL",
+        ),
+        sa.ForeignKeyConstraint(
+            ["task_id"],
+            [f"{schema_name}.tasks.id"],
+            name=op.f("fk_events_task_id_tasks"),
+            ondelete="SET NULL",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_events")),
+        schema=schema_name,
+    )
+    op.create_index(op.f("ix_events_title"), "events", ["title"], unique=False, schema=schema_name)
+    op.create_index(
+        op.f("ix_events_start_time"),
+        "events",
+        ["start_time"],
+        unique=False,
+        schema=schema_name,
+    )
+    op.create_index(
+        op.f("ix_events_end_time"),
+        "events",
+        ["end_time"],
+        unique=False,
+        schema=schema_name,
+    )
+    op.create_index(
+        "ix_events_status_start_time",
+        "events",
+        ["status", "start_time"],
+        unique=False,
+        schema=schema_name,
+    )
+    op.create_index("ix_events_area_id", "events", ["area_id"], unique=False, schema=schema_name)
+    op.create_index("ix_events_task_id", "events", ["task_id"], unique=False, schema=schema_name)
+    op.create_index(op.f("ix_events_status"), "events", ["status"], unique=False, schema=schema_name)
+    op.create_index(
+        op.f("ix_events_priority"),
+        "events",
+        ["priority"],
+        unique=False,
+        schema=schema_name,
+    )
+
+    op.create_table(
+        "timelogs",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("title", sa.String(length=200), nullable=False),
+        sa.Column("start_time", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("end_time", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("tracking_method", sa.String(length=20), nullable=False),
+        sa.Column("location", sa.String(length=200), nullable=True),
+        sa.Column("energy_level", sa.Integer(), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("area_id", sa.Uuid(), nullable=True),
+        sa.Column("task_id", sa.Uuid(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["area_id"],
+            [f"{schema_name}.areas.id"],
+            name=op.f("fk_timelogs_area_id_areas"),
+            ondelete="SET NULL",
+        ),
+        sa.ForeignKeyConstraint(
+            ["task_id"],
+            [f"{schema_name}.tasks.id"],
+            name=op.f("fk_timelogs_task_id_tasks"),
+            ondelete="SET NULL",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_timelogs")),
+        schema=schema_name,
+    )
+    op.create_index(
+        op.f("ix_timelogs_title"),
+        "timelogs",
+        ["title"],
+        unique=False,
+        schema=schema_name,
+    )
+    op.create_index(
+        op.f("ix_timelogs_start_time"),
+        "timelogs",
+        ["start_time"],
+        unique=False,
+        schema=schema_name,
+    )
+    op.create_index(
+        op.f("ix_timelogs_end_time"),
+        "timelogs",
+        ["end_time"],
+        unique=False,
+        schema=schema_name,
+    )
+    op.create_index(
+        "ix_timelogs_tracking_method",
+        "timelogs",
+        ["tracking_method"],
+        unique=False,
+        schema=schema_name,
+    )
+    op.create_index(
+        "ix_timelogs_area_id",
+        "timelogs",
+        ["area_id"],
+        unique=False,
+        schema=schema_name,
+    )
+    op.create_index(
+        "ix_timelogs_task_id",
+        "timelogs",
+        ["task_id"],
+        unique=False,
+        schema=schema_name,
+    )
+
+
+def downgrade() -> None:
+    schema_name = _schema_name()
+
+    op.drop_index("ix_timelogs_task_id", table_name="timelogs", schema=schema_name)
+    op.drop_index("ix_timelogs_area_id", table_name="timelogs", schema=schema_name)
+    op.drop_index(
+        "ix_timelogs_tracking_method",
+        table_name="timelogs",
+        schema=schema_name,
+    )
+    op.drop_index(op.f("ix_timelogs_end_time"), table_name="timelogs", schema=schema_name)
+    op.drop_index(op.f("ix_timelogs_start_time"), table_name="timelogs", schema=schema_name)
+    op.drop_index(op.f("ix_timelogs_title"), table_name="timelogs", schema=schema_name)
+    op.drop_table("timelogs", schema=schema_name)
+
+    op.drop_index(op.f("ix_events_priority"), table_name="events", schema=schema_name)
+    op.drop_index(op.f("ix_events_status"), table_name="events", schema=schema_name)
+    op.drop_index("ix_events_task_id", table_name="events", schema=schema_name)
+    op.drop_index("ix_events_area_id", table_name="events", schema=schema_name)
+    op.drop_index("ix_events_status_start_time", table_name="events", schema=schema_name)
+    op.drop_index(op.f("ix_events_end_time"), table_name="events", schema=schema_name)
+    op.drop_index(op.f("ix_events_start_time"), table_name="events", schema=schema_name)
+    op.drop_index(op.f("ix_events_title"), table_name="events", schema=schema_name)
+    op.drop_table("events", schema=schema_name)
+
+    op.drop_index(
+        "ix_person_associations_person_id",
+        table_name="person_associations",
+        schema=schema_name,
+    )
+    op.drop_index(
+        "ix_person_associations_entity",
+        table_name="person_associations",
+        schema=schema_name,
+    )
+    op.drop_table("person_associations", schema=schema_name)

--- a/alembic/versions/20260409_1400_create_event_and_timelog_tables.py
+++ b/alembic/versions/20260409_1400_create_event_and_timelog_tables.py
@@ -107,7 +107,9 @@ def upgrade() -> None:
     )
     op.create_index("ix_events_area_id", "events", ["area_id"], unique=False, schema=schema_name)
     op.create_index("ix_events_task_id", "events", ["task_id"], unique=False, schema=schema_name)
-    op.create_index(op.f("ix_events_status"), "events", ["status"], unique=False, schema=schema_name)
+    op.create_index(
+        op.f("ix_events_status"), "events", ["status"], unique=False, schema=schema_name
+    )
     op.create_index(
         op.f("ix_events_priority"),
         "events",

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -201,6 +201,8 @@ Current intent:
 - standalone `search` is intentionally deferred for now
 - `batch` is the grouped namespace for multi-record write operations
 - `habit-action` is a top-level resource instead of a nested `habit action` command tree
+- repeated `--person-id` flags attach people to supported resources such as `area`, `tag`,
+  `vision`, `task`, `event`, and `timelog`
 
 ## Structured Resource Workflows
 
@@ -210,6 +212,8 @@ These examples show the current intended command shape for the new structured re
 
 ```bash
 lifeos area add "Health" --description "Long-term wellbeing" --icon heart
+lifeos area update <area-id> --person-id <person-id-1> --person-id <person-id-2>
+lifeos area list --person-id <person-id>
 lifeos area list
 lifeos area show <area-id>
 lifeos area update <area-id> --name "Fitness" --clear-icon
@@ -220,6 +224,8 @@ lifeos area delete <area-id>
 
 ```bash
 lifeos tag add "family" --entity-type person --category relation --color green
+lifeos tag update <tag-id> --person-id <person-id>
+lifeos tag list --person-id <person-id>
 lifeos tag list
 lifeos tag show <tag-id>
 lifeos tag update <tag-id> --clear-color
@@ -290,6 +296,8 @@ lifeos people delete <person-id>
 
 ```bash
 lifeos vision add "Launch lifeos-cli" --area-id <area-id> --status active
+lifeos vision update <vision-id> --person-id <person-id-1> --person-id <person-id-2>
+lifeos vision list --person-id <person-id>
 lifeos vision list --status active
 lifeos vision show <vision-id>
 lifeos vision update <vision-id> --status archived --clear-area
@@ -300,6 +308,8 @@ lifeos vision delete <vision-id>
 
 ```bash
 lifeos task add "Draft release checklist" --vision-id <vision-id> --status todo
+lifeos task update <task-id> --person-id <person-id>
+lifeos task list --person-id <person-id>
 lifeos task list --vision-id <vision-id>
 lifeos task show <task-id>
 lifeos task update <task-id> --status in_progress
@@ -311,6 +321,8 @@ Current task notes:
 
 - `task` is the execution unit and supports tree structure through parent-child links
 - use `--clear-parent` to move a child task back to the root level
+- repeated `--person-id` flags link a task to one or more people without changing its place in
+  the task tree
 - use `--clear-*` flags when a field should become empty instead of being replaced
 
 ### Timelog
@@ -437,7 +449,6 @@ Not implemented yet:
 
 - note tags
 - note-to-task or note-to-person associations
-- person-to-vision or person-to-task links
 - vision experience workflows and advanced task-tree operations
 - batch update operations for the new structured resources
 - event/timelog recurrence or direct event-to-timelog conversion

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -171,6 +171,8 @@ Current behavior:
 The branch now exposes early CRUD-oriented command families for several additional domains:
 
 - `lifeos area ...`
+- `lifeos habit ...`
+- `lifeos habit-action ...`
 - `lifeos tag ...`
 - `lifeos people ...`
 - `lifeos vision ...`
@@ -180,6 +182,8 @@ Examples:
 
 ```bash
 lifeos area add "Health"
+lifeos habit add "Daily Exercise" --start-date 2026-04-09 --duration-days 21
+lifeos habit-action list --action-date 2026-04-09
 lifeos tag add "family" --entity-type person --category relation
 lifeos people add "Alice" --nickname ally --location Toronto
 lifeos vision add "Launch lifeos-cli"
@@ -192,6 +196,7 @@ Current intent:
 - `list` is the query entrypoint for these structured resources
 - standalone `search` is intentionally deferred for now
 - `batch` is the grouped namespace for multi-record write operations
+- `habit-action` is a top-level resource instead of a nested `habit action` command tree
 
 ## Structured Resource Workflows
 
@@ -216,6 +221,40 @@ lifeos tag show <tag-id>
 lifeos tag update <tag-id> --clear-color
 lifeos tag delete <tag-id>
 ```
+
+### Habit
+
+```bash
+lifeos habit add "Daily Exercise" --start-date 2026-04-09 --duration-days 21
+lifeos habit list --with-stats
+lifeos habit show <habit-id>
+lifeos habit update <habit-id> --status paused
+lifeos habit stats <habit-id>
+lifeos habit task-associations
+lifeos habit delete <habit-id>
+```
+
+Current habit notes:
+
+- a habit generates one dated `habit-action` row per day in its duration
+- updating start dates or duration automatically reconciles generated action rows
+- habit deletion is soft deletion only in the public CLI
+
+### Habit Action
+
+```bash
+lifeos habit-action list --habit-id <habit-id>
+lifeos habit-action list --action-date 2026-04-09
+lifeos habit-action show <action-id>
+lifeos habit-action update <action-id> --status done
+lifeos habit-action update <action-id> --clear-notes
+```
+
+Current habit-action notes:
+
+- public CLI does not create or delete habit actions directly
+- use `list` for both per-habit and by-date inspection flows
+- updates respect the habit-action editable window enforced by the service layer
 
 ### People
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -34,7 +34,7 @@ The CLI is designed around a few stable patterns:
 - soft-delete records with `delete`
 - group multi-record write operations under `batch`
 
-For structured resources such as `area`, `tag`, `people`, `vision`, and `task`:
+For structured resources such as `area`, `tag`, `people`, `vision`, `task`, `event`, and `timelog`:
 
 - prefer `list` as the main query command
 - expect future filtering and pagination growth on `list`
@@ -171,23 +171,27 @@ Current behavior:
 The branch now exposes early CRUD-oriented command families for several additional domains:
 
 - `lifeos area ...`
+- `lifeos event ...`
 - `lifeos habit ...`
 - `lifeos habit-action ...`
 - `lifeos tag ...`
 - `lifeos people ...`
-- `lifeos vision ...`
 - `lifeos task ...`
+- `lifeos timelog ...`
+- `lifeos vision ...`
 
 Examples:
 
 ```bash
 lifeos area add "Health"
+lifeos event add "Doctor appointment" --start-time 2026-04-10T09:00:00-04:00
 lifeos habit add "Daily Exercise" --start-date 2026-04-09 --duration-days 21
 lifeos habit-action list --action-date 2026-04-09
 lifeos tag add "family" --entity-type person --category relation
 lifeos people add "Alice" --nickname ally --location Toronto
 lifeos vision add "Launch lifeos-cli"
 lifeos task add "Draft release checklist" --vision-id <vision-id>
+lifeos timelog add "Deep work" --start-time 2026-04-10T13:00:00-04:00 --end-time 2026-04-10T14:30:00-04:00
 lifeos task batch delete --ids <task-id-1> <task-id-2>
 ```
 
@@ -221,6 +225,22 @@ lifeos tag show <tag-id>
 lifeos tag update <tag-id> --clear-color
 lifeos tag delete <tag-id>
 ```
+
+### Event
+
+```bash
+lifeos event add "Doctor appointment" --start-time 2026-04-10T09:00:00-04:00
+lifeos event list --window-start 2026-04-10T00:00:00-04:00 --window-end 2026-04-10T23:59:59-04:00
+lifeos event show <event-id>
+lifeos event update <event-id> --status completed --clear-task
+lifeos event delete <event-id>
+```
+
+Current event notes:
+
+- `event` is the planned schedule object, not the todo object
+- use `--window-start` and `--window-end` to query overlapping calendar ranges
+- use repeated `--tag-id` and `--person-id` flags to attach tags and people
 
 ### Habit
 
@@ -293,6 +313,22 @@ Current task notes:
 - use `--clear-parent` to move a child task back to the root level
 - use `--clear-*` flags when a field should become empty instead of being replaced
 
+### Timelog
+
+```bash
+lifeos timelog add "Deep work" --start-time 2026-04-10T13:00:00-04:00 --end-time 2026-04-10T14:30:00-04:00
+lifeos timelog list --window-start 2026-04-10T00:00:00-04:00 --window-end 2026-04-10T23:59:59-04:00
+lifeos timelog show <timelog-id>
+lifeos timelog update <timelog-id> --notes "Felt strong" --clear-task
+lifeos timelog delete <timelog-id>
+```
+
+Current timelog notes:
+
+- `timelog` is the actual time record and represents what really happened
+- use repeated `--tag-id` and `--person-id` flags to attach tags and people
+- timelog end time is currently required because the record models completed time spent
+
 ## Note Batch Operations
 
 The first grouped bulk namespace is `lifeos note batch`.
@@ -329,10 +365,12 @@ Structured resources also expose batch soft delete:
 
 ```bash
 lifeos area batch delete --ids <area-id-1> <area-id-2>
+lifeos event batch delete --ids <event-id-1> <event-id-2>
 lifeos tag batch delete --ids <tag-id-1> <tag-id-2>
 lifeos people batch delete --ids <person-id-1> <person-id-2>
 lifeos vision batch delete --ids <vision-id-1> <vision-id-2>
 lifeos task batch delete --ids <task-id-1> <task-id-2>
+lifeos timelog batch delete --ids <timelog-id-1> <timelog-id-2>
 ```
 
 ## Agent Usage Patterns
@@ -374,6 +412,8 @@ Currently implemented:
 - `lifeos db upgrade`
 - `lifeos area add|list|show|update|delete`
 - `lifeos area batch delete`
+- `lifeos event add|list|show|update|delete`
+- `lifeos event batch delete`
 - `lifeos tag add|list|show|update|delete`
 - `lifeos tag batch delete`
 - `lifeos people add|list|show|update|delete`
@@ -382,6 +422,8 @@ Currently implemented:
 - `lifeos vision batch delete`
 - `lifeos task add|list|show|update|delete`
 - `lifeos task batch delete`
+- `lifeos timelog add|list|show|update|delete`
+- `lifeos timelog batch delete`
 - `lifeos note add`
 - `lifeos note list`
 - `lifeos note search`
@@ -398,6 +440,7 @@ Not implemented yet:
 - person-to-vision or person-to-task links
 - vision experience workflows and advanced task-tree operations
 - batch update operations for the new structured resources
+- event/timelog recurrence or direct event-to-timelog conversion
 - note ingestion jobs
 - richer search ranking or association-aware note search
 - public CLI access to hard delete

--- a/scripts/purge_deleted_records.py
+++ b/scripts/purge_deleted_records.py
@@ -25,7 +25,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "resource",
-        choices=("note", "area", "tag", "people", "vision", "task"),
+        choices=("note", "area", "tag", "people", "vision", "task", "habit", "habit-action"),
         help="Resource type to purge",
     )
     parser.add_argument(

--- a/scripts/purge_deleted_records.py
+++ b/scripts/purge_deleted_records.py
@@ -25,7 +25,18 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "resource",
-        choices=("note", "area", "tag", "people", "vision", "task", "habit", "habit-action"),
+        choices=(
+            "note",
+            "area",
+            "tag",
+            "people",
+            "vision",
+            "task",
+            "event",
+            "timelog",
+            "habit",
+            "habit-action",
+        ),
         help="Resource type to purge",
     )
     parser.add_argument(

--- a/src/lifeos_cli/cli_support/parser.py
+++ b/src/lifeos_cli/cli_support/parser.py
@@ -11,12 +11,14 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from lifeos_cli.cli_support.help_utils import build_epilog
 from lifeos_cli.cli_support.resources.area.parser import build_area_parser
+from lifeos_cli.cli_support.resources.event.parser import build_event_parser
 from lifeos_cli.cli_support.resources.habit.parser import build_habit_parser
 from lifeos_cli.cli_support.resources.habit_action.parser import build_habit_action_parser
 from lifeos_cli.cli_support.resources.note.parser import build_note_parser
 from lifeos_cli.cli_support.resources.people.parser import build_people_parser
 from lifeos_cli.cli_support.resources.tag.parser import build_tag_parser
 from lifeos_cli.cli_support.resources.task.parser import build_task_parser
+from lifeos_cli.cli_support.resources.timelog.parser import build_timelog_parser
 from lifeos_cli.cli_support.resources.vision.parser import build_vision_parser
 from lifeos_cli.cli_support.runtime_utils import print_database_runtime_error
 from lifeos_cli.cli_support.system.config_commands import (
@@ -44,6 +46,8 @@ def build_parser() -> argparse.ArgumentParser:
             "Command grammar:\n"
             "  lifeos <resource> <action> [arguments] [options]\n\n"
             "Resources model domains such as areas, people, visions, tasks, and notes.\n"
+            "Time-oriented domains use `event` for planned schedule blocks and `timelog` "
+            "for actual time records.\n"
             "Habits and habit actions are exposed as separate top-level resources.\n"
             "System commands such as init, config, and db manage runtime setup.\n"
             "Actions are short verbs that operate on records or runtime state."
@@ -57,6 +61,9 @@ def build_parser() -> argparse.ArgumentParser:
                 'lifeos people add "Alice"',
                 'lifeos vision add "Launch lifeos-cli" --area-id <area-id>',
                 'lifeos task add "Draft release plan" --vision-id <vision-id>',
+                'lifeos event add "Doctor appointment" --start-time 2026-04-10T09:00:00-04:00',
+                'lifeos timelog add "Deep work" --start-time 2026-04-10T13:00:00-04:00 '
+                "--end-time 2026-04-10T14:30:00-04:00",
                 'lifeos habit add "Daily Exercise" --start-date 2026-04-09 --duration-days 21',
                 "lifeos habit-action list --action-date 2026-04-09",
                 'lifeos note add "Capture an idea"',
@@ -82,10 +89,12 @@ def build_parser() -> argparse.ArgumentParser:
     build_config_parser(subparsers)
     build_db_parser(subparsers)
     build_area_parser(subparsers)
+    build_event_parser(subparsers)
     build_tag_parser(subparsers)
     build_people_parser(subparsers)
     build_vision_parser(subparsers)
     build_task_parser(subparsers)
+    build_timelog_parser(subparsers)
     build_habit_parser(subparsers)
     build_habit_action_parser(subparsers)
     build_note_parser(subparsers)

--- a/src/lifeos_cli/cli_support/parser.py
+++ b/src/lifeos_cli/cli_support/parser.py
@@ -11,6 +11,8 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from lifeos_cli.cli_support.help_utils import build_epilog
 from lifeos_cli.cli_support.resources.area.parser import build_area_parser
+from lifeos_cli.cli_support.resources.habit.parser import build_habit_parser
+from lifeos_cli.cli_support.resources.habit_action.parser import build_habit_action_parser
 from lifeos_cli.cli_support.resources.note.parser import build_note_parser
 from lifeos_cli.cli_support.resources.people.parser import build_people_parser
 from lifeos_cli.cli_support.resources.tag.parser import build_tag_parser
@@ -42,6 +44,7 @@ def build_parser() -> argparse.ArgumentParser:
             "Command grammar:\n"
             "  lifeos <resource> <action> [arguments] [options]\n\n"
             "Resources model domains such as areas, people, visions, tasks, and notes.\n"
+            "Habits and habit actions are exposed as separate top-level resources.\n"
             "System commands such as init, config, and db manage runtime setup.\n"
             "Actions are short verbs that operate on records or runtime state."
         ),
@@ -54,6 +57,8 @@ def build_parser() -> argparse.ArgumentParser:
                 'lifeos people add "Alice"',
                 'lifeos vision add "Launch lifeos-cli" --area-id <area-id>',
                 'lifeos task add "Draft release plan" --vision-id <vision-id>',
+                'lifeos habit add "Daily Exercise" --start-date 2026-04-09 --duration-days 21',
+                "lifeos habit-action list --action-date 2026-04-09",
                 'lifeos note add "Capture an idea"',
                 'lifeos note search "meeting notes"',
             ),
@@ -81,6 +86,8 @@ def build_parser() -> argparse.ArgumentParser:
     build_people_parser(subparsers)
     build_vision_parser(subparsers)
     build_task_parser(subparsers)
+    build_habit_parser(subparsers)
+    build_habit_action_parser(subparsers)
     build_note_parser(subparsers)
     return parser
 

--- a/src/lifeos_cli/cli_support/resources/area/handlers.py
+++ b/src/lifeos_cli/cli_support/resources/area/handlers.py
@@ -21,6 +21,9 @@ def _format_area_summary(area: Area) -> str:
 
 
 def _format_area_detail(area: Area) -> str:
+    people_names = (
+        ", ".join(person.name for person in area.people) if getattr(area, "people", None) else "-"
+    )
     return "\n".join(
         (
             f"id: {area.id}",
@@ -30,6 +33,7 @@ def _format_area_detail(area: Area) -> str:
             f"icon: {area.icon or '-'}",
             f"is_active: {area.is_active}",
             f"display_order: {area.display_order}",
+            f"people: {people_names}",
             f"created_at: {format_timestamp(area.created_at)}",
             f"updated_at: {format_timestamp(area.updated_at)}",
             f"deleted_at: {format_timestamp(area.deleted_at)}",
@@ -48,6 +52,7 @@ async def handle_area_add_async(args: argparse.Namespace) -> int:
                 icon=args.icon,
                 is_active=not args.inactive,
                 display_order=args.display_order,
+                person_ids=args.person_ids,
             )
         except area_services.AreaAlreadyExistsError as exc:
             print(str(exc), file=sys.stderr)
@@ -66,6 +71,7 @@ async def handle_area_list_async(args: argparse.Namespace) -> int:
             session,
             include_deleted=args.include_deleted,
             include_inactive=args.include_inactive,
+            person_id=args.person_id,
             limit=args.limit,
             offset=args.offset,
         )
@@ -106,6 +112,9 @@ async def handle_area_update_async(args: argparse.Namespace) -> int:
     if args.clear_icon and args.icon is not None:
         print("Use either --icon or --clear-icon, not both.", file=sys.stderr)
         return 1
+    if args.clear_people and args.person_ids is not None:
+        print("Use either --person-id or --clear-people, not both.", file=sys.stderr)
+        return 1
     async with db_session.session_scope() as session:
         try:
             area = await area_services.update_area(
@@ -117,6 +126,8 @@ async def handle_area_update_async(args: argparse.Namespace) -> int:
                 color=args.color,
                 icon=args.icon,
                 clear_icon=args.clear_icon,
+                person_ids=args.person_ids,
+                clear_people=args.clear_people,
                 is_active=args.active,
                 display_order=args.display_order,
             )

--- a/src/lifeos_cli/cli_support/resources/area/parser.py
+++ b/src/lifeos_cli/cli_support/resources/area/parser.py
@@ -65,15 +65,27 @@ def build_area_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentPa
             examples=(
                 'lifeos area add "Health"',
                 'lifeos area add "Deep Work" --color "#2563EB" --icon brain --display-order 10',
+                'lifeos area add "Family" --person-id 11111111-1111-1111-1111-111111111111',
                 'lifeos area add "Travel" --inactive',
             ),
-            notes=("Use `--inactive` when the area should exist but not appear as active yet.",),
+            notes=(
+                "Use `--inactive` when the area should exist but not appear as active yet.",
+                "Repeat `--person-id` to associate one or more people.",
+            ),
         ),
     )
     add_parser.add_argument("name", help="Area name")
     add_parser.add_argument("--description", help="Optional area description")
     add_parser.add_argument("--color", default="#3B82F6", help="Hex color code")
     add_parser.add_argument("--icon", help="Optional icon identifier")
+    add_parser.add_argument(
+        "--person-id",
+        dest="person_ids",
+        type=UUID,
+        action="append",
+        default=None,
+        help="Repeat to associate one or more people",
+    )
     add_parser.add_argument("--inactive", action="store_true", help="Create the area as inactive")
     add_parser.add_argument("--display-order", type=int, default=0, help="Display order")
     add_parser.set_defaults(handler=handle_area_add)
@@ -90,6 +102,7 @@ def build_area_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentPa
             ),
             examples=(
                 "lifeos area list",
+                "lifeos area list --person-id 11111111-1111-1111-1111-111111111111",
                 "lifeos area list --include-inactive",
                 "lifeos area list --include-deleted --limit 20 --offset 20",
             ),
@@ -100,6 +113,7 @@ def build_area_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentPa
         ),
     )
     add_include_deleted_argument(list_parser, noun="areas")
+    list_parser.add_argument("--person-id", type=UUID, help="Filter by linked person identifier")
     list_parser.add_argument(
         "--include-inactive", action="store_true", help="Include inactive areas"
     )
@@ -139,9 +153,14 @@ def build_area_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentPa
                 'lifeos area update 11111111-1111-1111-1111-111111111111 --name "Fitness"',
                 "lifeos area update 11111111-1111-1111-1111-111111111111 "
                 "--display-order 20 --active",
+                "lifeos area update 11111111-1111-1111-1111-111111111111 "
+                "--person-id 11111111-1111-1111-1111-111111111111",
                 "lifeos area update 11111111-1111-1111-1111-111111111111 --clear-icon",
             ),
-            notes=("Use `--clear-description` or `--clear-icon` to remove optional values.",),
+            notes=(
+                "Use `--clear-description`, `--clear-icon`, or `--clear-people` "
+                "to remove optional values.",
+            ),
         ),
     )
     update_parser.add_argument("area_id", type=UUID, help="Area identifier")
@@ -158,6 +177,19 @@ def build_area_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentPa
         "--clear-icon",
         action="store_true",
         help="Clear the optional icon identifier",
+    )
+    update_parser.add_argument(
+        "--person-id",
+        dest="person_ids",
+        type=UUID,
+        action="append",
+        default=None,
+        help="Repeat to replace people with one or more identifiers",
+    )
+    update_parser.add_argument(
+        "--clear-people",
+        action="store_true",
+        help="Remove all linked people",
     )
     update_parser.add_argument(
         "--active",

--- a/src/lifeos_cli/cli_support/resources/event/__init__.py
+++ b/src/lifeos_cli/cli_support/resources/event/__init__.py
@@ -1,0 +1,1 @@
+"""Event CLI resource package."""

--- a/src/lifeos_cli/cli_support/resources/event/handlers.py
+++ b/src/lifeos_cli/cli_support/resources/event/handlers.py
@@ -1,0 +1,216 @@
+"""CLI handlers for the event resource."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from lifeos_cli.cli_support.output_utils import format_id_lines, format_timestamp
+from lifeos_cli.cli_support.runtime_utils import run_async
+from lifeos_cli.db import session as db_session
+from lifeos_cli.db.models.event import Event
+from lifeos_cli.db.services import events as event_services
+
+
+def _format_event_summary(event: Event) -> str:
+    status = "deleted" if event.deleted_at is not None else event.status
+    return (
+        f"{event.id}\t{status}\t{format_timestamp(event.start_time)}\t"
+        f"{format_timestamp(event.end_time)}\t{event.task_id or '-'}\t{event.title}"
+    )
+
+
+def _format_event_detail(event: Event) -> str:
+    tag_names = ", ".join(tag.name for tag in event.tags) if getattr(event, "tags", None) else "-"
+    people_names = (
+        ", ".join(person.name for person in event.people) if getattr(event, "people", None) else "-"
+    )
+    return "\n".join(
+        (
+            f"id: {event.id}",
+            f"title: {event.title}",
+            f"description: {event.description or '-'}",
+            f"status: {event.status}",
+            f"priority: {event.priority}",
+            f"is_all_day: {event.is_all_day}",
+            f"start_time: {format_timestamp(event.start_time)}",
+            f"end_time: {format_timestamp(event.end_time)}",
+            f"area_id: {event.area_id or '-'}",
+            f"task_id: {event.task_id or '-'}",
+            f"tags: {tag_names}",
+            f"people: {people_names}",
+            f"created_at: {format_timestamp(event.created_at)}",
+            f"updated_at: {format_timestamp(event.updated_at)}",
+            f"deleted_at: {format_timestamp(event.deleted_at)}",
+        )
+    )
+
+
+def _print_event_error(exc: Exception) -> int:
+    print(str(exc), file=sys.stderr)
+    return 1
+
+
+async def handle_event_add_async(args: argparse.Namespace) -> int:
+    async with db_session.session_scope() as session:
+        try:
+            event = await event_services.create_event(
+                session,
+                title=args.title,
+                description=args.description,
+                start_time=args.start_time,
+                end_time=args.end_time,
+                priority=args.priority,
+                status=args.status,
+                is_all_day=args.all_day,
+                area_id=args.area_id,
+                task_id=args.task_id,
+                tag_ids=args.tag_ids,
+                person_ids=args.person_ids,
+            )
+        except (
+            event_services.EventAreaReferenceNotFoundError,
+            event_services.EventTaskReferenceNotFoundError,
+            event_services.EventValidationError,
+            LookupError,
+        ) as exc:
+            return _print_event_error(exc)
+    print(f"Created event {event.id}")
+    return 0
+
+
+def handle_event_add(args: argparse.Namespace) -> int:
+    return run_async(handle_event_add_async(args))
+
+
+async def handle_event_list_async(args: argparse.Namespace) -> int:
+    async with db_session.session_scope() as session:
+        try:
+            events = await event_services.list_events(
+                session,
+                title_contains=args.title_contains,
+                status=args.status,
+                area_id=args.area_id,
+                task_id=args.task_id,
+                person_id=args.person_id,
+                tag_id=args.tag_id,
+                window_start=args.window_start,
+                window_end=args.window_end,
+                include_deleted=args.include_deleted,
+                limit=args.limit,
+                offset=args.offset,
+            )
+        except event_services.EventValidationError as exc:
+            return _print_event_error(exc)
+    if not events:
+        print("No events found.")
+        return 0
+    for event in events:
+        print(_format_event_summary(event))
+    return 0
+
+
+def handle_event_list(args: argparse.Namespace) -> int:
+    return run_async(handle_event_list_async(args))
+
+
+async def handle_event_show_async(args: argparse.Namespace) -> int:
+    async with db_session.session_scope() as session:
+        event = await event_services.get_event(
+            session,
+            event_id=args.event_id,
+            include_deleted=args.include_deleted,
+        )
+    if event is None:
+        print(f"Event {args.event_id} was not found", file=sys.stderr)
+        return 1
+    print(_format_event_detail(event))
+    return 0
+
+
+def handle_event_show(args: argparse.Namespace) -> int:
+    return run_async(handle_event_show_async(args))
+
+
+async def handle_event_update_async(args: argparse.Namespace) -> int:
+    conflicts = (
+        (args.clear_description and args.description is not None, "--description", "--clear-description"),
+        (args.clear_end_time and args.end_time is not None, "--end-time", "--clear-end-time"),
+        (args.clear_area and args.area_id is not None, "--area-id", "--clear-area"),
+        (args.clear_task and args.task_id is not None, "--task-id", "--clear-task"),
+        (args.clear_tags and args.tag_ids is not None, "--tag-id", "--clear-tags"),
+        (args.clear_people and args.person_ids is not None, "--person-id", "--clear-people"),
+    )
+    for is_conflict, value_flag, clear_flag in conflicts:
+        if is_conflict:
+            print(f"Use either {value_flag} or {clear_flag}, not both.", file=sys.stderr)
+            return 1
+    async with db_session.session_scope() as session:
+        try:
+            event = await event_services.update_event(
+                session,
+                event_id=args.event_id,
+                title=args.title,
+                description=args.description,
+                clear_description=args.clear_description,
+                start_time=args.start_time,
+                end_time=args.end_time,
+                clear_end_time=args.clear_end_time,
+                priority=args.priority,
+                status=args.status,
+                is_all_day=args.all_day,
+                area_id=args.area_id,
+                clear_area=args.clear_area,
+                task_id=args.task_id,
+                clear_task=args.clear_task,
+                tag_ids=args.tag_ids,
+                clear_tags=args.clear_tags,
+                person_ids=args.person_ids,
+                clear_people=args.clear_people,
+            )
+        except (
+            event_services.EventNotFoundError,
+            event_services.EventAreaReferenceNotFoundError,
+            event_services.EventTaskReferenceNotFoundError,
+            event_services.EventValidationError,
+            LookupError,
+        ) as exc:
+            return _print_event_error(exc)
+    print(f"Updated event {event.id}")
+    return 0
+
+
+def handle_event_update(args: argparse.Namespace) -> int:
+    return run_async(handle_event_update_async(args))
+
+
+async def handle_event_delete_async(args: argparse.Namespace) -> int:
+    async with db_session.session_scope() as session:
+        try:
+            await event_services.delete_event(session, event_id=args.event_id)
+        except event_services.EventNotFoundError as exc:
+            return _print_event_error(exc)
+    print(f"Soft-deleted event {args.event_id}")
+    return 0
+
+
+def handle_event_delete(args: argparse.Namespace) -> int:
+    return run_async(handle_event_delete_async(args))
+
+
+async def handle_event_batch_delete_async(args: argparse.Namespace) -> int:
+    async with db_session.session_scope() as session:
+        result = await event_services.batch_delete_events(
+            session,
+            event_ids=list(args.event_ids),
+        )
+    print(f"Deleted events: {result.deleted_count}")
+    if result.failed_ids:
+        print(format_id_lines("Failed event IDs", result.failed_ids), file=sys.stderr)
+    for error in result.errors:
+        print(f"Error: {error}", file=sys.stderr)
+    return 1 if result.failed_ids else 0
+
+
+def handle_event_batch_delete(args: argparse.Namespace) -> int:
+    return run_async(handle_event_batch_delete_async(args))

--- a/src/lifeos_cli/cli_support/resources/event/handlers.py
+++ b/src/lifeos_cli/cli_support/resources/event/handlers.py
@@ -134,7 +134,11 @@ def handle_event_show(args: argparse.Namespace) -> int:
 
 async def handle_event_update_async(args: argparse.Namespace) -> int:
     conflicts = (
-        (args.clear_description and args.description is not None, "--description", "--clear-description"),
+        (
+            args.clear_description and args.description is not None,
+            "--description",
+            "--clear-description",
+        ),
         (args.clear_end_time and args.end_time is not None, "--end-time", "--clear-end-time"),
         (args.clear_area and args.area_id is not None, "--area-id", "--clear-area"),
         (args.clear_task and args.task_id is not None, "--task-id", "--clear-task"),

--- a/src/lifeos_cli/cli_support/resources/event/parser.py
+++ b/src/lifeos_cli/cli_support/resources/event/parser.py
@@ -1,0 +1,248 @@
+"""Event resource parser construction."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime
+from uuid import UUID
+
+from lifeos_cli.cli_support.help_utils import HelpContent, add_documented_parser, make_help_handler
+from lifeos_cli.cli_support.parser_common import (
+    add_identifier_list_argument,
+    add_include_deleted_argument,
+    add_limit_offset_arguments,
+)
+from lifeos_cli.cli_support.resources.event.handlers import (
+    handle_event_add,
+    handle_event_batch_delete,
+    handle_event_delete,
+    handle_event_list,
+    handle_event_show,
+    handle_event_update,
+)
+
+
+def _datetime_value(value: str) -> datetime:
+    """Parse an ISO-8601 datetime value."""
+    return datetime.fromisoformat(value)
+
+
+def build_event_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    """Build the event command tree."""
+    event_parser = add_documented_parser(
+        subparsers,
+        "event",
+        help_content=HelpContent(
+            summary="Manage planned schedule events",
+            description=(
+                "Create and maintain planned schedule blocks.\n\n"
+                "Events represent calendar intent and time allocation, not todo semantics."
+            ),
+            examples=(
+                'lifeos event add "Doctor appointment" --start-time 2026-04-10T09:00:00-04:00',
+                "lifeos event list --window-start 2026-04-10T00:00:00-04:00 "
+                "--window-end 2026-04-10T23:59:59-04:00",
+                "lifeos event batch delete --ids <event-id-1> <event-id-2>",
+            ),
+            notes=(
+                "Use `list` as the primary query entrypoint for events.",
+                "Events can optionally reference one area and one task.",
+                "Delete operations in the public CLI always perform soft deletion.",
+            ),
+        ),
+    )
+    event_parser.set_defaults(handler=make_help_handler(event_parser))
+    event_subparsers = event_parser.add_subparsers(
+        dest="event_command", title="actions", metavar="action"
+    )
+
+    add_parser = add_documented_parser(
+        event_subparsers,
+        "add",
+        help_content=HelpContent(
+            summary="Create an event",
+            description="Create a planned schedule event.",
+            examples=(
+                'lifeos event add "Doctor appointment" --start-time 2026-04-10T09:00:00-04:00 '
+                "--end-time 2026-04-10T10:00:00-04:00",
+                'lifeos event add "Deep work block" --start-time 2026-04-10T13:00:00-04:00 '
+                "--task-id <task-id> --area-id <area-id>",
+            ),
+            notes=(
+                "Use repeated `--tag-id` and `--person-id` flags to attach tags and people.",
+                "If `--end-time` is omitted, the event is treated as open-ended.",
+            ),
+        ),
+    )
+    add_parser.add_argument("title", help="Event title")
+    add_parser.add_argument("--description", help="Optional event description")
+    add_parser.add_argument("--start-time", required=True, type=_datetime_value, help="Start time")
+    add_parser.add_argument("--end-time", type=_datetime_value, help="Optional end time")
+    add_parser.add_argument("--priority", type=int, default=0, help="Priority from 0 to 5")
+    add_parser.add_argument("--status", default="planned", help="Event status")
+    add_parser.add_argument(
+        "--all-day",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Mark the event as all-day",
+    )
+    add_parser.add_argument("--area-id", type=UUID, help="Optional linked area identifier")
+    add_parser.add_argument("--task-id", type=UUID, help="Optional linked task identifier")
+    add_parser.add_argument(
+        "--tag-id",
+        dest="tag_ids",
+        type=UUID,
+        action="append",
+        default=None,
+        help="Repeat to attach one or more event tags",
+    )
+    add_parser.add_argument(
+        "--person-id",
+        dest="person_ids",
+        type=UUID,
+        action="append",
+        default=None,
+        help="Repeat to attach one or more people",
+    )
+    add_parser.set_defaults(handler=handle_event_add)
+
+    list_parser = add_documented_parser(
+        event_subparsers,
+        "list",
+        help_content=HelpContent(
+            summary="List events",
+            description=(
+                "List events with optional time-window and relation filters.\n\n"
+                "Use this command as the main query entrypoint for scheduled events."
+            ),
+            examples=(
+                "lifeos event list",
+                "lifeos event list --status planned --window-start 2026-04-10T00:00:00-04:00 "
+                "--window-end 2026-04-10T23:59:59-04:00",
+                "lifeos event list --task-id <task-id> --person-id <person-id>",
+            ),
+            notes=(
+                "When both window flags are given, overlapping events are returned.",
+                "Use `--title-contains` for lightweight text filtering instead of a separate search command.",
+            ),
+        ),
+    )
+    list_parser.add_argument("--title-contains", help="Filter by title substring")
+    list_parser.add_argument("--status", help="Filter by event status")
+    list_parser.add_argument("--area-id", type=UUID, help="Filter by linked area")
+    list_parser.add_argument("--task-id", type=UUID, help="Filter by linked task")
+    list_parser.add_argument("--person-id", type=UUID, help="Filter by linked person")
+    list_parser.add_argument("--tag-id", type=UUID, help="Filter by linked tag")
+    list_parser.add_argument("--window-start", type=_datetime_value, help="Window start time")
+    list_parser.add_argument("--window-end", type=_datetime_value, help="Window end time")
+    add_include_deleted_argument(list_parser, noun="events")
+    add_limit_offset_arguments(list_parser)
+    list_parser.set_defaults(handler=handle_event_list)
+
+    show_parser = add_documented_parser(
+        event_subparsers,
+        "show",
+        help_content=HelpContent(
+            summary="Show an event",
+            description="Show one event with full metadata.",
+            examples=(
+                "lifeos event show 11111111-1111-1111-1111-111111111111",
+                "lifeos event show 11111111-1111-1111-1111-111111111111 --include-deleted",
+            ),
+        ),
+    )
+    show_parser.add_argument("event_id", type=UUID, help="Event identifier")
+    add_include_deleted_argument(show_parser, noun="events", help_prefix="Allow")
+    show_parser.set_defaults(handler=handle_event_show)
+
+    update_parser = add_documented_parser(
+        event_subparsers,
+        "update",
+        help_content=HelpContent(
+            summary="Update an event",
+            description="Update mutable event fields.",
+            examples=(
+                "lifeos event update 11111111-1111-1111-1111-111111111111 --status completed",
+                "lifeos event update 11111111-1111-1111-1111-111111111111 --clear-task --clear-area",
+                "lifeos event update 11111111-1111-1111-1111-111111111111 --clear-people --clear-tags",
+            ),
+            notes=(
+                "Use `--clear-*` flags to explicitly remove optional values.",
+                "Do not mix a value flag with the matching clear flag in the same command.",
+            ),
+        ),
+    )
+    update_parser.add_argument("event_id", type=UUID, help="Event identifier")
+    update_parser.add_argument("--title", help="Updated event title")
+    update_parser.add_argument("--description", help="Updated description")
+    update_parser.add_argument("--clear-description", action="store_true", help="Clear description")
+    update_parser.add_argument("--start-time", type=_datetime_value, help="Updated start time")
+    update_parser.add_argument("--end-time", type=_datetime_value, help="Updated end time")
+    update_parser.add_argument("--clear-end-time", action="store_true", help="Clear end time")
+    update_parser.add_argument("--priority", type=int, help="Updated priority from 0 to 5")
+    update_parser.add_argument("--status", help="Updated event status")
+    update_parser.add_argument(
+        "--all-day",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Toggle all-day status",
+    )
+    update_parser.add_argument("--area-id", type=UUID, help="Updated linked area identifier")
+    update_parser.add_argument("--clear-area", action="store_true", help="Clear linked area")
+    update_parser.add_argument("--task-id", type=UUID, help="Updated linked task identifier")
+    update_parser.add_argument("--clear-task", action="store_true", help="Clear linked task")
+    update_parser.add_argument(
+        "--tag-id",
+        dest="tag_ids",
+        type=UUID,
+        action="append",
+        default=None,
+        help="Repeat to replace tags with one or more identifiers",
+    )
+    update_parser.add_argument("--clear-tags", action="store_true", help="Remove all tags")
+    update_parser.add_argument(
+        "--person-id",
+        dest="person_ids",
+        type=UUID,
+        action="append",
+        default=None,
+        help="Repeat to replace people with one or more identifiers",
+    )
+    update_parser.add_argument("--clear-people", action="store_true", help="Remove all people")
+    update_parser.set_defaults(handler=handle_event_update)
+
+    delete_parser = add_documented_parser(
+        event_subparsers,
+        "delete",
+        help_content=HelpContent(
+            summary="Delete an event",
+            description="Soft-delete one event.",
+            examples=("lifeos event delete 11111111-1111-1111-1111-111111111111",),
+        ),
+    )
+    delete_parser.add_argument("event_id", type=UUID, help="Event identifier")
+    delete_parser.set_defaults(handler=handle_event_delete)
+
+    batch_parser = add_documented_parser(
+        event_subparsers,
+        "batch",
+        help_content=HelpContent(
+            summary="Run batch event operations",
+            description="Grouped namespace for multi-record event writes.",
+            examples=("lifeos event batch delete --ids <event-id-1> <event-id-2>",),
+        ),
+    )
+    batch_parser.set_defaults(handler=make_help_handler(batch_parser))
+    batch_subparsers = batch_parser.add_subparsers(
+        dest="event_batch_command", title="batch actions", metavar="batch-action"
+    )
+    batch_delete_parser = add_documented_parser(
+        batch_subparsers,
+        "delete",
+        help_content=HelpContent(
+            summary="Delete multiple events",
+            description="Soft-delete multiple events by identifier.",
+        ),
+    )
+    add_identifier_list_argument(batch_delete_parser, dest="event_ids", noun="event")
+    batch_delete_parser.set_defaults(handler=handle_event_batch_delete)

--- a/src/lifeos_cli/cli_support/resources/event/parser.py
+++ b/src/lifeos_cli/cli_support/resources/event/parser.py
@@ -123,7 +123,8 @@ def build_event_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentP
             ),
             notes=(
                 "When both window flags are given, overlapping events are returned.",
-                "Use `--title-contains` for lightweight text filtering instead of a separate search command.",
+                "Use `--title-contains` for lightweight text filtering instead of a "
+                "separate search command.",
             ),
         ),
     )
@@ -163,8 +164,10 @@ def build_event_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentP
             description="Update mutable event fields.",
             examples=(
                 "lifeos event update 11111111-1111-1111-1111-111111111111 --status completed",
-                "lifeos event update 11111111-1111-1111-1111-111111111111 --clear-task --clear-area",
-                "lifeos event update 11111111-1111-1111-1111-111111111111 --clear-people --clear-tags",
+                "lifeos event update 11111111-1111-1111-1111-111111111111 "
+                "--clear-task --clear-area",
+                "lifeos event update 11111111-1111-1111-1111-111111111111 "
+                "--clear-people --clear-tags",
             ),
             notes=(
                 "Use `--clear-*` flags to explicitly remove optional values.",

--- a/src/lifeos_cli/cli_support/resources/habit/__init__.py
+++ b/src/lifeos_cli/cli_support/resources/habit/__init__.py
@@ -1,0 +1,1 @@
+"""Habit CLI resource package."""

--- a/src/lifeos_cli/cli_support/resources/habit/handlers.py
+++ b/src/lifeos_cli/cli_support/resources/habit/handlers.py
@@ -1,0 +1,276 @@
+"""Habit resource handlers."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from lifeos_cli.cli_support.output_utils import format_id_lines, format_timestamp
+from lifeos_cli.cli_support.runtime_utils import run_async
+from lifeos_cli.db import session as db_session
+from lifeos_cli.db.models.habit import Habit
+from lifeos_cli.db.services import habits as habit_services
+
+
+def _format_habit_summary(habit: Habit) -> str:
+    status = "deleted" if habit.deleted_at is not None else habit.status
+    return (
+        f"{habit.id}\t{status}\t{habit.start_date}\t{habit.duration_days}\t"
+        f"{habit.task_id or '-'}\t{habit.title}"
+    )
+
+
+def _format_habit_summary_with_stats(overview: dict[str, object]) -> str:
+    habit = overview["habit"]
+    stats = overview["stats"]
+    assert isinstance(habit, Habit)
+    assert isinstance(stats, dict)
+    status = "deleted" if habit.deleted_at is not None else habit.status
+    return (
+        f"{habit.id}\t{status}\t{habit.start_date}\t{habit.duration_days}\t"
+        f"{stats['progress_percentage']:.1f}\t{stats['current_streak']}\t"
+        f"{stats['longest_streak']}\t{habit.title}"
+    )
+
+
+def _format_habit_detail(habit: Habit, stats: dict[str, object]) -> str:
+    return "\n".join(
+        (
+            f"id: {habit.id}",
+            f"title: {habit.title}",
+            f"description: {habit.description or '-'}",
+            f"status: {habit.status}",
+            f"start_date: {habit.start_date}",
+            f"end_date: {habit.end_date}",
+            f"duration_days: {habit.duration_days}",
+            f"task_id: {habit.task_id or '-'}",
+            f"progress_percentage: {stats['progress_percentage']:.1f}",
+            f"current_streak: {stats['current_streak']}",
+            f"longest_streak: {stats['longest_streak']}",
+            f"completed_actions: {stats['completed_actions']}",
+            f"missed_actions: {stats['missed_actions']}",
+            f"skipped_actions: {stats['skipped_actions']}",
+            f"total_actions: {stats['total_actions']}",
+            f"created_at: {format_timestamp(habit.created_at)}",
+            f"updated_at: {format_timestamp(habit.updated_at)}",
+            f"deleted_at: {format_timestamp(habit.deleted_at)}",
+        )
+    )
+
+
+def _format_habit_stats(stats: dict[str, object]) -> str:
+    return "\n".join(
+        (
+            f"habit_id: {stats['habit_id']}",
+            f"total_actions: {stats['total_actions']}",
+            f"completed_actions: {stats['completed_actions']}",
+            f"missed_actions: {stats['missed_actions']}",
+            f"skipped_actions: {stats['skipped_actions']}",
+            f"progress_percentage: {stats['progress_percentage']:.1f}",
+            f"current_streak: {stats['current_streak']}",
+            f"longest_streak: {stats['longest_streak']}",
+        )
+    )
+
+
+async def handle_habit_add_async(args: argparse.Namespace) -> int:
+    async with db_session.session_scope() as session:
+        try:
+            habit = await habit_services.create_habit(
+                session,
+                title=args.title,
+                description=args.description,
+                start_date=args.start_date,
+                duration_days=args.duration_days,
+                task_id=args.task_id,
+            )
+        except (
+            habit_services.HabitValidationError,
+            habit_services.HabitTaskReferenceNotFoundError,
+            habit_services.InvalidHabitOperationError,
+        ) as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
+    print(f"Created habit {habit.id}")
+    return 0
+
+
+def handle_habit_add(args: argparse.Namespace) -> int:
+    return run_async(handle_habit_add_async(args))
+
+
+async def handle_habit_list_async(args: argparse.Namespace) -> int:
+    async with db_session.session_scope() as session:
+        try:
+            if args.with_stats:
+                overviews = await habit_services.list_habit_overviews(
+                    session,
+                    status=args.status,
+                    title=args.title,
+                    active_window_only=args.active_window_only,
+                    include_deleted=args.include_deleted,
+                    limit=args.limit,
+                    offset=args.offset,
+                )
+                if not overviews:
+                    print("No habits found.")
+                    return 0
+                for overview in overviews:
+                    print(_format_habit_summary_with_stats(overview))
+                return 0
+            habits = await habit_services.list_habits(
+                session,
+                status=args.status,
+                title=args.title,
+                active_window_only=args.active_window_only,
+                include_deleted=args.include_deleted,
+                limit=args.limit,
+                offset=args.offset,
+            )
+        except habit_services.HabitValidationError as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
+    if not habits:
+        print("No habits found.")
+        return 0
+    for habit in habits:
+        print(_format_habit_summary(habit))
+    return 0
+
+
+def handle_habit_list(args: argparse.Namespace) -> int:
+    return run_async(handle_habit_list_async(args))
+
+
+async def handle_habit_show_async(args: argparse.Namespace) -> int:
+    async with db_session.session_scope() as session:
+        try:
+            overview = await habit_services.get_habit_overview(
+                session,
+                habit_id=args.habit_id,
+                include_deleted=args.include_deleted,
+            )
+        except habit_services.HabitNotFoundError as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
+    habit = overview["habit"]
+    stats = overview["stats"]
+    assert isinstance(habit, Habit)
+    assert isinstance(stats, dict)
+    print(_format_habit_detail(habit, stats))
+    return 0
+
+
+def handle_habit_show(args: argparse.Namespace) -> int:
+    return run_async(handle_habit_show_async(args))
+
+
+async def handle_habit_update_async(args: argparse.Namespace) -> int:
+    conflicts = (
+        (
+            args.clear_description and args.description is not None,
+            "--description",
+            "--clear-description",
+        ),
+        (
+            args.clear_task and args.task_id is not None,
+            "--task-id",
+            "--clear-task",
+        ),
+    )
+    for is_conflict, value_flag, clear_flag in conflicts:
+        if is_conflict:
+            print(f"Use either {value_flag} or {clear_flag}, not both.", file=sys.stderr)
+            return 1
+    async with db_session.session_scope() as session:
+        try:
+            habit = await habit_services.update_habit(
+                session,
+                habit_id=args.habit_id,
+                title=args.title,
+                description=args.description,
+                clear_description=args.clear_description,
+                start_date=args.start_date,
+                duration_days=args.duration_days,
+                status=args.status,
+                task_id=args.task_id,
+                clear_task=args.clear_task,
+            )
+        except (
+            habit_services.HabitNotFoundError,
+            habit_services.HabitValidationError,
+            habit_services.HabitTaskReferenceNotFoundError,
+            habit_services.InvalidHabitOperationError,
+        ) as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
+    print(f"Updated habit {habit.id}")
+    return 0
+
+
+def handle_habit_update(args: argparse.Namespace) -> int:
+    return run_async(handle_habit_update_async(args))
+
+
+async def handle_habit_delete_async(args: argparse.Namespace) -> int:
+    async with db_session.session_scope() as session:
+        try:
+            await habit_services.delete_habit(session, habit_id=args.habit_id)
+        except habit_services.HabitNotFoundError as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
+    print(f"Soft-deleted habit {args.habit_id}")
+    return 0
+
+
+def handle_habit_delete(args: argparse.Namespace) -> int:
+    return run_async(handle_habit_delete_async(args))
+
+
+async def handle_habit_stats_async(args: argparse.Namespace) -> int:
+    async with db_session.session_scope() as session:
+        try:
+            stats = await habit_services.get_habit_stats(session, habit_id=args.habit_id)
+        except habit_services.HabitNotFoundError as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
+    print(_format_habit_stats(stats))
+    return 0
+
+
+def handle_habit_stats(args: argparse.Namespace) -> int:
+    return run_async(handle_habit_stats_async(args))
+
+
+async def handle_habit_task_associations_async(_: argparse.Namespace) -> int:
+    async with db_session.session_scope() as session:
+        associations = await habit_services.get_habit_task_associations(session)
+    if not associations:
+        print("No task associations found.")
+        return 0
+    for task_id, habits in associations.items():
+        for habit in habits:
+            print(f"{task_id}\t{habit.id}\t{habit.status}\t{habit.start_date}\t{habit.title}")
+    return 0
+
+
+def handle_habit_task_associations(args: argparse.Namespace) -> int:
+    return run_async(handle_habit_task_associations_async(args))
+
+
+async def handle_habit_batch_delete_async(args: argparse.Namespace) -> int:
+    async with db_session.session_scope() as session:
+        result = await habit_services.batch_delete_habits(
+            session,
+            habit_ids=list(args.habit_ids),
+        )
+    print(f"Deleted habits: {result.deleted_count}")
+    if result.failed_ids:
+        print(format_id_lines("Failed habit IDs", result.failed_ids), file=sys.stderr)
+    for error in result.errors:
+        print(f"Error: {error}", file=sys.stderr)
+    return 1 if result.failed_ids else 0
+
+
+def handle_habit_batch_delete(args: argparse.Namespace) -> int:
+    return run_async(handle_habit_batch_delete_async(args))

--- a/src/lifeos_cli/cli_support/resources/habit/parser.py
+++ b/src/lifeos_cli/cli_support/resources/habit/parser.py
@@ -1,0 +1,249 @@
+"""Habit resource parser construction."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import date
+from uuid import UUID
+
+from lifeos_cli.cli_support.help_utils import HelpContent, add_documented_parser, make_help_handler
+from lifeos_cli.cli_support.parser_common import (
+    add_identifier_list_argument,
+    add_include_deleted_argument,
+    add_limit_offset_arguments,
+)
+from lifeos_cli.cli_support.resources.habit.handlers import (
+    handle_habit_add,
+    handle_habit_batch_delete,
+    handle_habit_delete,
+    handle_habit_list,
+    handle_habit_show,
+    handle_habit_stats,
+    handle_habit_task_associations,
+    handle_habit_update,
+)
+
+
+def build_habit_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    """Build the habit command tree."""
+    habit_parser = add_documented_parser(
+        subparsers,
+        "habit",
+        help_content=HelpContent(
+            summary="Manage recurring habits",
+            description=(
+                "Create and maintain recurring habits that generate dated habit-action rows.\n\n"
+                "A habit acts as a template. Each day in its duration produces "
+                "one habit-action record."
+            ),
+            examples=(
+                'lifeos habit add "Daily Exercise" --start-date 2026-04-09 --duration-days 21',
+                "lifeos habit list --with-stats",
+                "lifeos habit task-associations",
+            ),
+            notes=(
+                "Use `list` as the primary query entrypoint for habits.",
+                "Habit creation and timing updates automatically generate or "
+                "adjust habit-action rows.",
+                "Delete operations in the public CLI always perform soft deletion.",
+            ),
+        ),
+    )
+    habit_parser.set_defaults(handler=make_help_handler(habit_parser))
+    habit_subparsers = habit_parser.add_subparsers(
+        dest="habit_command",
+        title="actions",
+        metavar="action",
+    )
+
+    add_parser = add_documented_parser(
+        habit_subparsers,
+        "add",
+        help_content=HelpContent(
+            summary="Create a habit",
+            description="Create a recurring habit and generate its dated habit-action rows.",
+            examples=(
+                'lifeos habit add "Daily Exercise" --start-date 2026-04-09 --duration-days 21',
+                'lifeos habit add "Morning Review" --start-date 2026-04-09 --duration-days 100 '
+                "--task-id 11111111-1111-1111-1111-111111111111",
+            ),
+            notes=(
+                "Duration must be one of the supported program lengths.",
+                "If `--task-id` is provided, the task must already exist.",
+            ),
+        ),
+    )
+    add_parser.add_argument("title", help="Habit title")
+    add_parser.add_argument("--description", help="Optional habit description")
+    add_parser.add_argument(
+        "--start-date",
+        required=True,
+        type=date.fromisoformat,
+        help="Habit start date in YYYY-MM-DD format",
+    )
+    add_parser.add_argument(
+        "--duration-days",
+        required=True,
+        type=int,
+        help="Habit duration in days",
+    )
+    add_parser.add_argument("--task-id", type=UUID, help="Optional linked task identifier")
+    add_parser.set_defaults(handler=handle_habit_add)
+
+    list_parser = add_documented_parser(
+        habit_subparsers,
+        "list",
+        help_content=HelpContent(
+            summary="List habits",
+            description=(
+                "List habits with optional status, title, and activity-window filters.\n\n"
+                "Use this command as the main habit query entrypoint."
+            ),
+            examples=(
+                "lifeos habit list",
+                "lifeos habit list --status active --with-stats",
+                'lifeos habit list --title "Daily Exercise" --active-window-only',
+            ),
+            notes=(
+                "Use `--with-stats` when the summary should include progress and streak fields.",
+                "Use `--active-window-only` to show habits whose duration still covers today.",
+            ),
+        ),
+    )
+    list_parser.add_argument("--status", help="Filter by habit status")
+    list_parser.add_argument("--title", help="Filter by exact habit title")
+    list_parser.add_argument(
+        "--active-window-only",
+        action="store_true",
+        help="Restrict results to habits whose duration still covers today",
+    )
+    list_parser.add_argument(
+        "--with-stats",
+        action="store_true",
+        help="Include progress and streak information in each summary row",
+    )
+    add_include_deleted_argument(list_parser, noun="habits")
+    add_limit_offset_arguments(list_parser)
+    list_parser.set_defaults(handler=handle_habit_list)
+
+    show_parser = add_documented_parser(
+        habit_subparsers,
+        "show",
+        help_content=HelpContent(
+            summary="Show a habit",
+            description="Show one habit with full metadata and derived statistics.",
+            examples=(
+                "lifeos habit show 11111111-1111-1111-1111-111111111111",
+                "lifeos habit show 11111111-1111-1111-1111-111111111111 --include-deleted",
+            ),
+        ),
+    )
+    show_parser.add_argument("habit_id", type=UUID, help="Habit identifier")
+    add_include_deleted_argument(show_parser, noun="habits", help_prefix="Allow")
+    show_parser.set_defaults(handler=handle_habit_show)
+
+    update_parser = add_documented_parser(
+        habit_subparsers,
+        "update",
+        help_content=HelpContent(
+            summary="Update a habit",
+            description=(
+                "Update mutable habit fields.\n\n"
+                "Timing changes automatically reconcile generated habit-action rows."
+            ),
+            examples=(
+                "lifeos habit update 11111111-1111-1111-1111-111111111111 --status paused",
+                "lifeos habit update 11111111-1111-1111-1111-111111111111 "
+                "--duration-days 100 --start-date 2026-04-10",
+                "lifeos habit update 11111111-1111-1111-1111-111111111111 --clear-task",
+            ),
+            notes=(
+                "Use `--clear-description` or `--clear-task` to remove optional values.",
+                "Reactivating a habit still respects the active habit limit.",
+            ),
+        ),
+    )
+    update_parser.add_argument("habit_id", type=UUID, help="Habit identifier")
+    update_parser.add_argument("--title", help="Updated habit title")
+    update_parser.add_argument("--description", help="Updated habit description")
+    update_parser.add_argument(
+        "--clear-description",
+        action="store_true",
+        help="Clear the optional habit description",
+    )
+    update_parser.add_argument(
+        "--start-date",
+        type=date.fromisoformat,
+        help="Updated habit start date in YYYY-MM-DD format",
+    )
+    update_parser.add_argument("--duration-days", type=int, help="Updated duration in days")
+    update_parser.add_argument("--status", help="Updated habit status")
+    update_parser.add_argument("--task-id", type=UUID, help="Updated linked task identifier")
+    update_parser.add_argument(
+        "--clear-task",
+        action="store_true",
+        help="Remove the linked task reference",
+    )
+    update_parser.set_defaults(handler=handle_habit_update)
+
+    delete_parser = add_documented_parser(
+        habit_subparsers,
+        "delete",
+        help_content=HelpContent(
+            summary="Soft-delete a habit",
+            description="Soft-delete one habit. Public CLI deletion is never permanent.",
+            examples=("lifeos habit delete 11111111-1111-1111-1111-111111111111",),
+        ),
+    )
+    delete_parser.add_argument("habit_id", type=UUID, help="Habit identifier")
+    delete_parser.set_defaults(handler=handle_habit_delete)
+
+    stats_parser = add_documented_parser(
+        habit_subparsers,
+        "stats",
+        help_content=HelpContent(
+            summary="Show habit statistics",
+            description="Show derived completion and streak statistics for one habit.",
+            examples=("lifeos habit stats 11111111-1111-1111-1111-111111111111",),
+        ),
+    )
+    stats_parser.add_argument("habit_id", type=UUID, help="Habit identifier")
+    stats_parser.set_defaults(handler=handle_habit_stats)
+
+    associations_parser = add_documented_parser(
+        habit_subparsers,
+        "task-associations",
+        help_content=HelpContent(
+            summary="List task-to-habit associations",
+            description="Show active habits currently linked to tasks.",
+            examples=("lifeos habit task-associations",),
+        ),
+    )
+    associations_parser.set_defaults(handler=handle_habit_task_associations)
+
+    batch_parser = add_documented_parser(
+        habit_subparsers,
+        "batch",
+        help_content=HelpContent(
+            summary="Run bulk habit operations",
+            description="Grouped namespace for multi-record habit writes.",
+            examples=("lifeos habit batch delete --ids <habit-id-1> <habit-id-2>",),
+        ),
+    )
+    batch_parser.set_defaults(handler=make_help_handler(batch_parser))
+    batch_subparsers = batch_parser.add_subparsers(
+        dest="habit_batch_command",
+        title="batch actions",
+        metavar="batch-action",
+    )
+    batch_delete_parser = add_documented_parser(
+        batch_subparsers,
+        "delete",
+        help_content=HelpContent(
+            summary="Soft-delete multiple habits",
+            description="Soft-delete multiple habits in one command.",
+            examples=("lifeos habit batch delete --ids <habit-id-1> <habit-id-2>",),
+        ),
+    )
+    add_identifier_list_argument(batch_delete_parser, dest="habit_ids", noun="habit")
+    batch_delete_parser.set_defaults(handler=handle_habit_batch_delete)

--- a/src/lifeos_cli/cli_support/resources/habit_action/__init__.py
+++ b/src/lifeos_cli/cli_support/resources/habit_action/__init__.py
@@ -1,0 +1,1 @@
+"""Habit-action CLI resource package."""

--- a/src/lifeos_cli/cli_support/resources/habit_action/handlers.py
+++ b/src/lifeos_cli/cli_support/resources/habit_action/handlers.py
@@ -1,0 +1,114 @@
+"""Habit-action resource handlers."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from lifeos_cli.cli_support.output_utils import format_timestamp
+from lifeos_cli.cli_support.runtime_utils import run_async
+from lifeos_cli.db import session as db_session
+from lifeos_cli.db.models.habit_action import HabitAction
+from lifeos_cli.db.services import habit_actions as habit_action_services
+
+
+def _format_habit_action_summary(action: HabitAction) -> str:
+    status = "deleted" if action.deleted_at is not None else action.status
+    habit_title = action.habit.title if action.habit is not None else "-"
+    return f"{action.id}\t{status}\t{action.action_date}\t{action.habit_id}\t{habit_title}"
+
+
+def _format_habit_action_detail(action: HabitAction) -> str:
+    habit_title = action.habit.title if action.habit is not None else "-"
+    return "\n".join(
+        (
+            f"id: {action.id}",
+            f"habit_id: {action.habit_id}",
+            f"habit_title: {habit_title}",
+            f"action_date: {action.action_date}",
+            f"status: {action.status}",
+            f"notes: {action.notes or '-'}",
+            f"created_at: {format_timestamp(action.created_at)}",
+            f"updated_at: {format_timestamp(action.updated_at)}",
+            f"deleted_at: {format_timestamp(action.deleted_at)}",
+        )
+    )
+
+
+async def handle_habit_action_list_async(args: argparse.Namespace) -> int:
+    async with db_session.session_scope() as session:
+        try:
+            actions = await habit_action_services.list_habit_actions(
+                session,
+                habit_id=args.habit_id,
+                status=args.status,
+                action_date=args.action_date,
+                center_date=args.center_date,
+                days_before=args.days_before,
+                days_after=args.days_after,
+                include_deleted=args.include_deleted,
+                limit=args.limit,
+                offset=args.offset,
+            )
+        except (
+            habit_action_services.HabitNotFoundError,
+            habit_action_services.HabitValidationError,
+        ) as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
+    if not actions:
+        print("No habit actions found.")
+        return 0
+    for action in actions:
+        print(_format_habit_action_summary(action))
+    return 0
+
+
+def handle_habit_action_list(args: argparse.Namespace) -> int:
+    return run_async(handle_habit_action_list_async(args))
+
+
+async def handle_habit_action_show_async(args: argparse.Namespace) -> int:
+    async with db_session.session_scope() as session:
+        action = await habit_action_services.get_habit_action(
+            session,
+            action_id=args.action_id,
+            include_deleted=args.include_deleted,
+        )
+    if action is None:
+        print(f"Habit action {args.action_id} was not found", file=sys.stderr)
+        return 1
+    print(_format_habit_action_detail(action))
+    return 0
+
+
+def handle_habit_action_show(args: argparse.Namespace) -> int:
+    return run_async(handle_habit_action_show_async(args))
+
+
+async def handle_habit_action_update_async(args: argparse.Namespace) -> int:
+    if args.clear_notes and args.notes is not None:
+        print("Use either --notes or --clear-notes, not both.", file=sys.stderr)
+        return 1
+    async with db_session.session_scope() as session:
+        try:
+            action = await habit_action_services.update_habit_action(
+                session,
+                action_id=args.action_id,
+                status=args.status,
+                notes=args.notes,
+                clear_notes=args.clear_notes,
+            )
+        except (
+            habit_action_services.HabitActionNotFoundError,
+            habit_action_services.HabitValidationError,
+            habit_action_services.InvalidHabitOperationError,
+        ) as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
+    print(f"Updated habit action {action.id}")
+    return 0
+
+
+def handle_habit_action_update(args: argparse.Namespace) -> int:
+    return run_async(handle_habit_action_update_async(args))

--- a/src/lifeos_cli/cli_support/resources/habit_action/parser.py
+++ b/src/lifeos_cli/cli_support/resources/habit_action/parser.py
@@ -1,0 +1,131 @@
+"""Habit-action resource parser construction."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import date
+from uuid import UUID
+
+from lifeos_cli.cli_support.help_utils import HelpContent, add_documented_parser, make_help_handler
+from lifeos_cli.cli_support.parser_common import (
+    add_include_deleted_argument,
+    add_limit_offset_arguments,
+)
+from lifeos_cli.cli_support.resources.habit_action.handlers import (
+    handle_habit_action_list,
+    handle_habit_action_show,
+    handle_habit_action_update,
+)
+
+
+def build_habit_action_parser(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
+    """Build the habit-action command tree."""
+    action_parser = add_documented_parser(
+        subparsers,
+        "habit-action",
+        help_content=HelpContent(
+            summary="Manage dated habit actions",
+            description=(
+                "Inspect and update dated habit-action rows generated from habits.\n\n"
+                "Habit actions are generated automatically and are updated in place."
+            ),
+            examples=(
+                "lifeos habit-action list --habit-id 11111111-1111-1111-1111-111111111111",
+                "lifeos habit-action list --action-date 2026-04-09",
+                "lifeos habit-action update 11111111-1111-1111-1111-111111111111 --status done",
+            ),
+            notes=(
+                "Use `list` for both per-habit and by-date views.",
+                "Public CLI does not create or delete habit actions directly.",
+            ),
+        ),
+    )
+    action_parser.set_defaults(handler=make_help_handler(action_parser))
+    action_subparsers = action_parser.add_subparsers(
+        dest="habit_action_command",
+        title="actions",
+        metavar="action",
+    )
+
+    list_parser = add_documented_parser(
+        action_subparsers,
+        "list",
+        help_content=HelpContent(
+            summary="List habit actions",
+            description=(
+                "List habit actions for one habit or by date/window filters.\n\n"
+                "Use this command to inspect daily execution records."
+            ),
+            examples=(
+                "lifeos habit-action list --habit-id 11111111-1111-1111-1111-111111111111",
+                "lifeos habit-action list --action-date 2026-04-09",
+                "lifeos habit-action list --center-date 2026-04-09 --days-before 3 --days-after 3",
+            ),
+            notes=(
+                "Use `--action-date` for one exact day.",
+                "Use `--center-date` with a window when browsing nearby days.",
+            ),
+        ),
+    )
+    list_parser.add_argument("--habit-id", type=UUID, help="Filter by habit identifier")
+    list_parser.add_argument("--status", help="Filter by habit-action status")
+    list_parser.add_argument(
+        "--action-date",
+        type=date.fromisoformat,
+        help="Filter by one exact action date in YYYY-MM-DD format",
+    )
+    list_parser.add_argument(
+        "--center-date",
+        type=date.fromisoformat,
+        help="Reference date for a windowed action query in YYYY-MM-DD format",
+    )
+    list_parser.add_argument("--days-before", type=int, help="Days before the center date")
+    list_parser.add_argument("--days-after", type=int, help="Days after the center date")
+    add_include_deleted_argument(list_parser, noun="habit actions")
+    add_limit_offset_arguments(list_parser, row_noun="habit actions")
+    list_parser.set_defaults(handler=handle_habit_action_list)
+
+    show_parser = add_documented_parser(
+        action_subparsers,
+        "show",
+        help_content=HelpContent(
+            summary="Show a habit action",
+            description="Show one habit action with its linked habit metadata.",
+            examples=(
+                "lifeos habit-action show 11111111-1111-1111-1111-111111111111",
+                "lifeos habit-action show 11111111-1111-1111-1111-111111111111 --include-deleted",
+            ),
+        ),
+    )
+    show_parser.add_argument("action_id", type=UUID, help="Habit-action identifier")
+    add_include_deleted_argument(show_parser, noun="habit actions", help_prefix="Allow")
+    show_parser.set_defaults(handler=handle_habit_action_show)
+
+    update_parser = add_documented_parser(
+        action_subparsers,
+        "update",
+        help_content=HelpContent(
+            summary="Update a habit action",
+            description=(
+                "Update a generated habit action.\n\n"
+                "This command only allows status and notes changes within the editable window."
+            ),
+            examples=(
+                "lifeos habit-action update 11111111-1111-1111-1111-111111111111 --status done",
+                "lifeos habit-action update 11111111-1111-1111-1111-111111111111 "
+                '--notes "Completed after lunch"',
+            ),
+            notes=("Use `--clear-notes` to remove optional notes.",),
+        ),
+    )
+    update_parser.add_argument("action_id", type=UUID, help="Habit-action identifier")
+    update_parser.add_argument("--status", help="Updated habit-action status")
+    update_parser.add_argument("--notes", help="Updated notes")
+    update_parser.add_argument(
+        "--clear-notes",
+        action="store_true",
+        help="Clear the optional notes field",
+    )
+    update_parser.set_defaults(handler=handle_habit_action_update)

--- a/src/lifeos_cli/cli_support/resources/tag/handlers.py
+++ b/src/lifeos_cli/cli_support/resources/tag/handlers.py
@@ -18,6 +18,9 @@ def _format_tag_summary(tag: Tag) -> str:
 
 
 def _format_tag_detail(tag: Tag) -> str:
+    people_names = (
+        ", ".join(person.name for person in tag.people) if getattr(tag, "people", None) else "-"
+    )
     return "\n".join(
         (
             f"id: {tag.id}",
@@ -26,6 +29,7 @@ def _format_tag_detail(tag: Tag) -> str:
             f"category: {tag.category}",
             f"description: {tag.description or '-'}",
             f"color: {tag.color or '-'}",
+            f"people: {people_names}",
             f"created_at: {format_timestamp(tag.created_at)}",
             f"updated_at: {format_timestamp(tag.updated_at)}",
             f"deleted_at: {format_timestamp(tag.deleted_at)}",
@@ -43,6 +47,7 @@ async def handle_tag_add_async(args: argparse.Namespace) -> int:
                 category=args.category,
                 description=args.description,
                 color=args.color,
+                person_ids=args.person_ids,
             )
         except (
             tag_services.TagAlreadyExistsError,
@@ -66,6 +71,7 @@ async def handle_tag_list_async(args: argparse.Namespace) -> int:
                 session,
                 entity_type=args.entity_type,
                 category=args.category,
+                person_id=args.person_id,
                 include_deleted=args.include_deleted,
                 limit=args.limit,
                 offset=args.offset,
@@ -110,6 +116,9 @@ async def handle_tag_update_async(args: argparse.Namespace) -> int:
     if args.clear_color and args.color is not None:
         print("Use either --color or --clear-color, not both.", file=sys.stderr)
         return 1
+    if args.clear_people and args.person_ids is not None:
+        print("Use either --person-id or --clear-people, not both.", file=sys.stderr)
+        return 1
     async with db_session.session_scope() as session:
         try:
             tag = await tag_services.update_tag(
@@ -122,6 +131,8 @@ async def handle_tag_update_async(args: argparse.Namespace) -> int:
                 clear_description=args.clear_description,
                 color=args.color,
                 clear_color=args.clear_color,
+                person_ids=args.person_ids,
+                clear_people=args.clear_people,
             )
         except (
             tag_services.TagNotFoundError,

--- a/src/lifeos_cli/cli_support/resources/tag/parser.py
+++ b/src/lifeos_cli/cli_support/resources/tag/parser.py
@@ -61,6 +61,9 @@ def build_tag_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentPar
             examples=(
                 'lifeos tag add "family" --entity-type person --category relation',
                 'lifeos tag add "urgent" --entity-type task --color "#DC2626"',
+                "lifeos tag add "
+                '"coach" --entity-type vision --person-id '
+                "11111111-1111-1111-1111-111111111111",
             ),
         ),
     )
@@ -69,6 +72,14 @@ def build_tag_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentPar
     add_parser.add_argument("--category", default="general", help="Tag category")
     add_parser.add_argument("--description", help="Optional tag description")
     add_parser.add_argument("--color", help="Optional hex color code")
+    add_parser.add_argument(
+        "--person-id",
+        dest="person_ids",
+        type=UUID,
+        action="append",
+        default=None,
+        help="Repeat to associate one or more people",
+    )
     add_parser.set_defaults(handler=handle_tag_add)
 
     list_parser = add_documented_parser(
@@ -84,6 +95,7 @@ def build_tag_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentPar
             examples=(
                 "lifeos tag list",
                 "lifeos tag list --entity-type person",
+                "lifeos tag list --person-id 11111111-1111-1111-1111-111111111111",
                 "lifeos tag list --entity-type task --category priority --limit 20",
             ),
             notes=("Use `--include-deleted` to review previously deleted tags.",),
@@ -91,6 +103,7 @@ def build_tag_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentPar
     )
     list_parser.add_argument("--entity-type", help="Filter by entity type")
     list_parser.add_argument("--category", help="Filter by category")
+    list_parser.add_argument("--person-id", type=UUID, help="Filter by linked person identifier")
     add_include_deleted_argument(list_parser, noun="tags")
     add_limit_offset_arguments(list_parser)
     list_parser.set_defaults(handler=handle_tag_list)
@@ -122,9 +135,14 @@ def build_tag_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentPar
             ),
             examples=(
                 'lifeos tag update 11111111-1111-1111-1111-111111111111 --name "urgent"',
+                "lifeos tag update 11111111-1111-1111-1111-111111111111 "
+                "--person-id 11111111-1111-1111-1111-111111111111",
                 "lifeos tag update 11111111-1111-1111-1111-111111111111 --clear-color",
             ),
-            notes=("Use `--clear-description` or `--clear-color` to remove optional values.",),
+            notes=(
+                "Use `--clear-description`, `--clear-color`, or `--clear-people` "
+                "to remove optional values.",
+            ),
         ),
     )
     update_parser.add_argument("tag_id", type=UUID, help="Tag identifier")
@@ -143,6 +161,15 @@ def build_tag_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentPar
         action="store_true",
         help="Clear the optional tag color",
     )
+    update_parser.add_argument(
+        "--person-id",
+        dest="person_ids",
+        type=UUID,
+        action="append",
+        default=None,
+        help="Repeat to replace people with one or more identifiers",
+    )
+    update_parser.add_argument("--clear-people", action="store_true", help="Remove all people")
     update_parser.set_defaults(handler=handle_tag_update)
 
     delete_parser = add_documented_parser(

--- a/src/lifeos_cli/cli_support/resources/task/handlers.py
+++ b/src/lifeos_cli/cli_support/resources/task/handlers.py
@@ -25,6 +25,9 @@ def _format_task_summary(task: Task) -> str:
 
 
 def _format_task_detail(task: Task) -> str:
+    people_names = (
+        ", ".join(person.name for person in task.people) if getattr(task, "people", None) else "-"
+    )
     return "\n".join(
         (
             f"id: {task.id}",
@@ -39,6 +42,7 @@ def _format_task_detail(task: Task) -> str:
             f"planning_cycle_type: {task.planning_cycle_type or '-'}",
             f"planning_cycle_days: {task.planning_cycle_days or '-'}",
             f"planning_cycle_start_date: {task.planning_cycle_start_date or '-'}",
+            f"people: {people_names}",
             f"actual_effort_self: {task.actual_effort_self}",
             f"actual_effort_total: {task.actual_effort_total}",
             f"created_at: {format_timestamp(task.created_at)}",
@@ -60,6 +64,7 @@ async def handle_task_add_async(args: argparse.Namespace) -> int:
                 status=args.status,
                 priority=args.priority,
                 display_order=args.display_order,
+                person_ids=args.person_ids,
                 estimated_effort=args.estimated_effort,
                 planning_cycle_type=args.planning_cycle_type,
                 planning_cycle_days=args.planning_cycle_days,
@@ -89,6 +94,7 @@ async def handle_task_list_async(args: argparse.Namespace) -> int:
                 session,
                 vision_id=args.vision_id,
                 parent_task_id=args.parent_task_id,
+                person_id=args.person_id,
                 status=args.status,
                 include_deleted=args.include_deleted,
                 limit=args.limit,
@@ -144,6 +150,7 @@ async def handle_task_update_async(args: argparse.Namespace) -> int:
             "--estimated-effort",
             "--clear-estimated-effort",
         ),
+        (args.clear_people and args.person_ids is not None, "--person-id", "--clear-people"),
         (
             args.clear_planning_cycle
             and any(
@@ -175,6 +182,8 @@ async def handle_task_update_async(args: argparse.Namespace) -> int:
                 status=args.status,
                 priority=args.priority,
                 display_order=args.display_order,
+                person_ids=args.person_ids,
+                clear_people=args.clear_people,
                 estimated_effort=args.estimated_effort,
                 clear_estimated_effort=args.clear_estimated_effort,
                 planning_cycle_type=args.planning_cycle_type,

--- a/src/lifeos_cli/cli_support/resources/task/parser.py
+++ b/src/lifeos_cli/cli_support/resources/task/parser.py
@@ -65,8 +65,14 @@ def build_task_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentPa
                 'lifeos task add "Write changelog" '
                 "--vision-id 11111111-1111-1111-1111-111111111111 "
                 "--parent-task-id 22222222-2222-2222-2222-222222222222",
+                'lifeos task add "Prepare family meeting" '
+                "--vision-id 11111111-1111-1111-1111-111111111111 "
+                "--person-id 33333333-3333-3333-3333-333333333333",
             ),
-            notes=("Planning-cycle flags must be supplied as a complete set when used.",),
+            notes=(
+                "Planning-cycle flags must be supplied as a complete set when used.",
+                "Repeat `--person-id` to associate one or more people.",
+            ),
         ),
     )
     add_parser.add_argument("content", help="Task content")
@@ -78,6 +84,14 @@ def build_task_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentPa
     add_parser.add_argument("--status", default="todo", help="Task status")
     add_parser.add_argument("--priority", type=int, default=0, help="Task priority")
     add_parser.add_argument("--display-order", type=int, default=0, help="Display order")
+    add_parser.add_argument(
+        "--person-id",
+        dest="person_ids",
+        type=UUID,
+        action="append",
+        default=None,
+        help="Repeat to associate one or more people",
+    )
     add_parser.add_argument("--estimated-effort", type=int, help="Estimated effort in minutes")
     add_parser.add_argument("--planning-cycle-type", help="Planning cycle type")
     add_parser.add_argument(
@@ -100,6 +114,7 @@ def build_task_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentPa
             examples=(
                 "lifeos task list",
                 "lifeos task list --vision-id 11111111-1111-1111-1111-111111111111",
+                "lifeos task list --person-id 11111111-1111-1111-1111-111111111111",
                 "lifeos task list --parent-task-id "
                 "22222222-2222-2222-2222-222222222222 --status todo",
             ),
@@ -116,6 +131,7 @@ def build_task_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentPa
         help="Filter by vision identifier",
     )
     list_parser.add_argument("--parent-task-id", type=UUID, help="Filter by parent task identifier")
+    list_parser.add_argument("--person-id", type=UUID, help="Filter by linked person identifier")
     list_parser.add_argument("--status", help="Filter by task status")
     add_include_deleted_argument(list_parser, noun="tasks")
     add_limit_offset_arguments(list_parser)
@@ -150,6 +166,8 @@ def build_task_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentPa
                 "lifeos task update 11111111-1111-1111-1111-111111111111 --status in_progress",
                 "lifeos task update 11111111-1111-1111-1111-111111111111 "
                 "--priority 3 --display-order 20",
+                "lifeos task update 11111111-1111-1111-1111-111111111111 "
+                "--person-id 33333333-3333-3333-3333-333333333333",
                 "lifeos task update 11111111-1111-1111-1111-111111111111 --clear-parent",
                 "lifeos task update 11111111-1111-1111-1111-111111111111 --clear-planning-cycle",
             ),
@@ -178,6 +196,15 @@ def build_task_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentPa
     update_parser.add_argument("--status", help="Updated task status")
     update_parser.add_argument("--priority", type=int, help="Updated priority")
     update_parser.add_argument("--display-order", type=int, help="Updated display order")
+    update_parser.add_argument(
+        "--person-id",
+        dest="person_ids",
+        type=UUID,
+        action="append",
+        default=None,
+        help="Repeat to replace people with one or more identifiers",
+    )
+    update_parser.add_argument("--clear-people", action="store_true", help="Remove all people")
     update_parser.add_argument("--estimated-effort", type=int, help="Updated estimated effort")
     update_parser.add_argument(
         "--clear-estimated-effort",

--- a/src/lifeos_cli/cli_support/resources/timelog/__init__.py
+++ b/src/lifeos_cli/cli_support/resources/timelog/__init__.py
@@ -1,0 +1,1 @@
+"""Timelog CLI resource package."""

--- a/src/lifeos_cli/cli_support/resources/timelog/handlers.py
+++ b/src/lifeos_cli/cli_support/resources/timelog/handlers.py
@@ -1,0 +1,224 @@
+"""CLI handlers for the timelog resource."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from lifeos_cli.cli_support.output_utils import format_id_lines, format_timestamp
+from lifeos_cli.cli_support.runtime_utils import run_async
+from lifeos_cli.db import session as db_session
+from lifeos_cli.db.models.timelog import Timelog
+from lifeos_cli.db.services import timelogs as timelog_services
+
+
+def _format_timelog_summary(timelog: Timelog) -> str:
+    status = "deleted" if timelog.deleted_at is not None else timelog.tracking_method
+    return (
+        f"{timelog.id}\t{status}\t{format_timestamp(timelog.start_time)}\t"
+        f"{format_timestamp(timelog.end_time)}\t{timelog.task_id or '-'}\t{timelog.title}"
+    )
+
+
+def _format_timelog_detail(timelog: Timelog) -> str:
+    tag_names = ", ".join(tag.name for tag in timelog.tags) if getattr(timelog, "tags", None) else "-"
+    people_names = (
+        ", ".join(person.name for person in timelog.people)
+        if getattr(timelog, "people", None)
+        else "-"
+    )
+    return "\n".join(
+        (
+            f"id: {timelog.id}",
+            f"title: {timelog.title}",
+            f"tracking_method: {timelog.tracking_method}",
+            f"start_time: {format_timestamp(timelog.start_time)}",
+            f"end_time: {format_timestamp(timelog.end_time)}",
+            f"location: {timelog.location or '-'}",
+            f"energy_level: {timelog.energy_level if timelog.energy_level is not None else '-'}",
+            f"notes: {timelog.notes or '-'}",
+            f"area_id: {timelog.area_id or '-'}",
+            f"task_id: {timelog.task_id or '-'}",
+            f"tags: {tag_names}",
+            f"people: {people_names}",
+            f"created_at: {format_timestamp(timelog.created_at)}",
+            f"updated_at: {format_timestamp(timelog.updated_at)}",
+            f"deleted_at: {format_timestamp(timelog.deleted_at)}",
+        )
+    )
+
+
+def _print_timelog_error(exc: Exception) -> int:
+    print(str(exc), file=sys.stderr)
+    return 1
+
+
+async def handle_timelog_add_async(args: argparse.Namespace) -> int:
+    async with db_session.session_scope() as session:
+        try:
+            timelog = await timelog_services.create_timelog(
+                session,
+                title=args.title,
+                start_time=args.start_time,
+                end_time=args.end_time,
+                tracking_method=args.tracking_method,
+                location=args.location,
+                energy_level=args.energy_level,
+                notes=args.notes,
+                area_id=args.area_id,
+                task_id=args.task_id,
+                tag_ids=args.tag_ids,
+                person_ids=args.person_ids,
+            )
+        except (
+            timelog_services.TimelogAreaReferenceNotFoundError,
+            timelog_services.TimelogTaskReferenceNotFoundError,
+            timelog_services.TimelogValidationError,
+            LookupError,
+        ) as exc:
+            return _print_timelog_error(exc)
+    print(f"Created timelog {timelog.id}")
+    return 0
+
+
+def handle_timelog_add(args: argparse.Namespace) -> int:
+    return run_async(handle_timelog_add_async(args))
+
+
+async def handle_timelog_list_async(args: argparse.Namespace) -> int:
+    async with db_session.session_scope() as session:
+        try:
+            timelogs = await timelog_services.list_timelogs(
+                session,
+                title_contains=args.title_contains,
+                tracking_method=args.tracking_method,
+                area_id=args.area_id,
+                task_id=args.task_id,
+                person_id=args.person_id,
+                tag_id=args.tag_id,
+                window_start=args.window_start,
+                window_end=args.window_end,
+                include_deleted=args.include_deleted,
+                limit=args.limit,
+                offset=args.offset,
+            )
+        except timelog_services.TimelogValidationError as exc:
+            return _print_timelog_error(exc)
+    if not timelogs:
+        print("No timelogs found.")
+        return 0
+    for timelog in timelogs:
+        print(_format_timelog_summary(timelog))
+    return 0
+
+
+def handle_timelog_list(args: argparse.Namespace) -> int:
+    return run_async(handle_timelog_list_async(args))
+
+
+async def handle_timelog_show_async(args: argparse.Namespace) -> int:
+    async with db_session.session_scope() as session:
+        timelog = await timelog_services.get_timelog(
+            session,
+            timelog_id=args.timelog_id,
+            include_deleted=args.include_deleted,
+        )
+    if timelog is None:
+        print(f"Timelog {args.timelog_id} was not found", file=sys.stderr)
+        return 1
+    print(_format_timelog_detail(timelog))
+    return 0
+
+
+def handle_timelog_show(args: argparse.Namespace) -> int:
+    return run_async(handle_timelog_show_async(args))
+
+
+async def handle_timelog_update_async(args: argparse.Namespace) -> int:
+    conflicts = (
+        (args.clear_location and args.location is not None, "--location", "--clear-location"),
+        (
+            args.clear_energy_level and args.energy_level is not None,
+            "--energy-level",
+            "--clear-energy-level",
+        ),
+        (args.clear_notes and args.notes is not None, "--notes", "--clear-notes"),
+        (args.clear_area and args.area_id is not None, "--area-id", "--clear-area"),
+        (args.clear_task and args.task_id is not None, "--task-id", "--clear-task"),
+        (args.clear_tags and args.tag_ids is not None, "--tag-id", "--clear-tags"),
+        (args.clear_people and args.person_ids is not None, "--person-id", "--clear-people"),
+    )
+    for is_conflict, value_flag, clear_flag in conflicts:
+        if is_conflict:
+            print(f"Use either {value_flag} or {clear_flag}, not both.", file=sys.stderr)
+            return 1
+    async with db_session.session_scope() as session:
+        try:
+            timelog = await timelog_services.update_timelog(
+                session,
+                timelog_id=args.timelog_id,
+                title=args.title,
+                start_time=args.start_time,
+                end_time=args.end_time,
+                tracking_method=args.tracking_method,
+                location=args.location,
+                clear_location=args.clear_location,
+                energy_level=args.energy_level,
+                clear_energy_level=args.clear_energy_level,
+                notes=args.notes,
+                clear_notes=args.clear_notes,
+                area_id=args.area_id,
+                clear_area=args.clear_area,
+                task_id=args.task_id,
+                clear_task=args.clear_task,
+                tag_ids=args.tag_ids,
+                clear_tags=args.clear_tags,
+                person_ids=args.person_ids,
+                clear_people=args.clear_people,
+            )
+        except (
+            timelog_services.TimelogNotFoundError,
+            timelog_services.TimelogAreaReferenceNotFoundError,
+            timelog_services.TimelogTaskReferenceNotFoundError,
+            timelog_services.TimelogValidationError,
+            LookupError,
+        ) as exc:
+            return _print_timelog_error(exc)
+    print(f"Updated timelog {timelog.id}")
+    return 0
+
+
+def handle_timelog_update(args: argparse.Namespace) -> int:
+    return run_async(handle_timelog_update_async(args))
+
+
+async def handle_timelog_delete_async(args: argparse.Namespace) -> int:
+    async with db_session.session_scope() as session:
+        try:
+            await timelog_services.delete_timelog(session, timelog_id=args.timelog_id)
+        except timelog_services.TimelogNotFoundError as exc:
+            return _print_timelog_error(exc)
+    print(f"Soft-deleted timelog {args.timelog_id}")
+    return 0
+
+
+def handle_timelog_delete(args: argparse.Namespace) -> int:
+    return run_async(handle_timelog_delete_async(args))
+
+
+async def handle_timelog_batch_delete_async(args: argparse.Namespace) -> int:
+    async with db_session.session_scope() as session:
+        result = await timelog_services.batch_delete_timelogs(
+            session,
+            timelog_ids=list(args.timelog_ids),
+        )
+    print(f"Deleted timelogs: {result.deleted_count}")
+    if result.failed_ids:
+        print(format_id_lines("Failed timelog IDs", result.failed_ids), file=sys.stderr)
+    for error in result.errors:
+        print(f"Error: {error}", file=sys.stderr)
+    return 1 if result.failed_ids else 0
+
+
+def handle_timelog_batch_delete(args: argparse.Namespace) -> int:
+    return run_async(handle_timelog_batch_delete_async(args))

--- a/src/lifeos_cli/cli_support/resources/timelog/handlers.py
+++ b/src/lifeos_cli/cli_support/resources/timelog/handlers.py
@@ -21,7 +21,9 @@ def _format_timelog_summary(timelog: Timelog) -> str:
 
 
 def _format_timelog_detail(timelog: Timelog) -> str:
-    tag_names = ", ".join(tag.name for tag in timelog.tags) if getattr(timelog, "tags", None) else "-"
+    tag_names = (
+        ", ".join(tag.name for tag in timelog.tags) if getattr(timelog, "tags", None) else "-"
+    )
     people_names = (
         ", ".join(person.name for person in timelog.people)
         if getattr(timelog, "people", None)

--- a/src/lifeos_cli/cli_support/resources/timelog/parser.py
+++ b/src/lifeos_cli/cli_support/resources/timelog/parser.py
@@ -1,0 +1,244 @@
+"""Timelog resource parser construction."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime
+from uuid import UUID
+
+from lifeos_cli.cli_support.help_utils import HelpContent, add_documented_parser, make_help_handler
+from lifeos_cli.cli_support.parser_common import (
+    add_identifier_list_argument,
+    add_include_deleted_argument,
+    add_limit_offset_arguments,
+)
+from lifeos_cli.cli_support.resources.timelog.handlers import (
+    handle_timelog_add,
+    handle_timelog_batch_delete,
+    handle_timelog_delete,
+    handle_timelog_list,
+    handle_timelog_show,
+    handle_timelog_update,
+)
+
+
+def _datetime_value(value: str) -> datetime:
+    """Parse an ISO-8601 datetime value."""
+    return datetime.fromisoformat(value)
+
+
+def build_timelog_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    """Build the timelog command tree."""
+    timelog_parser = add_documented_parser(
+        subparsers,
+        "timelog",
+        help_content=HelpContent(
+            summary="Manage actual time records",
+            description=(
+                "Create and maintain actual time records.\n\n"
+                "Timelogs represent what really happened and how time was spent."
+            ),
+            examples=(
+                'lifeos timelog add "Deep work" --start-time 2026-04-10T13:00:00-04:00 '
+                "--end-time 2026-04-10T14:30:00-04:00",
+                "lifeos timelog list --window-start 2026-04-10T00:00:00-04:00 "
+                "--window-end 2026-04-10T23:59:59-04:00",
+                "lifeos timelog batch delete --ids <timelog-id-1> <timelog-id-2>",
+            ),
+            notes=(
+                "Use `list` as the primary query entrypoint for timelogs.",
+                "Timelogs can optionally reference one area and one task.",
+                "Delete operations in the public CLI always perform soft deletion.",
+            ),
+        ),
+    )
+    timelog_parser.set_defaults(handler=make_help_handler(timelog_parser))
+    timelog_subparsers = timelog_parser.add_subparsers(
+        dest="timelog_command", title="actions", metavar="action"
+    )
+
+    add_parser = add_documented_parser(
+        timelog_subparsers,
+        "add",
+        help_content=HelpContent(
+            summary="Create a timelog",
+            description="Create one actual time record.",
+            examples=(
+                'lifeos timelog add "Deep work" --start-time 2026-04-10T13:00:00-04:00 '
+                "--end-time 2026-04-10T14:30:00-04:00",
+                'lifeos timelog add "Run" --start-time 2026-04-10T07:00:00-04:00 '
+                "--end-time 2026-04-10T07:30:00-04:00 --area-id <area-id> --energy-level 4",
+            ),
+            notes=(
+                "Use repeated `--tag-id` and `--person-id` flags to attach tags and people.",
+                "Timelog end time is required because the record models completed time spent.",
+            ),
+        ),
+    )
+    add_parser.add_argument("title", help="Timelog title")
+    add_parser.add_argument("--start-time", required=True, type=_datetime_value, help="Start time")
+    add_parser.add_argument("--end-time", required=True, type=_datetime_value, help="End time")
+    add_parser.add_argument("--tracking-method", default="manual", help="Tracking method")
+    add_parser.add_argument("--location", help="Optional location")
+    add_parser.add_argument("--energy-level", type=int, help="Optional energy level from 1 to 5")
+    add_parser.add_argument("--notes", help="Optional notes")
+    add_parser.add_argument("--area-id", type=UUID, help="Optional linked area identifier")
+    add_parser.add_argument("--task-id", type=UUID, help="Optional linked task identifier")
+    add_parser.add_argument(
+        "--tag-id",
+        dest="tag_ids",
+        type=UUID,
+        action="append",
+        default=None,
+        help="Repeat to attach one or more timelog tags",
+    )
+    add_parser.add_argument(
+        "--person-id",
+        dest="person_ids",
+        type=UUID,
+        action="append",
+        default=None,
+        help="Repeat to attach one or more people",
+    )
+    add_parser.set_defaults(handler=handle_timelog_add)
+
+    list_parser = add_documented_parser(
+        timelog_subparsers,
+        "list",
+        help_content=HelpContent(
+            summary="List timelogs",
+            description=(
+                "List timelogs with optional time-window, relation, and method filters.\n\n"
+                "Use this command as the main query entrypoint for actual time data."
+            ),
+            examples=(
+                "lifeos timelog list",
+                "lifeos timelog list --tracking-method manual "
+                "--window-start 2026-04-10T00:00:00-04:00 "
+                "--window-end 2026-04-10T23:59:59-04:00",
+                "lifeos timelog list --task-id <task-id> --person-id <person-id>",
+            ),
+            notes=(
+                "Use `--title-contains` for lightweight text filtering instead of a separate search command.",
+            ),
+        ),
+    )
+    list_parser.add_argument("--title-contains", help="Filter by title substring")
+    list_parser.add_argument("--tracking-method", help="Filter by tracking method")
+    list_parser.add_argument("--area-id", type=UUID, help="Filter by linked area")
+    list_parser.add_argument("--task-id", type=UUID, help="Filter by linked task")
+    list_parser.add_argument("--person-id", type=UUID, help="Filter by linked person")
+    list_parser.add_argument("--tag-id", type=UUID, help="Filter by linked tag")
+    list_parser.add_argument("--window-start", type=_datetime_value, help="Window start time")
+    list_parser.add_argument("--window-end", type=_datetime_value, help="Window end time")
+    add_include_deleted_argument(list_parser, noun="timelogs")
+    add_limit_offset_arguments(list_parser)
+    list_parser.set_defaults(handler=handle_timelog_list)
+
+    show_parser = add_documented_parser(
+        timelog_subparsers,
+        "show",
+        help_content=HelpContent(
+            summary="Show a timelog",
+            description="Show one timelog with full metadata.",
+            examples=(
+                "lifeos timelog show 11111111-1111-1111-1111-111111111111",
+                "lifeos timelog show 11111111-1111-1111-1111-111111111111 --include-deleted",
+            ),
+        ),
+    )
+    show_parser.add_argument("timelog_id", type=UUID, help="Timelog identifier")
+    add_include_deleted_argument(show_parser, noun="timelogs", help_prefix="Allow")
+    show_parser.set_defaults(handler=handle_timelog_show)
+
+    update_parser = add_documented_parser(
+        timelog_subparsers,
+        "update",
+        help_content=HelpContent(
+            summary="Update a timelog",
+            description="Update mutable timelog fields.",
+            examples=(
+                "lifeos timelog update 11111111-1111-1111-1111-111111111111 --energy-level 5",
+                "lifeos timelog update 11111111-1111-1111-1111-111111111111 --clear-task --clear-area",
+                "lifeos timelog update 11111111-1111-1111-1111-111111111111 --clear-people --clear-tags",
+            ),
+            notes=(
+                "Use `--clear-*` flags to explicitly remove optional values.",
+                "Do not mix a value flag with the matching clear flag in the same command.",
+            ),
+        ),
+    )
+    update_parser.add_argument("timelog_id", type=UUID, help="Timelog identifier")
+    update_parser.add_argument("--title", help="Updated timelog title")
+    update_parser.add_argument("--start-time", type=_datetime_value, help="Updated start time")
+    update_parser.add_argument("--end-time", type=_datetime_value, help="Updated end time")
+    update_parser.add_argument("--tracking-method", help="Updated tracking method")
+    update_parser.add_argument("--location", help="Updated location")
+    update_parser.add_argument("--clear-location", action="store_true", help="Clear location")
+    update_parser.add_argument("--energy-level", type=int, help="Updated energy level from 1 to 5")
+    update_parser.add_argument(
+        "--clear-energy-level",
+        action="store_true",
+        help="Clear energy level",
+    )
+    update_parser.add_argument("--notes", help="Updated notes")
+    update_parser.add_argument("--clear-notes", action="store_true", help="Clear notes")
+    update_parser.add_argument("--area-id", type=UUID, help="Updated linked area identifier")
+    update_parser.add_argument("--clear-area", action="store_true", help="Clear linked area")
+    update_parser.add_argument("--task-id", type=UUID, help="Updated linked task identifier")
+    update_parser.add_argument("--clear-task", action="store_true", help="Clear linked task")
+    update_parser.add_argument(
+        "--tag-id",
+        dest="tag_ids",
+        type=UUID,
+        action="append",
+        default=None,
+        help="Repeat to replace tags with one or more identifiers",
+    )
+    update_parser.add_argument("--clear-tags", action="store_true", help="Remove all tags")
+    update_parser.add_argument(
+        "--person-id",
+        dest="person_ids",
+        type=UUID,
+        action="append",
+        default=None,
+        help="Repeat to replace people with one or more identifiers",
+    )
+    update_parser.add_argument("--clear-people", action="store_true", help="Remove all people")
+    update_parser.set_defaults(handler=handle_timelog_update)
+
+    delete_parser = add_documented_parser(
+        timelog_subparsers,
+        "delete",
+        help_content=HelpContent(
+            summary="Delete a timelog",
+            description="Soft-delete one timelog.",
+            examples=("lifeos timelog delete 11111111-1111-1111-1111-111111111111",),
+        ),
+    )
+    delete_parser.add_argument("timelog_id", type=UUID, help="Timelog identifier")
+    delete_parser.set_defaults(handler=handle_timelog_delete)
+
+    batch_parser = add_documented_parser(
+        timelog_subparsers,
+        "batch",
+        help_content=HelpContent(
+            summary="Run batch timelog operations",
+            description="Grouped namespace for multi-record timelog writes.",
+            examples=("lifeos timelog batch delete --ids <timelog-id-1> <timelog-id-2>",),
+        ),
+    )
+    batch_parser.set_defaults(handler=make_help_handler(batch_parser))
+    batch_subparsers = batch_parser.add_subparsers(
+        dest="timelog_batch_command", title="batch actions", metavar="batch-action"
+    )
+    batch_delete_parser = add_documented_parser(
+        batch_subparsers,
+        "delete",
+        help_content=HelpContent(
+            summary="Delete multiple timelogs",
+            description="Soft-delete multiple timelogs by identifier.",
+        ),
+    )
+    add_identifier_list_argument(batch_delete_parser, dest="timelog_ids", noun="timelog")
+    batch_delete_parser.set_defaults(handler=handle_timelog_batch_delete)

--- a/src/lifeos_cli/cli_support/resources/timelog/parser.py
+++ b/src/lifeos_cli/cli_support/resources/timelog/parser.py
@@ -119,7 +119,8 @@ def build_timelog_parser(subparsers: argparse._SubParsersAction[argparse.Argumen
                 "lifeos timelog list --task-id <task-id> --person-id <person-id>",
             ),
             notes=(
-                "Use `--title-contains` for lightweight text filtering instead of a separate search command.",
+                "Use `--title-contains` for lightweight text filtering instead of a "
+                "separate search command.",
             ),
         ),
     )
@@ -159,8 +160,10 @@ def build_timelog_parser(subparsers: argparse._SubParsersAction[argparse.Argumen
             description="Update mutable timelog fields.",
             examples=(
                 "lifeos timelog update 11111111-1111-1111-1111-111111111111 --energy-level 5",
-                "lifeos timelog update 11111111-1111-1111-1111-111111111111 --clear-task --clear-area",
-                "lifeos timelog update 11111111-1111-1111-1111-111111111111 --clear-people --clear-tags",
+                "lifeos timelog update 11111111-1111-1111-1111-111111111111 "
+                "--clear-task --clear-area",
+                "lifeos timelog update 11111111-1111-1111-1111-111111111111 "
+                "--clear-people --clear-tags",
             ),
             notes=(
                 "Use `--clear-*` flags to explicitly remove optional values.",

--- a/src/lifeos_cli/cli_support/resources/vision/handlers.py
+++ b/src/lifeos_cli/cli_support/resources/vision/handlers.py
@@ -18,6 +18,11 @@ def _format_vision_summary(vision: Vision) -> str:
 
 
 def _format_vision_detail(vision: Vision) -> str:
+    people_names = (
+        ", ".join(person.name for person in vision.people)
+        if getattr(vision, "people", None)
+        else "-"
+    )
     return "\n".join(
         (
             f"id: {vision.id}",
@@ -28,6 +33,7 @@ def _format_vision_detail(vision: Vision) -> str:
             f"experience_points: {vision.experience_points}",
             f"experience_rate_per_hour: {vision.experience_rate_per_hour or '-'}",
             f"area_id: {vision.area_id or '-'}",
+            f"people: {people_names}",
             f"created_at: {format_timestamp(vision.created_at)}",
             f"updated_at: {format_timestamp(vision.updated_at)}",
             f"deleted_at: {format_timestamp(vision.deleted_at)}",
@@ -44,6 +50,7 @@ async def handle_vision_add_async(args: argparse.Namespace) -> int:
                 description=args.description,
                 status=args.status,
                 area_id=args.area_id,
+                person_ids=args.person_ids,
                 experience_rate_per_hour=args.experience_rate_per_hour,
             )
         except (
@@ -68,6 +75,7 @@ async def handle_vision_list_async(args: argparse.Namespace) -> int:
                 session,
                 status=args.status,
                 area_id=args.area_id,
+                person_id=args.person_id,
                 include_deleted=args.include_deleted,
                 limit=args.limit,
                 offset=args.offset,
@@ -118,6 +126,7 @@ async def handle_vision_update_async(args: argparse.Namespace) -> int:
             "--experience-rate-per-hour",
             "--clear-experience-rate",
         ),
+        (args.clear_people and args.person_ids is not None, "--person-id", "--clear-people"),
     )
     for is_conflict, value_flag, clear_flag in conflicting_flags:
         if is_conflict:
@@ -134,6 +143,8 @@ async def handle_vision_update_async(args: argparse.Namespace) -> int:
                 status=args.status,
                 area_id=args.area_id,
                 clear_area=args.clear_area,
+                person_ids=args.person_ids,
+                clear_people=args.clear_people,
                 experience_rate_per_hour=args.experience_rate_per_hour,
                 clear_experience_rate=args.clear_experience_rate,
             )

--- a/src/lifeos_cli/cli_support/resources/vision/parser.py
+++ b/src/lifeos_cli/cli_support/resources/vision/parser.py
@@ -66,6 +66,8 @@ def build_vision_parser(subparsers: argparse._SubParsersAction[argparse.Argument
                 'lifeos vision add "Launch lifeos-cli" '
                 "--area-id 11111111-1111-1111-1111-111111111111",
                 'lifeos vision add "Improve sleep quality" --status active',
+                'lifeos vision add "Strengthen family rhythm" '
+                "--person-id 11111111-1111-1111-1111-111111111111",
             ),
         ),
     )
@@ -73,6 +75,14 @@ def build_vision_parser(subparsers: argparse._SubParsersAction[argparse.Argument
     add_parser.add_argument("--description", help="Optional vision description")
     add_parser.add_argument("--status", default="active", help="Vision status")
     add_parser.add_argument("--area-id", type=UUID, help="Owning area identifier")
+    add_parser.add_argument(
+        "--person-id",
+        dest="person_ids",
+        type=UUID,
+        action="append",
+        default=None,
+        help="Repeat to associate one or more people",
+    )
     add_parser.add_argument(
         "--experience-rate-per-hour",
         type=int,
@@ -92,12 +102,14 @@ def build_vision_parser(subparsers: argparse._SubParsersAction[argparse.Argument
             examples=(
                 "lifeos vision list",
                 "lifeos vision list --status active",
+                "lifeos vision list --person-id 11111111-1111-1111-1111-111111111111",
                 "lifeos vision list --area-id 11111111-1111-1111-1111-111111111111 --limit 20",
             ),
         ),
     )
     list_parser.add_argument("--status", help="Filter by status")
     list_parser.add_argument("--area-id", type=UUID, help="Filter by area identifier")
+    list_parser.add_argument("--person-id", type=UUID, help="Filter by linked person identifier")
     add_include_deleted_argument(list_parser, noun="visions")
     add_limit_offset_arguments(list_parser)
     list_parser.set_defaults(handler=handle_vision_list)
@@ -131,11 +143,13 @@ def build_vision_parser(subparsers: argparse._SubParsersAction[argparse.Argument
                 "lifeos vision update 11111111-1111-1111-1111-111111111111 "
                 '--name "Ship lifeos-cli"',
                 "lifeos vision update 11111111-1111-1111-1111-111111111111 --status archived",
+                "lifeos vision update 11111111-1111-1111-1111-111111111111 "
+                "--person-id 11111111-1111-1111-1111-111111111111",
                 "lifeos vision update 11111111-1111-1111-1111-111111111111 --clear-area",
             ),
             notes=(
                 "Valid statuses currently include `active`, `archived`, and `fruit`.",
-                "Use `--clear-*` flags to remove optional values.",
+                "Use `--clear-*` flags to remove optional values, including people.",
             ),
         ),
     )
@@ -154,6 +168,15 @@ def build_vision_parser(subparsers: argparse._SubParsersAction[argparse.Argument
         action="store_true",
         help="Clear the optional area reference",
     )
+    update_parser.add_argument(
+        "--person-id",
+        dest="person_ids",
+        type=UUID,
+        action="append",
+        default=None,
+        help="Repeat to replace people with one or more identifiers",
+    )
+    update_parser.add_argument("--clear-people", action="store_true", help="Remove all people")
     update_parser.add_argument(
         "--experience-rate-per-hour", type=int, help="Updated experience rate"
     )

--- a/src/lifeos_cli/db/maintenance.py
+++ b/src/lifeos_cli/db/maintenance.py
@@ -9,11 +9,24 @@ from uuid import UUID
 
 from alembic import command
 from alembic.config import Config
-from sqlalchemy import select, text
+from sqlalchemy import delete, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from lifeos_cli.config import get_database_settings
-from lifeos_cli.db.models import Area, Habit, HabitAction, Note, Person, Tag, Task, Vision
+from lifeos_cli.db.models import (
+    Area,
+    Event,
+    Habit,
+    HabitAction,
+    Note,
+    Person,
+    Tag,
+    Task,
+    Timelog,
+    Vision,
+)
+from lifeos_cli.db.models.person_association import person_associations
+from lifeos_cli.db.models.tag_association import tag_associations
 from lifeos_cli.db.session import get_async_engine
 
 ROOT_DIR = Path(__file__).resolve().parents[3]
@@ -31,12 +44,25 @@ class PurgeDecision:
 RESOURCE_MODELS: dict[str, Any] = {
     "note": Note,
     "area": Area,
+    "event": Event,
     "habit": Habit,
     "habit-action": HabitAction,
     "tag": Tag,
     "people": Person,
     "vision": Vision,
     "task": Task,
+    "timelog": Timelog,
+}
+
+RESOURCE_TAG_ENTITY_TYPES: dict[str, str] = {
+    "people": "person",
+    "event": "event",
+    "timelog": "timelog",
+}
+
+RESOURCE_PERSON_ENTITY_TYPES: dict[str, str] = {
+    "event": "event",
+    "timelog": "timelog",
 }
 
 
@@ -70,6 +96,22 @@ async def purge_soft_deleted_record(
         return PurgeDecision(status="missing", resource=resource, record_id=record_id)
     if record.deleted_at is None:
         return PurgeDecision(status="active", resource=resource, record_id=record_id)
+    tag_entity_type = RESOURCE_TAG_ENTITY_TYPES.get(resource)
+    if tag_entity_type is not None:
+        await session.execute(
+            delete(tag_associations).where(
+                tag_associations.c.entity_type == tag_entity_type,
+                tag_associations.c.entity_id == record_id,
+            )
+        )
+    person_entity_type = RESOURCE_PERSON_ENTITY_TYPES.get(resource)
+    if person_entity_type is not None:
+        await session.execute(
+            delete(person_associations).where(
+                person_associations.c.entity_type == person_entity_type,
+                person_associations.c.entity_id == record_id,
+            )
+        )
     await session.delete(record)
     await session.flush()
     return PurgeDecision(status="purged", resource=resource, record_id=record_id)

--- a/src/lifeos_cli/db/maintenance.py
+++ b/src/lifeos_cli/db/maintenance.py
@@ -13,7 +13,7 @@ from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from lifeos_cli.config import get_database_settings
-from lifeos_cli.db.models import Area, Note, Person, Tag, Task, Vision
+from lifeos_cli.db.models import Area, Habit, HabitAction, Note, Person, Tag, Task, Vision
 from lifeos_cli.db.session import get_async_engine
 
 ROOT_DIR = Path(__file__).resolve().parents[3]
@@ -31,6 +31,8 @@ class PurgeDecision:
 RESOURCE_MODELS: dict[str, Any] = {
     "note": Note,
     "area": Area,
+    "habit": Habit,
+    "habit-action": HabitAction,
     "tag": Tag,
     "people": Person,
     "vision": Vision,

--- a/src/lifeos_cli/db/maintenance.py
+++ b/src/lifeos_cli/db/maintenance.py
@@ -61,8 +61,12 @@ RESOURCE_TAG_ENTITY_TYPES: dict[str, str] = {
 }
 
 RESOURCE_PERSON_ENTITY_TYPES: dict[str, str] = {
+    "area": "area",
     "event": "event",
+    "tag": "tag",
     "timelog": "timelog",
+    "vision": "vision",
+    "task": "task",
 }
 
 

--- a/src/lifeos_cli/db/models/__init__.py
+++ b/src/lifeos_cli/db/models/__init__.py
@@ -1,12 +1,25 @@
 """ORM models for lifeos_cli."""
 
 from .area import Area
+from .event import Event
 from .habit import Habit
 from .habit_action import HabitAction
 from .note import Note
 from .person import Person
 from .tag import Tag
 from .task import Task
+from .timelog import Timelog
 from .vision import Vision
 
-__all__ = ["Area", "Habit", "HabitAction", "Note", "Person", "Tag", "Task", "Vision"]
+__all__ = [
+    "Area",
+    "Event",
+    "Habit",
+    "HabitAction",
+    "Note",
+    "Person",
+    "Tag",
+    "Task",
+    "Timelog",
+    "Vision",
+]

--- a/src/lifeos_cli/db/models/__init__.py
+++ b/src/lifeos_cli/db/models/__init__.py
@@ -1,10 +1,12 @@
 """ORM models for lifeos_cli."""
 
 from .area import Area
+from .habit import Habit
+from .habit_action import HabitAction
 from .note import Note
 from .person import Person
 from .tag import Tag
 from .task import Task
 from .vision import Vision
 
-__all__ = ["Area", "Note", "Person", "Tag", "Task", "Vision"]
+__all__ = ["Area", "Habit", "HabitAction", "Note", "Person", "Tag", "Task", "Vision"]

--- a/src/lifeos_cli/db/models/area.py
+++ b/src/lifeos_cli/db/models/area.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from sqlalchemy import Index, String, Text, text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from lifeos_cli.db.base import Base, SoftDeleteMixin, TimestampedMixin, UUIDPrimaryKeyMixin
+
+if TYPE_CHECKING:
+    from lifeos_cli.db.models.person import Person
 
 
 class Area(UUIDPrimaryKeyMixin, TimestampedMixin, SoftDeleteMixin, Base):
@@ -30,6 +35,9 @@ class Area(UUIDPrimaryKeyMixin, TimestampedMixin, SoftDeleteMixin, Base):
     display_order: Mapped[int] = mapped_column(nullable=False, default=0)
 
     visions = relationship("Vision", back_populates="area")
+
+    if TYPE_CHECKING:
+        people: list[Person]
 
     def __repr__(self) -> str:
         return f"Area(id={self.id!s}, name={self.name!r}, active={self.is_active!r})"

--- a/src/lifeos_cli/db/models/event.py
+++ b/src/lifeos_cli/db/models/event.py
@@ -28,7 +28,9 @@ class Event(UUIDPrimaryKeyMixin, TimestampedMixin, SoftDeleteMixin, Base):
 
     title: Mapped[str] = mapped_column(String(200), nullable=False, index=True)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
-    start_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, index=True)
+    start_time: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, index=True
+    )
     end_time: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True, index=True
     )

--- a/src/lifeos_cli/db/models/event.py
+++ b/src/lifeos_cli/db/models/event.py
@@ -1,0 +1,57 @@
+"""Event model for planned schedule blocks."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, Index, Integer, String, Text, Uuid
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from lifeos_cli.db.base import Base, SoftDeleteMixin, TimestampedMixin, UUIDPrimaryKeyMixin
+
+if TYPE_CHECKING:
+    from lifeos_cli.db.models.person import Person
+    from lifeos_cli.db.models.tag import Tag
+
+
+class Event(UUIDPrimaryKeyMixin, TimestampedMixin, SoftDeleteMixin, Base):
+    """Planned calendar event that may optionally point to a task and area."""
+
+    __tablename__ = "events"
+    __table_args__ = (
+        Index("ix_events_status_start_time", "status", "start_time"),
+        Index("ix_events_area_id", "area_id"),
+        Index("ix_events_task_id", "task_id"),
+    )
+
+    title: Mapped[str] = mapped_column(String(200), nullable=False, index=True)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    start_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, index=True)
+    end_time: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True, index=True
+    )
+    priority: Mapped[int] = mapped_column(Integer, nullable=False, default=0, index=True)
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default="planned", index=True)
+    is_all_day: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    area_id: Mapped[UUID | None] = mapped_column(
+        Uuid,
+        ForeignKey("areas.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    task_id: Mapped[UUID | None] = mapped_column(
+        Uuid,
+        ForeignKey("tasks.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+
+    area = relationship("Area", foreign_keys=[area_id])
+    task = relationship("Task", foreign_keys=[task_id])
+
+    if TYPE_CHECKING:
+        tags: list[Tag]
+        people: list[Person]
+
+    def __repr__(self) -> str:
+        return f"Event(id={self.id!s}, title={self.title!r}, status={self.status!r})"

--- a/src/lifeos_cli/db/models/habit.py
+++ b/src/lifeos_cli/db/models/habit.py
@@ -1,0 +1,68 @@
+"""Habit model for recurring practices that generate dated actions."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from uuid import UUID
+
+from sqlalchemy import Date, ForeignKey, Index, Integer, String, Text, Uuid
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from lifeos_cli.db.base import Base, SoftDeleteMixin, TimestampedMixin, UUIDPrimaryKeyMixin
+
+
+class Habit(UUIDPrimaryKeyMixin, TimestampedMixin, SoftDeleteMixin, Base):
+    """Recurring habit template that can generate dated action rows."""
+
+    __tablename__ = "habits"
+    __table_args__ = (
+        Index("ix_habits_title", "title"),
+        Index("ix_habits_start_date", "start_date"),
+        Index("ix_habits_status", "status"),
+        Index("ix_habits_task_id", "task_id"),
+    )
+
+    title: Mapped[str] = mapped_column(String(200), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    start_date: Mapped[date] = mapped_column(Date, nullable=False)
+    duration_days: Mapped[int] = mapped_column(Integer, nullable=False)
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default="active")
+    task_id: Mapped[UUID | None] = mapped_column(
+        Uuid,
+        ForeignKey("tasks.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+
+    task = relationship("Task", foreign_keys=[task_id])
+    actions = relationship(
+        "HabitAction",
+        back_populates="habit",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
+
+    @property
+    def end_date(self) -> date:
+        """Return the computed final date covered by the habit."""
+        return self.start_date + timedelta(days=self.duration_days - 1)
+
+    @property
+    def is_completed(self) -> bool:
+        """Return whether the habit duration has fully elapsed."""
+        return date.today() > self.end_date
+
+    @property
+    def progress_percentage(self) -> float:
+        """Return progress based on the current date and duration."""
+        if self.is_completed:
+            return 100.0
+        days_elapsed = (date.today() - self.start_date).days + 1
+        if days_elapsed <= 0:
+            return 0.0
+        return min(100.0, (days_elapsed / self.duration_days) * 100.0)
+
+    def __repr__(self) -> str:
+        return (
+            f"Habit(id={self.id!s}, title={self.title!r}, "
+            f"status={self.status!r}, duration_days={self.duration_days})"
+        )

--- a/src/lifeos_cli/db/models/habit_action.py
+++ b/src/lifeos_cli/db/models/habit_action.py
@@ -1,0 +1,66 @@
+"""Habit action model for dated habit execution records."""
+
+from __future__ import annotations
+
+from datetime import date
+from uuid import UUID
+
+from sqlalchemy import Date, ForeignKey, Index, String, Text, Uuid, text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from lifeos_cli.db.base import Base, SoftDeleteMixin, TimestampedMixin, UUIDPrimaryKeyMixin
+from lifeos_cli.db.services.habit_support import get_default_habit_action_status
+
+
+class HabitAction(UUIDPrimaryKeyMixin, TimestampedMixin, SoftDeleteMixin, Base):
+    """One dated execution record for a habit."""
+
+    __tablename__ = "habit_actions"
+    __table_args__ = (
+        Index("ix_habit_actions_habit_id", "habit_id"),
+        Index("ix_habit_actions_action_date", "action_date"),
+        Index("ix_habit_actions_status", "status"),
+        Index(
+            "uq_habit_actions_habit_id_action_date_active",
+            "habit_id",
+            "action_date",
+            unique=True,
+            postgresql_where=text("deleted_at IS NULL"),
+        ),
+    )
+
+    habit_id: Mapped[UUID] = mapped_column(
+        Uuid,
+        ForeignKey("habits.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    action_date: Mapped[date] = mapped_column(Date, nullable=False)
+    status: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+        default=get_default_habit_action_status,
+    )
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    habit = relationship("Habit", back_populates="actions")
+
+    @property
+    def is_today(self) -> bool:
+        """Return whether the action is for today."""
+        return self.action_date == date.today()
+
+    @property
+    def is_past(self) -> bool:
+        """Return whether the action is for a past day."""
+        return self.action_date < date.today()
+
+    @property
+    def is_future(self) -> bool:
+        """Return whether the action is for a future day."""
+        return self.action_date > date.today()
+
+    def __repr__(self) -> str:
+        return (
+            f"HabitAction(id={self.id!s}, habit_id={self.habit_id!s}, "
+            f"action_date={self.action_date!s}, status={self.status!r})"
+        )

--- a/src/lifeos_cli/db/models/person_association.py
+++ b/src/lifeos_cli/db/models/person_association.py
@@ -1,0 +1,29 @@
+"""Generic person association table."""
+
+from __future__ import annotations
+
+from sqlalchemy import Column, ForeignKey, Index, String, Table, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID
+
+from lifeos_cli.db.base import Base
+
+person_associations = Table(
+    "person_associations",
+    Base.metadata,
+    Column("entity_type", String(50), nullable=False),
+    Column("entity_id", UUID(as_uuid=True), nullable=False),
+    Column(
+        "person_id",
+        UUID(as_uuid=True),
+        ForeignKey("people.id", ondelete="CASCADE"),
+        nullable=False,
+    ),
+    UniqueConstraint(
+        "entity_type",
+        "entity_id",
+        "person_id",
+        name="uq_person_associations_entity_person",
+    ),
+    Index("ix_person_associations_entity", "entity_type", "entity_id"),
+    Index("ix_person_associations_person_id", "person_id"),
+)

--- a/src/lifeos_cli/db/models/tag.py
+++ b/src/lifeos_cli/db/models/tag.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from sqlalchemy import Index, String, Text, text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from lifeos_cli.db.base import Base, SoftDeleteMixin, TimestampedMixin, UUIDPrimaryKeyMixin
+
+if TYPE_CHECKING:
+    from lifeos_cli.db.models.person import Person
 
 
 class Tag(UUIDPrimaryKeyMixin, TimestampedMixin, SoftDeleteMixin, Base):
@@ -29,6 +34,9 @@ class Tag(UUIDPrimaryKeyMixin, TimestampedMixin, SoftDeleteMixin, Base):
     category: Mapped[str] = mapped_column(String(50), nullable=False, default="general")
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     color: Mapped[str | None] = mapped_column(String(7), nullable=True)
+
+    if TYPE_CHECKING:
+        people: list[Person]
 
     def __repr__(self) -> str:
         return (

--- a/src/lifeos_cli/db/models/task.py
+++ b/src/lifeos_cli/db/models/task.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 from datetime import date
+from typing import TYPE_CHECKING
 from uuid import UUID
 
 from sqlalchemy import Date, ForeignKey, Index, Integer, String, Text, Uuid
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from lifeos_cli.db.base import Base, SoftDeleteMixin, TimestampedMixin, UUIDPrimaryKeyMixin
+
+if TYPE_CHECKING:
+    from lifeos_cli.db.models.person import Person
 
 
 class Task(UUIDPrimaryKeyMixin, TimestampedMixin, SoftDeleteMixin, Base):
@@ -46,6 +50,9 @@ class Task(UUIDPrimaryKeyMixin, TimestampedMixin, SoftDeleteMixin, Base):
     vision = relationship("Vision", back_populates="tasks")
     parent_task = relationship("Task", remote_side="Task.id", back_populates="subtasks")
     subtasks = relationship("Task", back_populates="parent_task", cascade="all, delete-orphan")
+
+    if TYPE_CHECKING:
+        people: list[Person]
 
     def __repr__(self) -> str:
         return f"Task(id={self.id!s}, content={self.content!r}, status={self.status!r})"

--- a/src/lifeos_cli/db/models/timelog.py
+++ b/src/lifeos_cli/db/models/timelog.py
@@ -1,0 +1,55 @@
+"""Timelog model for actual time records."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import DateTime, ForeignKey, Index, Integer, String, Text, Uuid
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from lifeos_cli.db.base import Base, SoftDeleteMixin, TimestampedMixin, UUIDPrimaryKeyMixin
+
+if TYPE_CHECKING:
+    from lifeos_cli.db.models.person import Person
+    from lifeos_cli.db.models.tag import Tag
+
+
+class Timelog(UUIDPrimaryKeyMixin, TimestampedMixin, SoftDeleteMixin, Base):
+    """Actual time record describing what happened and when."""
+
+    __tablename__ = "timelogs"
+    __table_args__ = (
+        Index("ix_timelogs_task_id", "task_id"),
+        Index("ix_timelogs_area_id", "area_id"),
+        Index("ix_timelogs_tracking_method", "tracking_method"),
+    )
+
+    title: Mapped[str] = mapped_column(String(200), nullable=False, index=True)
+    start_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, index=True)
+    end_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, index=True)
+    tracking_method: Mapped[str] = mapped_column(String(20), nullable=False, default="manual")
+    location: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    energy_level: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    area_id: Mapped[UUID | None] = mapped_column(
+        Uuid,
+        ForeignKey("areas.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    task_id: Mapped[UUID | None] = mapped_column(
+        Uuid,
+        ForeignKey("tasks.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+
+    area = relationship("Area", foreign_keys=[area_id])
+    task = relationship("Task", foreign_keys=[task_id])
+
+    if TYPE_CHECKING:
+        tags: list[Tag]
+        people: list[Person]
+
+    def __repr__(self) -> str:
+        return f"Timelog(id={self.id!s}, title={self.title!r}, tracking_method={self.tracking_method!r})"

--- a/src/lifeos_cli/db/models/timelog.py
+++ b/src/lifeos_cli/db/models/timelog.py
@@ -27,7 +27,9 @@ class Timelog(UUIDPrimaryKeyMixin, TimestampedMixin, SoftDeleteMixin, Base):
     )
 
     title: Mapped[str] = mapped_column(String(200), nullable=False, index=True)
-    start_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, index=True)
+    start_time: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, index=True
+    )
     end_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, index=True)
     tracking_method: Mapped[str] = mapped_column(String(20), nullable=False, default="manual")
     location: Mapped[str | None] = mapped_column(String(200), nullable=True)
@@ -52,4 +54,7 @@ class Timelog(UUIDPrimaryKeyMixin, TimestampedMixin, SoftDeleteMixin, Base):
         people: list[Person]
 
     def __repr__(self) -> str:
-        return f"Timelog(id={self.id!s}, title={self.title!r}, tracking_method={self.tracking_method!r})"
+        return (
+            f"Timelog(id={self.id!s}, title={self.title!r}, "
+            f"tracking_method={self.tracking_method!r})"
+        )

--- a/src/lifeos_cli/db/models/vision.py
+++ b/src/lifeos_cli/db/models/vision.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from uuid import UUID
 
 from sqlalchemy import ForeignKey, Integer, String, Text, Uuid
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from lifeos_cli.db.base import Base, SoftDeleteMixin, TimestampedMixin, UUIDPrimaryKeyMixin
+
+if TYPE_CHECKING:
+    from lifeos_cli.db.models.person import Person
 
 
 class Vision(UUIDPrimaryKeyMixin, TimestampedMixin, SoftDeleteMixin, Base):
@@ -30,6 +34,9 @@ class Vision(UUIDPrimaryKeyMixin, TimestampedMixin, SoftDeleteMixin, Base):
 
     area = relationship("Area", back_populates="visions")
     tasks = relationship("Task", back_populates="vision", cascade="all, delete-orphan")
+
+    if TYPE_CHECKING:
+        people: list[Person]
 
     def __repr__(self) -> str:
         return f"Vision(id={self.id!s}, name={self.name!r}, status={self.status!r})"

--- a/src/lifeos_cli/db/services/areas.py
+++ b/src/lifeos_cli/db/services/areas.py
@@ -8,7 +8,9 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from lifeos_cli.db.models.area import Area
+from lifeos_cli.db.models.person_association import person_associations
 from lifeos_cli.db.services.batching import BatchDeleteResult
+from lifeos_cli.db.services.entity_people import load_people_for_entities, sync_entity_people
 
 
 class AreaNotFoundError(LookupError):
@@ -33,6 +35,7 @@ async def create_area(
     icon: str | None = None,
     is_active: bool = True,
     display_order: int = 0,
+    person_ids: list[UUID] | None = None,
 ) -> Area:
     """Create a new area."""
     normalized_name = name.strip()
@@ -51,7 +54,13 @@ async def create_area(
     )
     session.add(area)
     await session.flush()
+    if person_ids is not None:
+        await sync_entity_people(
+            session, entity_id=area.id, entity_type="area", desired_person_ids=person_ids
+        )
     await session.refresh(area)
+    people_map = await load_people_for_entities(session, entity_ids=[area.id], entity_type="area")
+    area.people = people_map.get(area.id, [])
     return area
 
 
@@ -65,12 +74,18 @@ async def get_area(
     stmt = select(Area).where(Area.id == area_id).limit(1)
     if not include_deleted:
         stmt = stmt.where(Area.deleted_at.is_(None))
-    return (await session.execute(stmt)).scalar_one_or_none()
+    area = (await session.execute(stmt)).scalar_one_or_none()
+    if area is None:
+        return None
+    people_map = await load_people_for_entities(session, entity_ids=[area.id], entity_type="area")
+    area.people = people_map.get(area.id, [])
+    return area
 
 
 async def list_areas(
     session: AsyncSession,
     *,
+    person_id: UUID | None = None,
     include_deleted: bool = False,
     include_inactive: bool = False,
     limit: int = 100,
@@ -82,8 +97,22 @@ async def list_areas(
         stmt = stmt.where(Area.deleted_at.is_(None))
     if not include_inactive:
         stmt = stmt.where(Area.is_active.is_(True))
+    if person_id is not None:
+        stmt = stmt.join(
+            person_associations,
+            (person_associations.c.entity_id == Area.id)
+            & (person_associations.c.entity_type == "area"),
+        ).where(person_associations.c.person_id == person_id)
     stmt = stmt.order_by(Area.display_order.asc(), Area.name.asc()).offset(offset).limit(limit)
-    return list((await session.execute(stmt)).scalars())
+    areas = list((await session.execute(stmt)).scalars())
+    people_map = await load_people_for_entities(
+        session,
+        entity_ids=[area.id for area in areas],
+        entity_type="area",
+    )
+    for area in areas:
+        area.people = people_map.get(area.id, [])
+    return areas
 
 
 async def update_area(
@@ -96,6 +125,8 @@ async def update_area(
     color: str | None = None,
     icon: str | None = None,
     clear_icon: bool = False,
+    person_ids: list[UUID] | None = None,
+    clear_people: bool = False,
     is_active: bool | None = None,
     display_order: int | None = None,
 ) -> Area:
@@ -125,12 +156,22 @@ async def update_area(
         area.icon = None
     elif icon is not None:
         area.icon = icon
+    if clear_people:
+        await sync_entity_people(
+            session, entity_id=area.id, entity_type="area", desired_person_ids=[]
+        )
+    elif person_ids is not None:
+        await sync_entity_people(
+            session, entity_id=area.id, entity_type="area", desired_person_ids=person_ids
+        )
     if is_active is not None:
         area.is_active = is_active
     if display_order is not None:
         area.display_order = display_order
     await session.flush()
     await session.refresh(area)
+    people_map = await load_people_for_entities(session, entity_ids=[area.id], entity_type="area")
+    area.people = people_map.get(area.id, [])
     return area
 
 

--- a/src/lifeos_cli/db/services/entity_people.py
+++ b/src/lifeos_cli/db/services/entity_people.py
@@ -28,7 +28,9 @@ async def sync_entity_people(
     existing_rows = await session.execute(existing_stmt)
     existing_person_ids = set(existing_rows.scalars().all())
 
-    missing = [str(person_id) for person_id in unique_person_ids if person_id not in existing_person_ids]
+    missing = [
+        str(person_id) for person_id in unique_person_ids if person_id not in existing_person_ids
+    ]
     if missing:
         raise LookupError(f"Unknown person IDs for entity type {entity_type}: {', '.join(missing)}")
 

--- a/src/lifeos_cli/db/services/entity_people.py
+++ b/src/lifeos_cli/db/services/entity_people.py
@@ -1,0 +1,75 @@
+"""Helpers for generic entity-to-person links."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from uuid import UUID
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from lifeos_cli.db.models.person import Person
+from lifeos_cli.db.models.person_association import person_associations
+
+
+async def sync_entity_people(
+    session: AsyncSession,
+    *,
+    entity_id: UUID,
+    entity_type: str,
+    desired_person_ids: list[UUID],
+) -> None:
+    """Replace an entity's linked people with the provided identifiers."""
+    unique_person_ids = list(dict.fromkeys(desired_person_ids))
+    existing_stmt = select(Person.id).where(
+        Person.id.in_(unique_person_ids),
+        Person.deleted_at.is_(None),
+    )
+    existing_rows = await session.execute(existing_stmt)
+    existing_person_ids = set(existing_rows.scalars().all())
+
+    missing = [str(person_id) for person_id in unique_person_ids if person_id not in existing_person_ids]
+    if missing:
+        raise LookupError(f"Unknown person IDs for entity type {entity_type}: {', '.join(missing)}")
+
+    await session.execute(
+        delete(person_associations).where(
+            person_associations.c.entity_id == entity_id,
+            person_associations.c.entity_type == entity_type,
+        )
+    )
+    for person_id in unique_person_ids:
+        await session.execute(
+            person_associations.insert().values(
+                entity_id=entity_id,
+                entity_type=entity_type,
+                person_id=person_id,
+            )
+        )
+
+
+async def load_people_for_entities(
+    session: AsyncSession,
+    *,
+    entity_ids: list[UUID],
+    entity_type: str,
+) -> dict[UUID, list[Person]]:
+    """Return people grouped by entity identifier."""
+    if not entity_ids:
+        return {}
+
+    stmt = (
+        select(person_associations.c.entity_id, Person)
+        .join(Person, Person.id == person_associations.c.person_id)
+        .where(
+            person_associations.c.entity_type == entity_type,
+            person_associations.c.entity_id.in_(entity_ids),
+            Person.deleted_at.is_(None),
+        )
+        .order_by(Person.name.asc(), Person.id.asc())
+    )
+    rows = await session.execute(stmt)
+    grouped: defaultdict[UUID, list[Person]] = defaultdict(list)
+    for entity_id, person in rows.all():
+        grouped[entity_id].append(person)
+    return dict(grouped)

--- a/src/lifeos_cli/db/services/event_support.py
+++ b/src/lifeos_cli/db/services/event_support.py
@@ -1,0 +1,91 @@
+"""Support utilities and validations for event services."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from lifeos_cli.db.models.area import Area
+from lifeos_cli.db.models.task import Task
+
+VALID_EVENT_STATUSES = {"planned", "cancelled", "completed"}
+
+
+class EventNotFoundError(LookupError):
+    """Raised when an event cannot be found."""
+
+
+class EventAreaReferenceNotFoundError(LookupError):
+    """Raised when a referenced area cannot be found."""
+
+
+class EventTaskReferenceNotFoundError(LookupError):
+    """Raised when a referenced task cannot be found."""
+
+
+class EventValidationError(ValueError):
+    """Raised when event data is invalid."""
+
+
+def validate_event_status(status: str) -> str:
+    """Validate an event status value."""
+    normalized = status.strip().lower()
+    if normalized not in VALID_EVENT_STATUSES:
+        allowed = ", ".join(sorted(VALID_EVENT_STATUSES))
+        raise EventValidationError(
+            f"Invalid event status {normalized!r}. Expected one of: {allowed}"
+        )
+    return normalized
+
+
+def validate_event_title(title: str) -> str:
+    """Validate and normalize an event title."""
+    normalized = title.strip()
+    if not normalized:
+        raise EventValidationError("Event title must not be empty")
+    if len(normalized) > 200:
+        raise EventValidationError("Event title must be 200 characters or fewer")
+    return normalized
+
+
+def validate_event_time_range(
+    *,
+    start_time: datetime,
+    end_time: datetime | None,
+) -> None:
+    """Validate that an event time range is coherent."""
+    if end_time is not None and end_time < start_time:
+        raise EventValidationError("Event end time must be on or after the start time")
+
+
+def validate_event_priority(priority: int) -> int:
+    """Validate event priority."""
+    if priority < 0 or priority > 5:
+        raise EventValidationError("Event priority must be between 0 and 5")
+    return priority
+
+
+async def ensure_event_area_exists(session: AsyncSession, area_id: UUID | None) -> None:
+    """Ensure an optional event area reference exists."""
+    if area_id is None:
+        return
+    stmt = select(Area.id).where(Area.id == area_id, Area.deleted_at.is_(None)).limit(1)
+    if (await session.scalar(stmt)) is None:
+        raise EventAreaReferenceNotFoundError(f"Area {area_id} was not found")
+
+
+async def ensure_event_task_exists(session: AsyncSession, task_id: UUID | None) -> None:
+    """Ensure an optional event task reference exists."""
+    if task_id is None:
+        return
+    stmt = select(Task.id).where(Task.id == task_id, Task.deleted_at.is_(None)).limit(1)
+    if (await session.scalar(stmt)) is None:
+        raise EventTaskReferenceNotFoundError(f"Task {task_id} was not found")
+
+
+def deduplicate_event_ids(event_ids: list[UUID]) -> list[UUID]:
+    """Return event identifiers in original order without duplicates."""
+    return list(dict.fromkeys(event_ids))

--- a/src/lifeos_cli/db/services/events.py
+++ b/src/lifeos_cli/db/services/events.py
@@ -1,0 +1,294 @@
+"""Async CRUD helpers for events."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from lifeos_cli.db.models.event import Event
+from lifeos_cli.db.services.batching import BatchDeleteResult
+from lifeos_cli.db.services.entity_people import load_people_for_entities, sync_entity_people
+from lifeos_cli.db.services.entity_tags import load_tags_for_entities, sync_entity_tags
+from lifeos_cli.db.services.event_support import (
+    EventAreaReferenceNotFoundError,
+    EventNotFoundError,
+    EventTaskReferenceNotFoundError,
+    EventValidationError,
+    deduplicate_event_ids,
+    ensure_event_area_exists,
+    ensure_event_task_exists,
+    validate_event_priority,
+    validate_event_status,
+    validate_event_time_range,
+    validate_event_title,
+)
+from lifeos_cli.db.models.person_association import person_associations
+from lifeos_cli.db.models.tag_association import tag_associations
+
+
+async def _attach_event_links(session: AsyncSession, event: Event) -> Event:
+    tags_map = await load_tags_for_entities(session, entity_ids=[event.id], entity_type="event")
+    people_map = await load_people_for_entities(session, entity_ids=[event.id], entity_type="event")
+    event.tags = tags_map.get(event.id, [])
+    event.people = people_map.get(event.id, [])
+    return event
+
+
+async def _attach_event_links_for_many(session: AsyncSession, events: list[Event]) -> list[Event]:
+    if not events:
+        return []
+    event_ids = [event.id for event in events]
+    tags_map = await load_tags_for_entities(session, entity_ids=event_ids, entity_type="event")
+    people_map = await load_people_for_entities(session, entity_ids=event_ids, entity_type="event")
+    for event in events:
+        event.tags = tags_map.get(event.id, [])
+        event.people = people_map.get(event.id, [])
+    return events
+
+
+async def create_event(
+    session: AsyncSession,
+    *,
+    title: str,
+    start_time: datetime,
+    end_time: datetime | None = None,
+    description: str | None = None,
+    priority: int = 0,
+    status: str = "planned",
+    is_all_day: bool = False,
+    area_id: UUID | None = None,
+    task_id: UUID | None = None,
+    tag_ids: list[UUID] | None = None,
+    person_ids: list[UUID] | None = None,
+) -> Event:
+    """Create a new event."""
+    normalized_title = validate_event_title(title)
+    validate_event_time_range(start_time=start_time, end_time=end_time)
+    normalized_priority = validate_event_priority(priority)
+    normalized_status = validate_event_status(status)
+    await ensure_event_area_exists(session, area_id)
+    await ensure_event_task_exists(session, task_id)
+    event = Event(
+        title=normalized_title,
+        description=description,
+        start_time=start_time,
+        end_time=end_time,
+        priority=normalized_priority,
+        status=normalized_status,
+        is_all_day=is_all_day,
+        area_id=area_id,
+        task_id=task_id,
+    )
+    session.add(event)
+    await session.flush()
+    if tag_ids is not None:
+        await sync_entity_tags(
+            session, entity_id=event.id, entity_type="event", desired_tag_ids=tag_ids
+        )
+    if person_ids is not None:
+        await sync_entity_people(
+            session, entity_id=event.id, entity_type="event", desired_person_ids=person_ids
+        )
+    await session.refresh(event)
+    return await _attach_event_links(session, event)
+
+
+async def get_event(
+    session: AsyncSession,
+    *,
+    event_id: UUID,
+    include_deleted: bool = False,
+) -> Event | None:
+    """Load an event by identifier."""
+    stmt = (
+        select(Event)
+        .options(selectinload(Event.area), selectinload(Event.task))
+        .where(Event.id == event_id)
+        .limit(1)
+    )
+    if not include_deleted:
+        stmt = stmt.where(Event.deleted_at.is_(None))
+    event = (await session.execute(stmt)).scalar_one_or_none()
+    if event is None:
+        return None
+    return await _attach_event_links(session, event)
+
+
+async def list_events(
+    session: AsyncSession,
+    *,
+    title_contains: str | None = None,
+    status: str | None = None,
+    area_id: UUID | None = None,
+    task_id: UUID | None = None,
+    person_id: UUID | None = None,
+    tag_id: UUID | None = None,
+    window_start: datetime | None = None,
+    window_end: datetime | None = None,
+    include_deleted: bool = False,
+    limit: int = 100,
+    offset: int = 0,
+) -> list[Event]:
+    """List events with optional filters."""
+    stmt = select(Event).options(selectinload(Event.area), selectinload(Event.task))
+    if not include_deleted:
+        stmt = stmt.where(Event.deleted_at.is_(None))
+    if title_contains:
+        stmt = stmt.where(Event.title.ilike(f"%{title_contains.strip()}%"))
+    if status is not None:
+        stmt = stmt.where(Event.status == validate_event_status(status))
+    if area_id is not None:
+        stmt = stmt.where(Event.area_id == area_id)
+    if task_id is not None:
+        stmt = stmt.where(Event.task_id == task_id)
+    if person_id is not None:
+        stmt = stmt.join(
+            person_associations,
+            (person_associations.c.entity_id == Event.id)
+            & (person_associations.c.entity_type == "event"),
+        ).where(person_associations.c.person_id == person_id)
+    if tag_id is not None:
+        stmt = stmt.join(
+            tag_associations,
+            (tag_associations.c.entity_id == Event.id)
+            & (tag_associations.c.entity_type == "event"),
+        ).where(tag_associations.c.tag_id == tag_id)
+    if window_start is not None and window_end is not None:
+        stmt = stmt.where(Event.start_time <= window_end).where(
+            or_(Event.end_time.is_(None), Event.end_time >= window_start)
+        )
+    elif window_start is not None:
+        stmt = stmt.where(or_(Event.end_time.is_(None), Event.end_time >= window_start))
+    elif window_end is not None:
+        stmt = stmt.where(Event.start_time <= window_end)
+    stmt = stmt.order_by(Event.start_time.desc(), Event.id.desc()).offset(offset).limit(limit)
+    events = list((await session.execute(stmt)).scalars())
+    return await _attach_event_links_for_many(session, events)
+
+
+async def update_event(
+    session: AsyncSession,
+    *,
+    event_id: UUID,
+    title: str | None = None,
+    description: str | None = None,
+    clear_description: bool = False,
+    start_time: datetime | None = None,
+    end_time: datetime | None = None,
+    clear_end_time: bool = False,
+    priority: int | None = None,
+    status: str | None = None,
+    is_all_day: bool | None = None,
+    area_id: UUID | None = None,
+    clear_area: bool = False,
+    task_id: UUID | None = None,
+    clear_task: bool = False,
+    tag_ids: list[UUID] | None = None,
+    clear_tags: bool = False,
+    person_ids: list[UUID] | None = None,
+    clear_people: bool = False,
+) -> Event:
+    """Update one event."""
+    event = await get_event(session, event_id=event_id, include_deleted=False)
+    if event is None:
+        raise EventNotFoundError(f"Event {event_id} was not found")
+
+    next_start_time = start_time if start_time is not None else event.start_time
+    next_end_time = None if clear_end_time else end_time if end_time is not None else event.end_time
+    validate_event_time_range(start_time=next_start_time, end_time=next_end_time)
+
+    if title is not None:
+        event.title = validate_event_title(title)
+    if clear_description:
+        event.description = None
+    elif description is not None:
+        event.description = description
+    if start_time is not None:
+        event.start_time = start_time
+    if clear_end_time:
+        event.end_time = None
+    elif end_time is not None:
+        event.end_time = end_time
+    if priority is not None:
+        event.priority = validate_event_priority(priority)
+    if status is not None:
+        event.status = validate_event_status(status)
+    if is_all_day is not None:
+        event.is_all_day = is_all_day
+    if clear_area:
+        event.area_id = None
+    elif area_id is not None:
+        await ensure_event_area_exists(session, area_id)
+        event.area_id = area_id
+    if clear_task:
+        event.task_id = None
+    elif task_id is not None:
+        await ensure_event_task_exists(session, task_id)
+        event.task_id = task_id
+    if clear_tags:
+        await sync_entity_tags(session, entity_id=event.id, entity_type="event", desired_tag_ids=[])
+    elif tag_ids is not None:
+        await sync_entity_tags(
+            session, entity_id=event.id, entity_type="event", desired_tag_ids=tag_ids
+        )
+    if clear_people:
+        await sync_entity_people(
+            session, entity_id=event.id, entity_type="event", desired_person_ids=[]
+        )
+    elif person_ids is not None:
+        await sync_entity_people(
+            session, entity_id=event.id, entity_type="event", desired_person_ids=person_ids
+        )
+    await session.flush()
+    await session.refresh(event)
+    return await _attach_event_links(session, event)
+
+
+async def delete_event(session: AsyncSession, *, event_id: UUID) -> None:
+    """Soft-delete one event."""
+    event = await get_event(session, event_id=event_id, include_deleted=False)
+    if event is None:
+        raise EventNotFoundError(f"Event {event_id} was not found")
+    event.soft_delete()
+    await session.flush()
+
+
+async def batch_delete_events(
+    session: AsyncSession,
+    *,
+    event_ids: list[UUID],
+) -> BatchDeleteResult:
+    """Soft-delete multiple events."""
+    deleted_count = 0
+    failed_ids: list[UUID] = []
+    errors: list[str] = []
+    for event_id in deduplicate_event_ids(event_ids):
+        try:
+            await delete_event(session, event_id=event_id)
+            deleted_count += 1
+        except EventNotFoundError as exc:
+            failed_ids.append(event_id)
+            errors.append(str(exc))
+    return BatchDeleteResult(
+        deleted_count=deleted_count,
+        failed_ids=tuple(failed_ids),
+        errors=tuple(errors),
+    )
+
+
+__all__ = [
+    "EventAreaReferenceNotFoundError",
+    "EventNotFoundError",
+    "EventTaskReferenceNotFoundError",
+    "EventValidationError",
+    "batch_delete_events",
+    "create_event",
+    "delete_event",
+    "get_event",
+    "list_events",
+    "update_event",
+]

--- a/src/lifeos_cli/db/services/events.py
+++ b/src/lifeos_cli/db/services/events.py
@@ -10,6 +10,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from lifeos_cli.db.models.event import Event
+from lifeos_cli.db.models.person_association import person_associations
+from lifeos_cli.db.models.tag_association import tag_associations
 from lifeos_cli.db.services.batching import BatchDeleteResult
 from lifeos_cli.db.services.entity_people import load_people_for_entities, sync_entity_people
 from lifeos_cli.db.services.entity_tags import load_tags_for_entities, sync_entity_tags
@@ -26,8 +28,6 @@ from lifeos_cli.db.services.event_support import (
     validate_event_time_range,
     validate_event_title,
 )
-from lifeos_cli.db.models.person_association import person_associations
-from lifeos_cli.db.models.tag_association import tag_associations
 
 
 async def _attach_event_links(session: AsyncSession, event: Event) -> Event:

--- a/src/lifeos_cli/db/services/habit_actions.py
+++ b/src/lifeos_cli/db/services/habit_actions.py
@@ -1,0 +1,31 @@
+"""Facade exports for habit-action service functions."""
+
+from __future__ import annotations
+
+from lifeos_cli.db.services.habit_support import (
+    DEFAULT_HABIT_ACTION_WINDOW_DAYS,
+    HABIT_EDITABLE_DAYS,
+    MAX_HABIT_ACTION_WINDOW_DAYS,
+    VALID_HABIT_ACTION_STATUSES,
+    HabitActionNotFoundError,
+    HabitNotFoundError,
+    HabitValidationError,
+    InvalidHabitOperationError,
+    validate_habit_action_status,
+)
+from lifeos_cli.db.services.habits import get_habit_action, list_habit_actions, update_habit_action
+
+__all__ = [
+    "DEFAULT_HABIT_ACTION_WINDOW_DAYS",
+    "HABIT_EDITABLE_DAYS",
+    "MAX_HABIT_ACTION_WINDOW_DAYS",
+    "HabitActionNotFoundError",
+    "HabitNotFoundError",
+    "HabitValidationError",
+    "InvalidHabitOperationError",
+    "VALID_HABIT_ACTION_STATUSES",
+    "get_habit_action",
+    "list_habit_actions",
+    "update_habit_action",
+    "validate_habit_action_status",
+]

--- a/src/lifeos_cli/db/services/habit_support.py
+++ b/src/lifeos_cli/db/services/habit_support.py
@@ -1,0 +1,237 @@
+"""Support constants and helpers for habit services."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import func, select, text, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from lifeos_cli.db.base import utc_now
+
+if TYPE_CHECKING:
+    from lifeos_cli.db.models.habit import Habit
+    from lifeos_cli.db.models.habit_action import HabitAction
+
+VALID_HABIT_STATUSES = {"active", "completed", "paused", "expired"}
+HABIT_ACTION_STATUS_CONFIG = {
+    "pending": {
+        "display_name": "Pending",
+        "default_for_new": True,
+        "manual_status": False,
+        "count_as_completed": False,
+    },
+    "done": {
+        "display_name": "Done",
+        "default_for_new": False,
+        "manual_status": True,
+        "count_as_completed": True,
+    },
+    "skip": {
+        "display_name": "Skip",
+        "default_for_new": False,
+        "manual_status": True,
+        "count_as_completed": False,
+    },
+    "miss": {
+        "display_name": "Miss",
+        "default_for_new": False,
+        "manual_status": True,
+        "count_as_completed": False,
+    },
+}
+VALID_HABIT_ACTION_STATUSES = set(HABIT_ACTION_STATUS_CONFIG)
+HABIT_DURATION_OPTIONS = {7, 14, 21, 100, 365, 1000}
+HABIT_EDITABLE_DAYS = 10000
+MAX_ACTIVE_HABITS = 99
+DEFAULT_HABIT_ACTION_WINDOW_DAYS = 5
+MAX_HABIT_ACTION_WINDOW_DAYS = 100
+
+
+class HabitNotFoundError(LookupError):
+    """Raised when a habit cannot be found."""
+
+
+class HabitActionNotFoundError(LookupError):
+    """Raised when a habit action cannot be found."""
+
+
+class HabitTaskReferenceNotFoundError(LookupError):
+    """Raised when a referenced task cannot be found."""
+
+
+class HabitValidationError(ValueError):
+    """Raised when habit input validation fails."""
+
+
+class InvalidHabitOperationError(ValueError):
+    """Raised when a habit operation is not allowed."""
+
+
+def deduplicate_habit_ids(habit_ids: list[UUID]) -> list[UUID]:
+    """Return habit identifiers without duplicates while keeping input order."""
+    return list(dict.fromkeys(habit_ids))
+
+
+def get_default_habit_action_status() -> str:
+    """Return the configured default status for newly generated actions."""
+    for status, config in HABIT_ACTION_STATUS_CONFIG.items():
+        if config["default_for_new"]:
+            return status
+    raise HabitValidationError("No default habit action status is configured")
+
+
+def validate_habit_status(status: str) -> str:
+    """Validate and normalize a habit status."""
+    normalized = status.strip().lower()
+    if normalized not in VALID_HABIT_STATUSES:
+        allowed = ", ".join(sorted(VALID_HABIT_STATUSES))
+        raise HabitValidationError(
+            f"Invalid habit status {normalized!r}. Expected one of: {allowed}"
+        )
+    return normalized
+
+
+def validate_habit_action_status(status: str) -> str:
+    """Validate and normalize a habit-action status."""
+    normalized = status.strip().lower()
+    if normalized not in VALID_HABIT_ACTION_STATUSES:
+        allowed = ", ".join(sorted(VALID_HABIT_ACTION_STATUSES))
+        raise HabitValidationError(
+            f"Invalid habit-action status {normalized!r}. Expected one of: {allowed}"
+        )
+    return normalized
+
+
+def validate_habit_duration(duration_days: int) -> int:
+    """Validate habit duration options."""
+    if duration_days not in HABIT_DURATION_OPTIONS:
+        allowed = ", ".join(str(value) for value in sorted(HABIT_DURATION_OPTIONS))
+        raise HabitValidationError(
+            f"Invalid duration_days {duration_days!r}. Expected one of: {allowed}"
+        )
+    return duration_days
+
+
+def validate_habit_start_date(start_date: date) -> date:
+    """Validate that a habit does not begin too far in the past."""
+    if start_date < date.today() - timedelta(days=HABIT_EDITABLE_DAYS):
+        raise HabitValidationError(
+            f"Start date cannot be more than {HABIT_EDITABLE_DAYS} days in the past"
+        )
+    return start_date
+
+
+async def ensure_task_exists(session: AsyncSession, task_id: UUID | None) -> None:
+    """Ensure an optional task reference exists."""
+    from lifeos_cli.db.models.task import Task
+
+    if task_id is None:
+        return
+    result = await session.execute(
+        select(Task.id).where(Task.id == task_id, Task.deleted_at.is_(None)).limit(1)
+    )
+    if result.scalar_one_or_none() is None:
+        raise HabitTaskReferenceNotFoundError(f"Task {task_id} was not found")
+
+
+async def ensure_active_capacity(
+    session: AsyncSession,
+    *,
+    exclude_habit_id: UUID | None = None,
+) -> None:
+    """Ensure the active habit cap has not been exceeded."""
+    from lifeos_cli.db.models.habit import Habit
+
+    local_today = date.today()
+    end_expr = Habit.start_date + (Habit.duration_days - 1) * text("INTERVAL '1 day'")
+    filters = [
+        Habit.deleted_at.is_(None),
+        Habit.status == "active",
+        end_expr >= local_today,
+    ]
+    if exclude_habit_id is not None:
+        filters.append(Habit.id != exclude_habit_id)
+    stmt = select(func.count()).where(*filters)
+    active_count = (await session.execute(stmt)).scalar_one()
+    if active_count >= MAX_ACTIVE_HABITS:
+        raise InvalidHabitOperationError(
+            f"You already have {MAX_ACTIVE_HABITS} active habits. Pause or complete one first."
+        )
+
+
+async def refresh_habit_expiration(
+    session: AsyncSession,
+    *,
+    habit_id: UUID | None = None,
+) -> int:
+    """Mark active habits as expired when their end date is in the past."""
+    from lifeos_cli.db.models.habit import Habit
+
+    local_today = date.today()
+    end_expr = Habit.start_date + (Habit.duration_days - 1) * text("INTERVAL '1 day'")
+    filters = [
+        Habit.deleted_at.is_(None),
+        Habit.status == "active",
+        end_expr < local_today,
+    ]
+    if habit_id is not None:
+        filters.append(Habit.id == habit_id)
+    stmt = update(Habit).where(*filters).values(status="expired", updated_at=utc_now())
+    result = await session.execute(stmt)
+    rowcount = getattr(result, "rowcount", 0)
+    return int(0 if rowcount is None else rowcount)
+
+
+def build_habit_stats_payload(habit: Habit, actions: list[HabitAction]) -> dict[str, object]:
+    """Build stats shared by overview, show, and stats commands."""
+    total_actions = len(actions)
+    completed_actions = len(
+        [
+            action
+            for action in actions
+            if HABIT_ACTION_STATUS_CONFIG.get(action.status, {}).get("count_as_completed", False)
+        ]
+    )
+    missed_actions = len([action for action in actions if action.status == "miss"])
+    skipped_actions = len([action for action in actions if action.status == "skip"])
+    progress_percentage = (completed_actions / total_actions) * 100 if total_actions else 0.0
+    return {
+        "habit_id": habit.id,
+        "total_actions": total_actions,
+        "completed_actions": completed_actions,
+        "missed_actions": missed_actions,
+        "skipped_actions": skipped_actions,
+        "progress_percentage": progress_percentage,
+        "current_streak": calculate_current_streak(actions),
+        "longest_streak": calculate_longest_streak(actions),
+    }
+
+
+def calculate_current_streak(actions: list[HabitAction]) -> int:
+    """Return the current streak of completed actions."""
+    streak = 0
+    today = date.today()
+    for action in sorted(actions, key=lambda row: row.action_date, reverse=True):
+        if action.action_date > today:
+            continue
+        if action.status == "done":
+            streak += 1
+            continue
+        break
+    return streak
+
+
+def calculate_longest_streak(actions: list[HabitAction]) -> int:
+    """Return the longest historical streak of completed actions."""
+    max_streak = 0
+    current_streak = 0
+    for action in sorted(actions, key=lambda row: row.action_date):
+        if action.status == "done":
+            current_streak += 1
+            max_streak = max(max_streak, current_streak)
+        else:
+            current_streak = 0
+    return max_streak

--- a/src/lifeos_cli/db/services/habits.py
+++ b/src/lifeos_cli/db/services/habits.py
@@ -1,0 +1,523 @@
+"""Async CRUD and overview helpers for habits."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from uuid import UUID
+
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from lifeos_cli.db.base import utc_now
+from lifeos_cli.db.models.habit import Habit
+from lifeos_cli.db.models.habit_action import HabitAction
+from lifeos_cli.db.services.batching import BatchDeleteResult
+from lifeos_cli.db.services.habit_support import (
+    DEFAULT_HABIT_ACTION_WINDOW_DAYS,
+    HABIT_ACTION_STATUS_CONFIG,
+    HABIT_EDITABLE_DAYS,
+    MAX_HABIT_ACTION_WINDOW_DAYS,
+    HabitActionNotFoundError,
+    HabitNotFoundError,
+    HabitTaskReferenceNotFoundError,
+    HabitValidationError,
+    InvalidHabitOperationError,
+    build_habit_stats_payload,
+    deduplicate_habit_ids,
+    ensure_active_capacity,
+    ensure_task_exists,
+    get_default_habit_action_status,
+    refresh_habit_expiration,
+    validate_habit_action_status,
+    validate_habit_duration,
+    validate_habit_start_date,
+    validate_habit_status,
+)
+
+
+async def get_habit(
+    session: AsyncSession,
+    *,
+    habit_id: UUID,
+    include_deleted: bool = False,
+) -> Habit | None:
+    """Load a habit by identifier."""
+    await refresh_habit_expiration(session, habit_id=habit_id)
+    stmt = select(Habit).where(Habit.id == habit_id).options(selectinload(Habit.task)).limit(1)
+    if not include_deleted:
+        stmt = stmt.where(Habit.deleted_at.is_(None))
+    return (await session.execute(stmt)).scalar_one_or_none()
+
+
+async def list_habits(
+    session: AsyncSession,
+    *,
+    status: str | None = None,
+    title: str | None = None,
+    active_window_only: bool = False,
+    include_deleted: bool = False,
+    limit: int = 100,
+    offset: int = 0,
+) -> list[Habit]:
+    """List habits with optional status and title filters."""
+    await refresh_habit_expiration(session)
+    stmt = select(Habit).options(selectinload(Habit.task))
+    if not include_deleted:
+        stmt = stmt.where(Habit.deleted_at.is_(None))
+    if status is not None:
+        stmt = stmt.where(Habit.status == validate_habit_status(status))
+    if title is not None:
+        normalized_title = title.strip()
+        if normalized_title:
+            stmt = stmt.where(Habit.title == normalized_title)
+    if active_window_only:
+        local_today = date.today()
+        end_expr = Habit.start_date + (Habit.duration_days - 1) * text("INTERVAL '1 day'")
+        stmt = stmt.where(Habit.start_date <= local_today)
+        stmt = stmt.where(end_expr >= local_today)
+    stmt = stmt.order_by(Habit.created_at.desc(), Habit.id.desc()).offset(offset).limit(limit)
+    return list((await session.execute(stmt)).scalars())
+
+
+async def create_habit(
+    session: AsyncSession,
+    *,
+    title: str,
+    description: str | None = None,
+    start_date: date,
+    duration_days: int,
+    task_id: UUID | None = None,
+) -> Habit:
+    """Create a new habit and generate its dated action rows."""
+    normalized_title = title.strip()
+    validate_habit_start_date(start_date)
+    validate_habit_duration(duration_days)
+    await ensure_active_capacity(session)
+    await ensure_task_exists(session, task_id)
+    habit = Habit(
+        title=normalized_title,
+        description=description,
+        start_date=start_date,
+        duration_days=duration_days,
+        status="active",
+        task_id=task_id,
+    )
+    session.add(habit)
+    await session.flush()
+    await _generate_habit_actions(session, habit)
+    await refresh_habit_expiration(session, habit_id=habit.id)
+    await session.refresh(habit)
+    return habit
+
+
+async def update_habit(
+    session: AsyncSession,
+    *,
+    habit_id: UUID,
+    title: str | None = None,
+    description: str | None = None,
+    clear_description: bool = False,
+    start_date: date | None = None,
+    duration_days: int | None = None,
+    status: str | None = None,
+    task_id: UUID | None = None,
+    clear_task: bool = False,
+) -> Habit:
+    """Update a habit and adjust generated actions when timing changes."""
+    habit = await get_habit(session, habit_id=habit_id, include_deleted=False)
+    if habit is None:
+        raise HabitNotFoundError(f"Habit {habit_id} was not found")
+
+    old_start_date = habit.start_date
+    old_duration = habit.duration_days
+    start_date_changed = False
+    duration_changed = False
+
+    if title is not None:
+        habit.title = title.strip()
+    if clear_description:
+        habit.description = None
+    elif description is not None:
+        habit.description = description
+    if start_date is not None:
+        validate_habit_start_date(start_date)
+        habit.start_date = start_date
+        start_date_changed = start_date != old_start_date
+    if duration_days is not None:
+        habit.duration_days = validate_habit_duration(duration_days)
+        duration_changed = duration_days != old_duration
+    if clear_task:
+        habit.task_id = None
+    elif task_id is not None:
+        await ensure_task_exists(session, task_id)
+        habit.task_id = task_id
+    if status is not None:
+        normalized_status = validate_habit_status(status)
+        if normalized_status == "active" and habit.status != "active":
+            await ensure_active_capacity(session, exclude_habit_id=habit.id)
+        habit.status = normalized_status
+
+    if start_date_changed and duration_changed:
+        await _adjust_actions_for_both_changes(session, habit)
+    elif start_date_changed:
+        await _adjust_actions_for_start_change(session, habit)
+    elif duration_changed:
+        await _adjust_actions_for_duration_change(session, habit, old_duration=old_duration)
+
+    await session.flush()
+    await refresh_habit_expiration(session, habit_id=habit.id)
+    await session.refresh(habit)
+    return habit
+
+
+async def delete_habit(session: AsyncSession, *, habit_id: UUID) -> None:
+    """Soft-delete a habit."""
+    habit = await get_habit(session, habit_id=habit_id, include_deleted=False)
+    if habit is None:
+        raise HabitNotFoundError(f"Habit {habit_id} was not found")
+    habit.soft_delete()
+    await session.flush()
+
+
+async def batch_delete_habits(
+    session: AsyncSession,
+    *,
+    habit_ids: list[UUID],
+) -> BatchDeleteResult:
+    """Soft-delete multiple habits."""
+    deleted_count = 0
+    failed_ids: list[UUID] = []
+    errors: list[str] = []
+
+    for habit_id in deduplicate_habit_ids(habit_ids):
+        try:
+            await delete_habit(session, habit_id=habit_id)
+            deleted_count += 1
+        except HabitNotFoundError as exc:
+            failed_ids.append(habit_id)
+            errors.append(str(exc))
+
+    return BatchDeleteResult(
+        deleted_count=deleted_count,
+        failed_ids=tuple(failed_ids),
+        errors=tuple(errors),
+    )
+
+
+async def get_habit_stats(session: AsyncSession, *, habit_id: UUID) -> dict[str, object]:
+    """Return statistics for one habit."""
+    habit = await get_habit(session, habit_id=habit_id, include_deleted=False)
+    if habit is None:
+        raise HabitNotFoundError(f"Habit {habit_id} was not found")
+    actions = await _load_active_actions(session, habit)
+    return build_habit_stats_payload(habit, actions)
+
+
+async def get_habit_overview(
+    session: AsyncSession,
+    *,
+    habit_id: UUID,
+    include_deleted: bool = False,
+) -> dict[str, object]:
+    """Return a habit plus its derived statistics."""
+    habit = await get_habit(session, habit_id=habit_id, include_deleted=include_deleted)
+    if habit is None:
+        raise HabitNotFoundError(f"Habit {habit_id} was not found")
+    actions = await _load_actions_for_overview(
+        session, habit_id=habit.id, include_deleted=include_deleted
+    )
+    return {"habit": habit, "stats": build_habit_stats_payload(habit, actions)}
+
+
+async def list_habit_overviews(
+    session: AsyncSession,
+    *,
+    status: str | None = None,
+    title: str | None = None,
+    active_window_only: bool = False,
+    include_deleted: bool = False,
+    limit: int = 100,
+    offset: int = 0,
+) -> list[dict[str, object]]:
+    """Return habits with derived statistics."""
+    habits = await list_habits(
+        session,
+        status=status,
+        title=title,
+        active_window_only=active_window_only,
+        include_deleted=include_deleted,
+        limit=limit,
+        offset=offset,
+    )
+    if not habits:
+        return []
+    habit_ids = [habit.id for habit in habits]
+    actions_stmt = select(HabitAction).where(HabitAction.habit_id.in_(habit_ids))
+    if not include_deleted:
+        actions_stmt = actions_stmt.where(HabitAction.deleted_at.is_(None))
+    actions_stmt = actions_stmt.order_by(HabitAction.action_date.asc())
+    actions = list((await session.execute(actions_stmt)).scalars())
+    action_map: dict[UUID, list[HabitAction]] = {habit_id: [] for habit_id in habit_ids}
+    for action in actions:
+        action_map.setdefault(action.habit_id, []).append(action)
+    return [
+        {"habit": habit, "stats": build_habit_stats_payload(habit, action_map.get(habit.id, []))}
+        for habit in habits
+    ]
+
+
+async def get_habit_task_associations(session: AsyncSession) -> dict[UUID, list[Habit]]:
+    """Return task-to-habits mappings for active, non-deleted habits."""
+    await refresh_habit_expiration(session)
+    stmt = (
+        select(Habit)
+        .where(
+            Habit.deleted_at.is_(None),
+            Habit.task_id.is_not(None),
+            Habit.status == "active",
+        )
+        .options(selectinload(Habit.task))
+        .order_by(Habit.created_at.desc())
+    )
+    habits = list((await session.execute(stmt)).scalars())
+    associations: dict[UUID, list[Habit]] = {}
+    for habit in habits:
+        if habit.task_id is None:
+            continue
+        associations.setdefault(habit.task_id, []).append(habit)
+    return associations
+
+
+async def list_habit_actions(
+    session: AsyncSession,
+    *,
+    habit_id: UUID | None = None,
+    status: str | None = None,
+    action_date: date | None = None,
+    center_date: date | None = None,
+    days_before: int | None = None,
+    days_after: int | None = None,
+    include_deleted: bool = False,
+    limit: int = 100,
+    offset: int = 0,
+) -> list[HabitAction]:
+    """List habit actions with optional habit, status, and date filters."""
+    stmt = select(HabitAction).options(selectinload(HabitAction.habit))
+    if habit_id is not None:
+        habit = await get_habit(session, habit_id=habit_id, include_deleted=include_deleted)
+        if habit is None:
+            raise HabitNotFoundError(f"Habit {habit_id} was not found")
+        stmt = stmt.where(HabitAction.habit_id == habit_id)
+    if not include_deleted:
+        stmt = stmt.where(HabitAction.deleted_at.is_(None))
+    if status is not None:
+        stmt = stmt.where(HabitAction.status == validate_habit_action_status(status))
+    if action_date is not None:
+        stmt = stmt.where(HabitAction.action_date == action_date)
+    else:
+        use_window = any(value is not None for value in (center_date, days_before, days_after))
+        if use_window:
+            reference_date = center_date or date.today()
+            window_before = (
+                days_before if days_before is not None else DEFAULT_HABIT_ACTION_WINDOW_DAYS
+            )
+            window_after = days_after if days_after is not None else window_before
+            if window_before < 0 or window_after < 0:
+                raise HabitValidationError("days_before and days_after must be non-negative")
+            if window_before + window_after + 1 > MAX_HABIT_ACTION_WINDOW_DAYS:
+                raise HabitValidationError(
+                    "The requested action window is larger than the allowed maximum"
+                )
+            start = reference_date - timedelta(days=window_before)
+            end = reference_date + timedelta(days=window_after)
+            stmt = stmt.where(HabitAction.action_date >= start, HabitAction.action_date <= end)
+    stmt = stmt.order_by(HabitAction.action_date.asc(), HabitAction.id.asc())
+    stmt = stmt.offset(offset).limit(limit)
+    return list((await session.execute(stmt)).scalars())
+
+
+async def get_habit_action(
+    session: AsyncSession,
+    *,
+    action_id: UUID,
+    include_deleted: bool = False,
+) -> HabitAction | None:
+    """Load one habit action with its parent habit."""
+    stmt = (
+        select(HabitAction)
+        .where(HabitAction.id == action_id)
+        .options(selectinload(HabitAction.habit))
+        .limit(1)
+    )
+    if not include_deleted:
+        stmt = stmt.where(HabitAction.deleted_at.is_(None))
+    return (await session.execute(stmt)).scalar_one_or_none()
+
+
+async def update_habit_action(
+    session: AsyncSession,
+    *,
+    action_id: UUID,
+    status: str | None = None,
+    notes: str | None = None,
+    clear_notes: bool = False,
+) -> HabitAction:
+    """Update one habit action within the editable window."""
+    action = await get_habit_action(session, action_id=action_id, include_deleted=False)
+    if action is None:
+        raise HabitActionNotFoundError(f"Habit action {action_id} was not found")
+    today = date.today()
+    if action.action_date > today or (today - action.action_date).days > HABIT_EDITABLE_DAYS:
+        raise InvalidHabitOperationError(
+            "Habit action cannot be modified outside the allowed time window"
+        )
+    if status is not None:
+        action.status = validate_habit_action_status(status)
+    if clear_notes:
+        action.notes = None
+    elif notes is not None:
+        action.notes = notes
+    await session.flush()
+    await session.refresh(action)
+    return action
+
+
+async def _generate_habit_actions(session: AsyncSession, habit: Habit) -> None:
+    current_date = habit.start_date
+    while current_date <= habit.end_date:
+        session.add(
+            HabitAction(
+                habit_id=habit.id,
+                action_date=current_date,
+                status=get_default_habit_action_status(),
+            )
+        )
+        current_date += timedelta(days=1)
+    await session.flush()
+
+
+async def _load_active_actions(session: AsyncSession, habit: Habit) -> list[HabitAction]:
+    stmt = select(HabitAction).where(
+        HabitAction.habit_id == habit.id,
+        HabitAction.deleted_at.is_(None),
+    )
+    return list((await session.execute(stmt)).scalars())
+
+
+async def _load_actions_for_overview(
+    session: AsyncSession,
+    *,
+    habit_id: UUID,
+    include_deleted: bool,
+) -> list[HabitAction]:
+    stmt = select(HabitAction).where(HabitAction.habit_id == habit_id)
+    if not include_deleted:
+        stmt = stmt.where(HabitAction.deleted_at.is_(None))
+    stmt = stmt.order_by(HabitAction.action_date.asc())
+    return list((await session.execute(stmt)).scalars())
+
+
+async def _adjust_actions_for_duration_change(
+    session: AsyncSession,
+    habit: Habit,
+    *,
+    old_duration: int,
+) -> None:
+    new_end_date = habit.end_date
+    old_end_date = habit.start_date + timedelta(days=old_duration - 1)
+    if habit.duration_days > old_duration:
+        current_date = old_end_date + timedelta(days=1)
+        while current_date <= new_end_date:
+            exists = (
+                await session.execute(
+                    select(HabitAction.id).where(
+                        HabitAction.habit_id == habit.id,
+                        HabitAction.action_date == current_date,
+                        HabitAction.deleted_at.is_(None),
+                    )
+                )
+            ).scalar_one_or_none()
+            if exists is None:
+                session.add(
+                    HabitAction(
+                        habit_id=habit.id,
+                        action_date=current_date,
+                        status=get_default_habit_action_status(),
+                    )
+                )
+            current_date += timedelta(days=1)
+    else:
+        cutoff_date = habit.start_date + timedelta(days=habit.duration_days - 1)
+        actions = list(
+            (
+                await session.execute(
+                    select(HabitAction).where(
+                        HabitAction.habit_id == habit.id,
+                        HabitAction.action_date > cutoff_date,
+                        HabitAction.deleted_at.is_(None),
+                    )
+                )
+            ).scalars()
+        )
+        for action in actions:
+            action.deleted_at = utc_now()
+    await session.flush()
+
+
+async def _adjust_actions_for_start_change(session: AsyncSession, habit: Habit) -> None:
+    desired_dates: set[date] = set()
+    current_date = habit.start_date
+    while current_date <= habit.end_date:
+        desired_dates.add(current_date)
+        current_date += timedelta(days=1)
+
+    existing_actions = await _load_active_actions(session, habit)
+    existing_by_date = {action.action_date: action for action in existing_actions}
+
+    for action in existing_actions:
+        if action.action_date not in desired_dates:
+            action.deleted_at = utc_now()
+
+    for desired_date in sorted(desired_dates):
+        if desired_date not in existing_by_date:
+            session.add(
+                HabitAction(
+                    habit_id=habit.id,
+                    action_date=desired_date,
+                    status=get_default_habit_action_status(),
+                )
+            )
+    await session.flush()
+
+
+async def _adjust_actions_for_both_changes(session: AsyncSession, habit: Habit) -> None:
+    await _adjust_actions_for_start_change(session, habit)
+
+
+__all__ = [
+    "DEFAULT_HABIT_ACTION_WINDOW_DAYS",
+    "HABIT_ACTION_STATUS_CONFIG",
+    "HABIT_EDITABLE_DAYS",
+    "MAX_HABIT_ACTION_WINDOW_DAYS",
+    "HabitActionNotFoundError",
+    "HabitNotFoundError",
+    "HabitTaskReferenceNotFoundError",
+    "HabitValidationError",
+    "InvalidHabitOperationError",
+    "batch_delete_habits",
+    "create_habit",
+    "delete_habit",
+    "get_habit",
+    "get_habit_action",
+    "get_habit_overview",
+    "get_habit_stats",
+    "get_habit_task_associations",
+    "list_habit_actions",
+    "list_habit_overviews",
+    "list_habits",
+    "update_habit",
+    "update_habit_action",
+    "validate_habit_action_status",
+    "validate_habit_status",
+]

--- a/src/lifeos_cli/db/services/tags.py
+++ b/src/lifeos_cli/db/services/tags.py
@@ -7,8 +7,10 @@ from uuid import UUID
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from lifeos_cli.db.models.person_association import person_associations
 from lifeos_cli.db.models.tag import Tag
 from lifeos_cli.db.services.batching import BatchDeleteResult
+from lifeos_cli.db.services.entity_people import load_people_for_entities, sync_entity_people
 
 VALID_TAG_ENTITY_TYPES = {"note", "person", "task", "vision", "area", "event", "timelog"}
 
@@ -57,6 +59,7 @@ async def create_tag(
     category: str = "general",
     description: str | None = None,
     color: str | None = None,
+    person_ids: list[UUID] | None = None,
 ) -> Tag:
     """Create a new tag."""
     normalized_name = normalize_tag_name(name)
@@ -83,7 +86,13 @@ async def create_tag(
     )
     session.add(tag)
     await session.flush()
+    if person_ids is not None:
+        await sync_entity_people(
+            session, entity_id=tag.id, entity_type="tag", desired_person_ids=person_ids
+        )
     await session.refresh(tag)
+    people_map = await load_people_for_entities(session, entity_ids=[tag.id], entity_type="tag")
+    tag.people = people_map.get(tag.id, [])
     return tag
 
 
@@ -97,7 +106,12 @@ async def get_tag(
     stmt = select(Tag).where(Tag.id == tag_id).limit(1)
     if not include_deleted:
         stmt = stmt.where(Tag.deleted_at.is_(None))
-    return (await session.execute(stmt)).scalar_one_or_none()
+    tag = (await session.execute(stmt)).scalar_one_or_none()
+    if tag is None:
+        return None
+    people_map = await load_people_for_entities(session, entity_ids=[tag.id], entity_type="tag")
+    tag.people = people_map.get(tag.id, [])
+    return tag
 
 
 async def list_tags(
@@ -105,6 +119,7 @@ async def list_tags(
     *,
     entity_type: str | None = None,
     category: str | None = None,
+    person_id: UUID | None = None,
     include_deleted: bool = False,
     limit: int = 100,
     offset: int = 0,
@@ -117,8 +132,22 @@ async def list_tags(
         stmt = stmt.where(Tag.entity_type == validate_tag_entity_type(entity_type))
     if category is not None:
         stmt = stmt.where(Tag.category == category.strip().lower())
+    if person_id is not None:
+        stmt = stmt.join(
+            person_associations,
+            (person_associations.c.entity_id == Tag.id)
+            & (person_associations.c.entity_type == "tag"),
+        ).where(person_associations.c.person_id == person_id)
     stmt = stmt.order_by(Tag.name.asc(), Tag.id.asc()).offset(offset).limit(limit)
-    return list((await session.execute(stmt)).scalars())
+    tags = list((await session.execute(stmt)).scalars())
+    people_map = await load_people_for_entities(
+        session,
+        entity_ids=[tag.id for tag in tags],
+        entity_type="tag",
+    )
+    for tag in tags:
+        tag.people = people_map.get(tag.id, [])
+    return tags
 
 
 async def update_tag(
@@ -132,6 +161,8 @@ async def update_tag(
     clear_description: bool = False,
     color: str | None = None,
     clear_color: bool = False,
+    person_ids: list[UUID] | None = None,
+    clear_people: bool = False,
 ) -> Tag:
     """Update a tag."""
     tag = await get_tag(session, tag_id=tag_id)
@@ -164,8 +195,18 @@ async def update_tag(
         tag.color = None
     elif color is not None:
         tag.color = color
+    if clear_people:
+        await sync_entity_people(
+            session, entity_id=tag.id, entity_type="tag", desired_person_ids=[]
+        )
+    elif person_ids is not None:
+        await sync_entity_people(
+            session, entity_id=tag.id, entity_type="tag", desired_person_ids=person_ids
+        )
     await session.flush()
     await session.refresh(tag)
+    people_map = await load_people_for_entities(session, entity_ids=[tag.id], entity_type="tag")
+    tag.people = people_map.get(tag.id, [])
     return tag
 
 

--- a/src/lifeos_cli/db/services/tags.py
+++ b/src/lifeos_cli/db/services/tags.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from lifeos_cli.db.models.tag import Tag
 from lifeos_cli.db.services.batching import BatchDeleteResult
 
-VALID_TAG_ENTITY_TYPES = {"note", "person", "task", "vision", "area"}
+VALID_TAG_ENTITY_TYPES = {"note", "person", "task", "vision", "area", "event", "timelog"}
 
 
 class TagNotFoundError(LookupError):

--- a/src/lifeos_cli/db/services/task_mutations.py
+++ b/src/lifeos_cli/db/services/task_mutations.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from lifeos_cli.db.models.task import Task
 from lifeos_cli.db.services.batching import BatchDeleteResult
+from lifeos_cli.db.services.entity_people import load_people_for_entities, sync_entity_people
 from lifeos_cli.db.services.task_queries import get_task
 from lifeos_cli.db.services.task_support import (
     ParentTaskReferenceNotFoundError,
@@ -35,6 +36,7 @@ async def create_task(
     planning_cycle_type: str | None = None,
     planning_cycle_days: int | None = None,
     planning_cycle_start_date: date | None = None,
+    person_ids: list[UUID] | None = None,
 ) -> Task:
     """Create a task."""
     await ensure_vision_exists(session, vision_id)
@@ -59,7 +61,13 @@ async def create_task(
     )
     session.add(task)
     await session.flush()
+    if person_ids is not None:
+        await sync_entity_people(
+            session, entity_id=task.id, entity_type="task", desired_person_ids=person_ids
+        )
     await session.refresh(task)
+    people_map = await load_people_for_entities(session, entity_ids=[task.id], entity_type="task")
+    task.people = people_map.get(task.id, [])
     return task
 
 
@@ -81,6 +89,8 @@ async def update_task(
     planning_cycle_days: int | None = None,
     planning_cycle_start_date: date | None = None,
     clear_planning_cycle: bool = False,
+    person_ids: list[UUID] | None = None,
+    clear_people: bool = False,
 ) -> Task:
     """Update a task."""
     task = await get_task(session, task_id=task_id)
@@ -148,11 +158,21 @@ async def update_task(
         task.estimated_effort = None
     elif estimated_effort is not None:
         task.estimated_effort = estimated_effort
+    if clear_people:
+        await sync_entity_people(
+            session, entity_id=task.id, entity_type="task", desired_person_ids=[]
+        )
+    elif person_ids is not None:
+        await sync_entity_people(
+            session, entity_id=task.id, entity_type="task", desired_person_ids=person_ids
+        )
     task.planning_cycle_type = normalized_cycle_type
     task.planning_cycle_days = normalized_cycle_days
     task.planning_cycle_start_date = normalized_cycle_start_date
     await session.flush()
     await session.refresh(task)
+    people_map = await load_people_for_entities(session, entity_ids=[task.id], entity_type="task")
+    task.people = people_map.get(task.id, [])
     return task
 
 

--- a/src/lifeos_cli/db/services/task_queries.py
+++ b/src/lifeos_cli/db/services/task_queries.py
@@ -7,7 +7,9 @@ from uuid import UUID
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from lifeos_cli.db.models.person_association import person_associations
 from lifeos_cli.db.models.task import Task
+from lifeos_cli.db.services.entity_people import load_people_for_entities
 from lifeos_cli.db.services.task_support import validate_task_status
 
 
@@ -21,7 +23,12 @@ async def get_task(
     stmt = select(Task).where(Task.id == task_id).limit(1)
     if not include_deleted:
         stmt = stmt.where(Task.deleted_at.is_(None))
-    return (await session.execute(stmt)).scalar_one_or_none()
+    task = (await session.execute(stmt)).scalar_one_or_none()
+    if task is None:
+        return None
+    people_map = await load_people_for_entities(session, entity_ids=[task.id], entity_type="task")
+    task.people = people_map.get(task.id, [])
+    return task
 
 
 async def list_tasks(
@@ -29,6 +36,7 @@ async def list_tasks(
     *,
     vision_id: UUID | None = None,
     parent_task_id: UUID | None = None,
+    person_id: UUID | None = None,
     status: str | None = None,
     include_deleted: bool = False,
     limit: int = 100,
@@ -44,6 +52,12 @@ async def list_tasks(
         stmt = stmt.where(Task.parent_task_id.is_(None))
     elif parent_task_id is not None:
         stmt = stmt.where(Task.parent_task_id == parent_task_id)
+    if person_id is not None:
+        stmt = stmt.join(
+            person_associations,
+            (person_associations.c.entity_id == Task.id)
+            & (person_associations.c.entity_type == "task"),
+        ).where(person_associations.c.person_id == person_id)
     if status is not None:
         stmt = stmt.where(Task.status == validate_task_status(status))
     stmt = (
@@ -51,4 +65,12 @@ async def list_tasks(
         .offset(offset)
         .limit(limit)
     )
-    return list((await session.execute(stmt)).scalars())
+    tasks = list((await session.execute(stmt)).scalars())
+    people_map = await load_people_for_entities(
+        session,
+        entity_ids=[task.id for task in tasks],
+        entity_type="task",
+    )
+    for task in tasks:
+        task.people = people_map.get(task.id, [])
+    return tasks

--- a/src/lifeos_cli/db/services/timelog_support.py
+++ b/src/lifeos_cli/db/services/timelog_support.py
@@ -1,0 +1,89 @@
+"""Support utilities and validations for timelog services."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from lifeos_cli.db.models.area import Area
+from lifeos_cli.db.models.task import Task
+
+VALID_TIMELOG_TRACKING_METHODS = {"manual", "automatic", "imported"}
+
+
+class TimelogNotFoundError(LookupError):
+    """Raised when a timelog cannot be found."""
+
+
+class TimelogAreaReferenceNotFoundError(LookupError):
+    """Raised when a referenced area cannot be found."""
+
+
+class TimelogTaskReferenceNotFoundError(LookupError):
+    """Raised when a referenced task cannot be found."""
+
+
+class TimelogValidationError(ValueError):
+    """Raised when timelog data is invalid."""
+
+
+def validate_timelog_title(title: str) -> str:
+    """Validate and normalize a timelog title."""
+    normalized = title.strip()
+    if not normalized:
+        raise TimelogValidationError("Timelog title must not be empty")
+    if len(normalized) > 200:
+        raise TimelogValidationError("Timelog title must be 200 characters or fewer")
+    return normalized
+
+
+def validate_timelog_time_range(*, start_time: datetime, end_time: datetime) -> None:
+    """Validate a timelog time range."""
+    if end_time < start_time:
+        raise TimelogValidationError("Timelog end time must be on or after the start time")
+
+
+def validate_tracking_method(tracking_method: str) -> str:
+    """Validate and normalize a tracking method."""
+    normalized = tracking_method.strip().lower()
+    if normalized not in VALID_TIMELOG_TRACKING_METHODS:
+        allowed = ", ".join(sorted(VALID_TIMELOG_TRACKING_METHODS))
+        raise TimelogValidationError(
+            f"Invalid tracking method {normalized!r}. Expected one of: {allowed}"
+        )
+    return normalized
+
+
+def validate_energy_level(energy_level: int | None) -> int | None:
+    """Validate an optional energy level."""
+    if energy_level is None:
+        return None
+    if energy_level < 1 or energy_level > 5:
+        raise TimelogValidationError("Energy level must be between 1 and 5")
+    return energy_level
+
+
+async def ensure_timelog_area_exists(session: AsyncSession, area_id: UUID | None) -> None:
+    """Ensure an optional timelog area reference exists."""
+    if area_id is None:
+        return
+    stmt = select(Area.id).where(Area.id == area_id, Area.deleted_at.is_(None)).limit(1)
+    if (await session.scalar(stmt)) is None:
+        raise TimelogAreaReferenceNotFoundError(f"Area {area_id} was not found")
+
+
+async def ensure_timelog_task_exists(session: AsyncSession, task_id: UUID | None) -> None:
+    """Ensure an optional timelog task reference exists."""
+    if task_id is None:
+        return
+    stmt = select(Task.id).where(Task.id == task_id, Task.deleted_at.is_(None)).limit(1)
+    if (await session.scalar(stmt)) is None:
+        raise TimelogTaskReferenceNotFoundError(f"Task {task_id} was not found")
+
+
+def deduplicate_timelog_ids(timelog_ids: list[UUID]) -> list[UUID]:
+    """Return timelog identifiers in original order without duplicates."""
+    return list(dict.fromkeys(timelog_ids))

--- a/src/lifeos_cli/db/services/timelogs.py
+++ b/src/lifeos_cli/db/services/timelogs.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 from datetime import datetime
 from uuid import UUID
 
-from sqlalchemy import or_, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from lifeos_cli.db.models.timelog import Timelog
 from lifeos_cli.db.models.person_association import person_associations
 from lifeos_cli.db.models.tag_association import tag_associations
+from lifeos_cli.db.models.timelog import Timelog
 from lifeos_cli.db.services.batching import BatchDeleteResult
 from lifeos_cli.db.services.entity_people import load_people_for_entities, sync_entity_people
 from lifeos_cli.db.services.entity_tags import load_tags_for_entities, sync_entity_tags
@@ -31,9 +31,7 @@ from lifeos_cli.db.services.timelog_support import (
 
 
 async def _attach_timelog_links(session: AsyncSession, timelog: Timelog) -> Timelog:
-    tags_map = await load_tags_for_entities(
-        session, entity_ids=[timelog.id], entity_type="timelog"
-    )
+    tags_map = await load_tags_for_entities(session, entity_ids=[timelog.id], entity_type="timelog")
     people_map = await load_people_for_entities(
         session, entity_ids=[timelog.id], entity_type="timelog"
     )
@@ -49,9 +47,7 @@ async def _attach_timelog_links_for_many(
     if not timelogs:
         return []
     timelog_ids = [timelog.id for timelog in timelogs]
-    tags_map = await load_tags_for_entities(
-        session, entity_ids=timelog_ids, entity_type="timelog"
-    )
+    tags_map = await load_tags_for_entities(session, entity_ids=timelog_ids, entity_type="timelog")
     people_map = await load_people_for_entities(
         session, entity_ids=timelog_ids, entity_type="timelog"
     )

--- a/src/lifeos_cli/db/services/timelogs.py
+++ b/src/lifeos_cli/db/services/timelogs.py
@@ -1,0 +1,312 @@
+"""Async CRUD helpers for timelogs."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from lifeos_cli.db.models.timelog import Timelog
+from lifeos_cli.db.models.person_association import person_associations
+from lifeos_cli.db.models.tag_association import tag_associations
+from lifeos_cli.db.services.batching import BatchDeleteResult
+from lifeos_cli.db.services.entity_people import load_people_for_entities, sync_entity_people
+from lifeos_cli.db.services.entity_tags import load_tags_for_entities, sync_entity_tags
+from lifeos_cli.db.services.timelog_support import (
+    TimelogAreaReferenceNotFoundError,
+    TimelogNotFoundError,
+    TimelogTaskReferenceNotFoundError,
+    TimelogValidationError,
+    deduplicate_timelog_ids,
+    ensure_timelog_area_exists,
+    ensure_timelog_task_exists,
+    validate_energy_level,
+    validate_timelog_time_range,
+    validate_timelog_title,
+    validate_tracking_method,
+)
+
+
+async def _attach_timelog_links(session: AsyncSession, timelog: Timelog) -> Timelog:
+    tags_map = await load_tags_for_entities(
+        session, entity_ids=[timelog.id], entity_type="timelog"
+    )
+    people_map = await load_people_for_entities(
+        session, entity_ids=[timelog.id], entity_type="timelog"
+    )
+    timelog.tags = tags_map.get(timelog.id, [])
+    timelog.people = people_map.get(timelog.id, [])
+    return timelog
+
+
+async def _attach_timelog_links_for_many(
+    session: AsyncSession,
+    timelogs: list[Timelog],
+) -> list[Timelog]:
+    if not timelogs:
+        return []
+    timelog_ids = [timelog.id for timelog in timelogs]
+    tags_map = await load_tags_for_entities(
+        session, entity_ids=timelog_ids, entity_type="timelog"
+    )
+    people_map = await load_people_for_entities(
+        session, entity_ids=timelog_ids, entity_type="timelog"
+    )
+    for timelog in timelogs:
+        timelog.tags = tags_map.get(timelog.id, [])
+        timelog.people = people_map.get(timelog.id, [])
+    return timelogs
+
+
+async def create_timelog(
+    session: AsyncSession,
+    *,
+    title: str,
+    start_time: datetime,
+    end_time: datetime,
+    tracking_method: str = "manual",
+    location: str | None = None,
+    energy_level: int | None = None,
+    notes: str | None = None,
+    area_id: UUID | None = None,
+    task_id: UUID | None = None,
+    tag_ids: list[UUID] | None = None,
+    person_ids: list[UUID] | None = None,
+) -> Timelog:
+    """Create a new timelog."""
+    normalized_title = validate_timelog_title(title)
+    validate_timelog_time_range(start_time=start_time, end_time=end_time)
+    normalized_tracking_method = validate_tracking_method(tracking_method)
+    normalized_energy_level = validate_energy_level(energy_level)
+    await ensure_timelog_area_exists(session, area_id)
+    await ensure_timelog_task_exists(session, task_id)
+    timelog = Timelog(
+        title=normalized_title,
+        start_time=start_time,
+        end_time=end_time,
+        tracking_method=normalized_tracking_method,
+        location=location,
+        energy_level=normalized_energy_level,
+        notes=notes,
+        area_id=area_id,
+        task_id=task_id,
+    )
+    session.add(timelog)
+    await session.flush()
+    if tag_ids is not None:
+        await sync_entity_tags(
+            session, entity_id=timelog.id, entity_type="timelog", desired_tag_ids=tag_ids
+        )
+    if person_ids is not None:
+        await sync_entity_people(
+            session,
+            entity_id=timelog.id,
+            entity_type="timelog",
+            desired_person_ids=person_ids,
+        )
+    await session.refresh(timelog)
+    return await _attach_timelog_links(session, timelog)
+
+
+async def get_timelog(
+    session: AsyncSession,
+    *,
+    timelog_id: UUID,
+    include_deleted: bool = False,
+) -> Timelog | None:
+    """Load a timelog by identifier."""
+    stmt = (
+        select(Timelog)
+        .options(selectinload(Timelog.area), selectinload(Timelog.task))
+        .where(Timelog.id == timelog_id)
+        .limit(1)
+    )
+    if not include_deleted:
+        stmt = stmt.where(Timelog.deleted_at.is_(None))
+    timelog = (await session.execute(stmt)).scalar_one_or_none()
+    if timelog is None:
+        return None
+    return await _attach_timelog_links(session, timelog)
+
+
+async def list_timelogs(
+    session: AsyncSession,
+    *,
+    title_contains: str | None = None,
+    tracking_method: str | None = None,
+    area_id: UUID | None = None,
+    task_id: UUID | None = None,
+    person_id: UUID | None = None,
+    tag_id: UUID | None = None,
+    window_start: datetime | None = None,
+    window_end: datetime | None = None,
+    include_deleted: bool = False,
+    limit: int = 100,
+    offset: int = 0,
+) -> list[Timelog]:
+    """List timelogs with optional filters."""
+    stmt = select(Timelog).options(selectinload(Timelog.area), selectinload(Timelog.task))
+    if not include_deleted:
+        stmt = stmt.where(Timelog.deleted_at.is_(None))
+    if title_contains:
+        stmt = stmt.where(Timelog.title.ilike(f"%{title_contains.strip()}%"))
+    if tracking_method is not None:
+        stmt = stmt.where(Timelog.tracking_method == validate_tracking_method(tracking_method))
+    if area_id is not None:
+        stmt = stmt.where(Timelog.area_id == area_id)
+    if task_id is not None:
+        stmt = stmt.where(Timelog.task_id == task_id)
+    if person_id is not None:
+        stmt = stmt.join(
+            person_associations,
+            (person_associations.c.entity_id == Timelog.id)
+            & (person_associations.c.entity_type == "timelog"),
+        ).where(person_associations.c.person_id == person_id)
+    if tag_id is not None:
+        stmt = stmt.join(
+            tag_associations,
+            (tag_associations.c.entity_id == Timelog.id)
+            & (tag_associations.c.entity_type == "timelog"),
+        ).where(tag_associations.c.tag_id == tag_id)
+    if window_start is not None:
+        stmt = stmt.where(Timelog.end_time >= window_start)
+    if window_end is not None:
+        stmt = stmt.where(Timelog.start_time <= window_end)
+    stmt = stmt.order_by(Timelog.start_time.desc(), Timelog.id.desc()).offset(offset).limit(limit)
+    timelogs = list((await session.execute(stmt)).scalars())
+    return await _attach_timelog_links_for_many(session, timelogs)
+
+
+async def update_timelog(
+    session: AsyncSession,
+    *,
+    timelog_id: UUID,
+    title: str | None = None,
+    start_time: datetime | None = None,
+    end_time: datetime | None = None,
+    tracking_method: str | None = None,
+    location: str | None = None,
+    clear_location: bool = False,
+    energy_level: int | None = None,
+    clear_energy_level: bool = False,
+    notes: str | None = None,
+    clear_notes: bool = False,
+    area_id: UUID | None = None,
+    clear_area: bool = False,
+    task_id: UUID | None = None,
+    clear_task: bool = False,
+    tag_ids: list[UUID] | None = None,
+    clear_tags: bool = False,
+    person_ids: list[UUID] | None = None,
+    clear_people: bool = False,
+) -> Timelog:
+    """Update one timelog."""
+    timelog = await get_timelog(session, timelog_id=timelog_id, include_deleted=False)
+    if timelog is None:
+        raise TimelogNotFoundError(f"Timelog {timelog_id} was not found")
+
+    next_start_time = start_time if start_time is not None else timelog.start_time
+    next_end_time = end_time if end_time is not None else timelog.end_time
+    validate_timelog_time_range(start_time=next_start_time, end_time=next_end_time)
+
+    if title is not None:
+        timelog.title = validate_timelog_title(title)
+    if start_time is not None:
+        timelog.start_time = start_time
+    if end_time is not None:
+        timelog.end_time = end_time
+    if tracking_method is not None:
+        timelog.tracking_method = validate_tracking_method(tracking_method)
+    if clear_location:
+        timelog.location = None
+    elif location is not None:
+        timelog.location = location
+    if clear_energy_level:
+        timelog.energy_level = None
+    elif energy_level is not None:
+        timelog.energy_level = validate_energy_level(energy_level)
+    if clear_notes:
+        timelog.notes = None
+    elif notes is not None:
+        timelog.notes = notes
+    if clear_area:
+        timelog.area_id = None
+    elif area_id is not None:
+        await ensure_timelog_area_exists(session, area_id)
+        timelog.area_id = area_id
+    if clear_task:
+        timelog.task_id = None
+    elif task_id is not None:
+        await ensure_timelog_task_exists(session, task_id)
+        timelog.task_id = task_id
+    if clear_tags:
+        await sync_entity_tags(
+            session, entity_id=timelog.id, entity_type="timelog", desired_tag_ids=[]
+        )
+    elif tag_ids is not None:
+        await sync_entity_tags(
+            session, entity_id=timelog.id, entity_type="timelog", desired_tag_ids=tag_ids
+        )
+    if clear_people:
+        await sync_entity_people(
+            session, entity_id=timelog.id, entity_type="timelog", desired_person_ids=[]
+        )
+    elif person_ids is not None:
+        await sync_entity_people(
+            session,
+            entity_id=timelog.id,
+            entity_type="timelog",
+            desired_person_ids=person_ids,
+        )
+    await session.flush()
+    await session.refresh(timelog)
+    return await _attach_timelog_links(session, timelog)
+
+
+async def delete_timelog(session: AsyncSession, *, timelog_id: UUID) -> None:
+    """Soft-delete one timelog."""
+    timelog = await get_timelog(session, timelog_id=timelog_id, include_deleted=False)
+    if timelog is None:
+        raise TimelogNotFoundError(f"Timelog {timelog_id} was not found")
+    timelog.soft_delete()
+    await session.flush()
+
+
+async def batch_delete_timelogs(
+    session: AsyncSession,
+    *,
+    timelog_ids: list[UUID],
+) -> BatchDeleteResult:
+    """Soft-delete multiple timelogs."""
+    deleted_count = 0
+    failed_ids: list[UUID] = []
+    errors: list[str] = []
+    for timelog_id in deduplicate_timelog_ids(timelog_ids):
+        try:
+            await delete_timelog(session, timelog_id=timelog_id)
+            deleted_count += 1
+        except TimelogNotFoundError as exc:
+            failed_ids.append(timelog_id)
+            errors.append(str(exc))
+    return BatchDeleteResult(
+        deleted_count=deleted_count,
+        failed_ids=tuple(failed_ids),
+        errors=tuple(errors),
+    )
+
+
+__all__ = [
+    "TimelogAreaReferenceNotFoundError",
+    "TimelogNotFoundError",
+    "TimelogTaskReferenceNotFoundError",
+    "TimelogValidationError",
+    "batch_delete_timelogs",
+    "create_timelog",
+    "delete_timelog",
+    "get_timelog",
+    "list_timelogs",
+    "update_timelog",
+]

--- a/src/lifeos_cli/db/services/visions.py
+++ b/src/lifeos_cli/db/services/visions.py
@@ -8,8 +8,10 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from lifeos_cli.db.models.area import Area
+from lifeos_cli.db.models.person_association import person_associations
 from lifeos_cli.db.models.vision import Vision
 from lifeos_cli.db.services.batching import BatchDeleteResult
+from lifeos_cli.db.services.entity_people import load_people_for_entities, sync_entity_people
 
 VALID_VISION_STATUSES = {"active", "archived", "fruit"}
 
@@ -58,6 +60,7 @@ async def create_vision(
     status: str = "active",
     area_id: UUID | None = None,
     experience_rate_per_hour: int | None = None,
+    person_ids: list[UUID] | None = None,
 ) -> Vision:
     """Create a new vision."""
     normalized_name = name.strip()
@@ -76,7 +79,15 @@ async def create_vision(
     )
     session.add(vision)
     await session.flush()
+    if person_ids is not None:
+        await sync_entity_people(
+            session, entity_id=vision.id, entity_type="vision", desired_person_ids=person_ids
+        )
     await session.refresh(vision)
+    people_map = await load_people_for_entities(
+        session, entity_ids=[vision.id], entity_type="vision"
+    )
+    vision.people = people_map.get(vision.id, [])
     return vision
 
 
@@ -90,7 +101,14 @@ async def get_vision(
     stmt = select(Vision).where(Vision.id == vision_id).limit(1)
     if not include_deleted:
         stmt = stmt.where(Vision.deleted_at.is_(None))
-    return (await session.execute(stmt)).scalar_one_or_none()
+    vision = (await session.execute(stmt)).scalar_one_or_none()
+    if vision is None:
+        return None
+    people_map = await load_people_for_entities(
+        session, entity_ids=[vision.id], entity_type="vision"
+    )
+    vision.people = people_map.get(vision.id, [])
+    return vision
 
 
 async def list_visions(
@@ -98,6 +116,7 @@ async def list_visions(
     *,
     status: str | None = None,
     area_id: UUID | None = None,
+    person_id: UUID | None = None,
     include_deleted: bool = False,
     limit: int = 100,
     offset: int = 0,
@@ -110,8 +129,22 @@ async def list_visions(
         stmt = stmt.where(Vision.status == validate_vision_status(status))
     if area_id is not None:
         stmt = stmt.where(Vision.area_id == area_id)
+    if person_id is not None:
+        stmt = stmt.join(
+            person_associations,
+            (person_associations.c.entity_id == Vision.id)
+            & (person_associations.c.entity_type == "vision"),
+        ).where(person_associations.c.person_id == person_id)
     stmt = stmt.order_by(Vision.created_at.desc(), Vision.id.desc()).offset(offset).limit(limit)
-    return list((await session.execute(stmt)).scalars())
+    visions = list((await session.execute(stmt)).scalars())
+    people_map = await load_people_for_entities(
+        session,
+        entity_ids=[vision.id for vision in visions],
+        entity_type="vision",
+    )
+    for vision in visions:
+        vision.people = people_map.get(vision.id, [])
+    return visions
 
 
 async def update_vision(
@@ -126,6 +159,8 @@ async def update_vision(
     clear_area: bool = False,
     experience_rate_per_hour: int | None = None,
     clear_experience_rate: bool = False,
+    person_ids: list[UUID] | None = None,
+    clear_people: bool = False,
 ) -> Vision:
     """Update a vision."""
     vision = await get_vision(session, vision_id=vision_id)
@@ -158,8 +193,20 @@ async def update_vision(
         vision.experience_rate_per_hour = None
     elif experience_rate_per_hour is not None:
         vision.experience_rate_per_hour = experience_rate_per_hour
+    if clear_people:
+        await sync_entity_people(
+            session, entity_id=vision.id, entity_type="vision", desired_person_ids=[]
+        )
+    elif person_ids is not None:
+        await sync_entity_people(
+            session, entity_id=vision.id, entity_type="vision", desired_person_ids=person_ids
+        )
     await session.flush()
     await session.refresh(vision)
+    people_map = await load_people_for_entities(
+        session, entity_ids=[vision.id], entity_type="vision"
+    )
+    vision.people = people_map.get(vision.id, [])
     return vision
 
 

--- a/tests/test_cli_domains.py
+++ b/tests/test_cli_domains.py
@@ -6,7 +6,17 @@ import pytest
 
 from lifeos_cli import cli
 from lifeos_cli.db import session as db_session
-from lifeos_cli.db.services import areas, habit_actions, habits, people, tags, tasks, visions
+from lifeos_cli.db.services import (
+    areas,
+    events,
+    habit_actions,
+    habits,
+    people,
+    tags,
+    tasks,
+    timelogs,
+    visions,
+)
 from tests.support import make_record, make_session_scope, utc_datetime
 
 
@@ -47,6 +57,35 @@ def test_main_area_update_rejects_conflicting_clear_icon_flags(
     assert "Use either --icon or --clear-icon, not both." in captured.err
 
 
+def test_main_event_add_creates_event(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    async def fake_create_event(session: object, **kwargs: object) -> object:
+        assert kwargs["title"] == "Doctor appointment"
+        assert kwargs["person_ids"] == [UUID("11111111-1111-1111-1111-111111111111")]
+        return make_record(id=UUID("12121212-1212-1212-1212-121212121212"))
+
+    monkeypatch.setattr(db_session, "session_scope", make_session_scope())
+    monkeypatch.setattr(events, "create_event", fake_create_event)
+
+    exit_code = cli.main(
+        [
+            "event",
+            "add",
+            "Doctor appointment",
+            "--start-time",
+            "2026-04-10T09:00:00-04:00",
+            "--person-id",
+            "11111111-1111-1111-1111-111111111111",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "Created event 12121212-1212-1212-1212-121212121212" in captured.out
+
+
 def test_main_tag_add_creates_tag(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -64,6 +103,35 @@ def test_main_tag_add_creates_tag(
 
     assert exit_code == 0
     assert "Created tag 22222222-2222-2222-2222-222222222222" in captured.out
+
+
+def test_main_timelog_add_creates_timelog(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    async def fake_create_timelog(session: object, **kwargs: object) -> object:
+        assert kwargs["title"] == "Deep work"
+        assert kwargs["tracking_method"] == "manual"
+        return make_record(id=UUID("13131313-1313-1313-1313-131313131313"))
+
+    monkeypatch.setattr(db_session, "session_scope", make_session_scope())
+    monkeypatch.setattr(timelogs, "create_timelog", fake_create_timelog)
+
+    exit_code = cli.main(
+        [
+            "timelog",
+            "add",
+            "Deep work",
+            "--start-time",
+            "2026-04-10T13:00:00-04:00",
+            "--end-time",
+            "2026-04-10T14:30:00-04:00",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "Created timelog 13131313-1313-1313-1313-131313131313" in captured.out
 
 
 def test_main_people_show_prints_tags(
@@ -98,6 +166,25 @@ def test_main_people_show_prints_tags(
     assert exit_code == 0
     assert "name: Alice" in captured.out
     assert "tags: family, friend" in captured.out
+
+
+def test_main_event_update_rejects_conflicting_clear_area_flags(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = cli.main(
+        [
+            "event",
+            "update",
+            "12121212-1212-1212-1212-121212121212",
+            "--area-id",
+            "11111111-1111-1111-1111-111111111111",
+            "--clear-area",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "Use either --area-id or --clear-area, not both." in captured.err
 
 
 def test_main_people_update_can_clear_location(
@@ -292,6 +379,25 @@ def test_main_task_update_rejects_conflicting_parent_flags(
 
     assert exit_code == 1
     assert "Use either --parent-task-id or --clear-parent, not both." in captured.err
+
+
+def test_main_timelog_update_rejects_conflicting_clear_notes_flags(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = cli.main(
+        [
+            "timelog",
+            "update",
+            "13131313-1313-1313-1313-131313131313",
+            "--notes",
+            "done",
+            "--clear-notes",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "Use either --notes or --clear-notes, not both." in captured.err
 
 
 def test_main_people_batch_delete_reports_missing_ids(

--- a/tests/test_cli_domains.py
+++ b/tests/test_cli_domains.py
@@ -26,12 +26,21 @@ def test_main_area_add_creates_area(
 ) -> None:
     async def fake_create_area(session: object, **kwargs: object) -> object:
         assert kwargs["name"] == "Health"
+        assert kwargs["person_ids"] == [UUID("11111111-1111-1111-1111-111111111111")]
         return make_record(id=UUID("11111111-1111-1111-1111-111111111111"))
 
     monkeypatch.setattr(db_session, "session_scope", make_session_scope())
     monkeypatch.setattr(areas, "create_area", fake_create_area)
 
-    exit_code = cli.main(["area", "add", "Health"])
+    exit_code = cli.main(
+        [
+            "area",
+            "add",
+            "Health",
+            "--person-id",
+            "11111111-1111-1111-1111-111111111111",
+        ]
+    )
     captured = capsys.readouterr()
 
     assert exit_code == 0
@@ -103,6 +112,32 @@ def test_main_tag_add_creates_tag(
 
     assert exit_code == 0
     assert "Created tag 22222222-2222-2222-2222-222222222222" in captured.out
+
+
+def test_main_tag_update_can_clear_people(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    async def fake_update_tag(session: object, **kwargs: object) -> object:
+        assert kwargs["clear_people"] is True
+        assert kwargs["person_ids"] is None
+        return make_record(id=UUID("22222222-2222-2222-2222-222222222222"))
+
+    monkeypatch.setattr(db_session, "session_scope", make_session_scope())
+    monkeypatch.setattr(tags, "update_tag", fake_update_tag)
+
+    exit_code = cli.main(
+        [
+            "tag",
+            "update",
+            "22222222-2222-2222-2222-222222222222",
+            "--clear-people",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "Updated tag 22222222-2222-2222-2222-222222222222" in captured.out
 
 
 def test_main_timelog_add_creates_timelog(
@@ -219,12 +254,21 @@ def test_main_vision_add_creates_vision(
 ) -> None:
     async def fake_create_vision(session: object, **kwargs: object) -> object:
         assert kwargs["name"] == "Launch lifeos-cli"
+        assert kwargs["person_ids"] == [UUID("11111111-1111-1111-1111-111111111111")]
         return make_record(id=UUID("44444444-4444-4444-4444-444444444444"))
 
     monkeypatch.setattr(db_session, "session_scope", make_session_scope())
     monkeypatch.setattr(visions, "create_vision", fake_create_vision)
 
-    exit_code = cli.main(["vision", "add", "Launch lifeos-cli"])
+    exit_code = cli.main(
+        [
+            "vision",
+            "add",
+            "Launch lifeos-cli",
+            "--person-id",
+            "11111111-1111-1111-1111-111111111111",
+        ]
+    )
     captured = capsys.readouterr()
 
     assert exit_code == 0
@@ -257,6 +301,7 @@ def test_main_task_add_creates_task(
     async def fake_create_task(session: object, **kwargs: object) -> object:
         assert kwargs["content"] == "Draft release checklist"
         assert kwargs["priority"] == 2
+        assert kwargs["person_ids"] == [UUID("11111111-1111-1111-1111-111111111111")]
         return make_record(id=UUID("55555555-5555-5555-5555-555555555555"))
 
     monkeypatch.setattr(db_session, "session_scope", make_session_scope())
@@ -271,6 +316,8 @@ def test_main_task_add_creates_task(
             "66666666-6666-6666-6666-666666666666",
             "--priority",
             "2",
+            "--person-id",
+            "11111111-1111-1111-1111-111111111111",
         ]
     )
     captured = capsys.readouterr()
@@ -335,6 +382,32 @@ def test_main_task_update_can_clear_parent(
             "update",
             "55555555-5555-5555-5555-555555555555",
             "--clear-parent",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "Updated task 55555555-5555-5555-5555-555555555555" in captured.out
+
+
+def test_main_task_update_can_clear_people(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    async def fake_update_task(session: object, **kwargs: object) -> object:
+        assert kwargs["clear_people"] is True
+        assert kwargs["person_ids"] is None
+        return make_record(id=UUID("55555555-5555-5555-5555-555555555555"))
+
+    monkeypatch.setattr(db_session, "session_scope", make_session_scope())
+    monkeypatch.setattr(tasks, "update_task", fake_update_task)
+
+    exit_code = cli.main(
+        [
+            "task",
+            "update",
+            "55555555-5555-5555-5555-555555555555",
+            "--clear-people",
         ]
     )
     captured = capsys.readouterr()

--- a/tests/test_cli_domains.py
+++ b/tests/test_cli_domains.py
@@ -6,7 +6,7 @@ import pytest
 
 from lifeos_cli import cli
 from lifeos_cli.db import session as db_session
-from lifeos_cli.db.services import areas, people, tags, tasks, visions
+from lifeos_cli.db.services import areas, habit_actions, habits, people, tags, tasks, visions
 from tests.support import make_record, make_session_scope, utc_datetime
 
 
@@ -327,3 +327,78 @@ def test_main_people_batch_delete_reports_missing_ids(
     assert exit_code == 1
     assert "Deleted people: 0" in captured.out
     assert "Failed person IDs" in captured.err
+
+
+def test_main_habit_add_creates_habit(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    async def fake_create_habit(session: object, **kwargs: object) -> object:
+        assert kwargs["title"] == "Daily Exercise"
+        assert str(kwargs["start_date"]) == "2026-04-09"
+        assert kwargs["duration_days"] == 21
+        return make_record(id=UUID("77777777-7777-7777-7777-777777777777"))
+
+    monkeypatch.setattr(db_session, "session_scope", make_session_scope())
+    monkeypatch.setattr(habits, "create_habit", fake_create_habit)
+
+    exit_code = cli.main(
+        [
+            "habit",
+            "add",
+            "Daily Exercise",
+            "--start-date",
+            "2026-04-09",
+            "--duration-days",
+            "21",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "Created habit 77777777-7777-7777-7777-777777777777" in captured.out
+
+
+def test_main_habit_update_rejects_conflicting_clear_task_flags(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = cli.main(
+        [
+            "habit",
+            "update",
+            "77777777-7777-7777-7777-777777777777",
+            "--task-id",
+            "11111111-1111-1111-1111-111111111111",
+            "--clear-task",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "Use either --task-id or --clear-task, not both." in captured.err
+
+
+def test_main_habit_action_update_can_clear_notes(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    async def fake_update_habit_action(session: object, **kwargs: object) -> object:
+        assert kwargs["clear_notes"] is True
+        assert kwargs["notes"] is None
+        return make_record(id=UUID("88888888-8888-8888-8888-888888888888"))
+
+    monkeypatch.setattr(db_session, "session_scope", make_session_scope())
+    monkeypatch.setattr(habit_actions, "update_habit_action", fake_update_habit_action)
+
+    exit_code = cli.main(
+        [
+            "habit-action",
+            "update",
+            "88888888-8888-8888-8888-888888888888",
+            "--clear-notes",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "Updated habit action 88888888-8888-8888-8888-888888888888" in captured.out

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -422,6 +422,18 @@ def test_real_cli_core_resource_workflow(integration_context: IntegrationContext
     )
     _assert_ok(people_update_result)
 
+    area_people_result = _run_lifeos(
+        integration_context,
+        "area",
+        "update",
+        area_one_id,
+        "--person-id",
+        person_one_id,
+        "--person-id",
+        person_two_id,
+    )
+    _assert_ok(area_people_result)
+
     tag_one_result = _run_lifeos(
         integration_context,
         "tag",
@@ -464,6 +476,16 @@ def test_real_cli_core_resource_workflow(integration_context: IntegrationContext
     )
     _assert_ok(tag_update_result)
 
+    tag_people_result = _run_lifeos(
+        integration_context,
+        "tag",
+        "update",
+        tag_one_id,
+        "--person-id",
+        person_one_id,
+    )
+    _assert_ok(tag_people_result)
+
     tag_clear_result = _run_lifeos(
         integration_context,
         "tag",
@@ -474,8 +496,50 @@ def test_real_cli_core_resource_workflow(integration_context: IntegrationContext
     )
     _assert_ok(tag_clear_result)
 
+    vision_people_result = _run_lifeos(
+        integration_context,
+        "vision",
+        "update",
+        vision_one_id,
+        "--person-id",
+        person_one_id,
+        "--person-id",
+        person_two_id,
+    )
+    _assert_ok(vision_people_result)
+
+    task_people_result = _run_lifeos(
+        integration_context,
+        "task",
+        "update",
+        task_one_id,
+        "--person-id",
+        person_one_id,
+    )
+    _assert_ok(task_people_result)
+
     assert area_one_id in _run_lifeos(integration_context, "area", "list").stdout
+    assert (
+        area_one_id
+        in _run_lifeos(
+            integration_context,
+            "area",
+            "list",
+            "--person-id",
+            person_one_id,
+        ).stdout
+    )
     assert vision_one_id in _run_lifeos(integration_context, "vision", "list").stdout
+    assert (
+        vision_one_id
+        in _run_lifeos(
+            integration_context,
+            "vision",
+            "list",
+            "--person-id",
+            person_two_id,
+        ).stdout
+    )
     assert (
         task_one_id
         in _run_lifeos(
@@ -484,6 +548,16 @@ def test_real_cli_core_resource_workflow(integration_context: IntegrationContext
             "list",
             "--vision-id",
             vision_one_id,
+        ).stdout
+    )
+    assert (
+        task_one_id
+        in _run_lifeos(
+            integration_context,
+            "task",
+            "list",
+            "--person-id",
+            person_one_id,
         ).stdout
     )
     assert (
@@ -506,6 +580,37 @@ def test_real_cli_core_resource_workflow(integration_context: IntegrationContext
             "person",
         ).stdout
     )
+    assert (
+        tag_one_id
+        in _run_lifeos(
+            integration_context,
+            "tag",
+            "list",
+            "--person-id",
+            person_one_id,
+        ).stdout
+    )
+
+    area_show_with_people_result = _run_lifeos(integration_context, "area", "show", area_one_id)
+    _assert_ok(area_show_with_people_result)
+    assert "people: Alice, Bob" in area_show_with_people_result.stdout
+
+    vision_show_with_people_result = _run_lifeos(
+        integration_context,
+        "vision",
+        "show",
+        vision_one_id,
+    )
+    _assert_ok(vision_show_with_people_result)
+    assert "people: Alice, Bob" in vision_show_with_people_result.stdout
+
+    task_show_with_people_result = _run_lifeos(integration_context, "task", "show", task_one_id)
+    _assert_ok(task_show_with_people_result)
+    assert "people: Alice" in task_show_with_people_result.stdout
+
+    tag_show_with_people_result = _run_lifeos(integration_context, "tag", "show", tag_one_id)
+    _assert_ok(tag_show_with_people_result)
+    assert "people: Alice" in tag_show_with_people_result.stdout
 
     people_delete_result = _run_lifeos(
         integration_context,

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -260,6 +260,87 @@ def test_real_cli_structured_resource_workflow(integration_context: IntegrationC
         tag_id in _run_lifeos(integration_context, "tag", "list", "--entity-type", "person").stdout
     )
 
+
+def test_real_cli_habit_workflow(integration_context: IntegrationContext) -> None:
+    init_result = _run_lifeos(
+        integration_context,
+        "init",
+        "--non-interactive",
+        "--database-url",
+        integration_context.database_url,
+        "--schema",
+        integration_context.schema,
+    )
+    assert init_result.returncode == 0, init_result.stderr
+
+    vision_result = _run_lifeos(integration_context, "vision", "add", "Improve fitness")
+    assert vision_result.returncode == 0, vision_result.stderr
+    vision_id = _extract_created_id(vision_result.stdout)
+
+    task_result = _run_lifeos(
+        integration_context,
+        "task",
+        "add",
+        "Exercise consistently",
+        "--vision-id",
+        vision_id,
+    )
+    assert task_result.returncode == 0, task_result.stderr
+    task_id = _extract_created_id(task_result.stdout)
+
+    habit_result = _run_lifeos(
+        integration_context,
+        "habit",
+        "add",
+        "Daily Exercise",
+        "--start-date",
+        "2026-04-09",
+        "--duration-days",
+        "21",
+        "--task-id",
+        task_id,
+    )
+    assert habit_result.returncode == 0, habit_result.stderr
+    habit_id = _extract_created_id(habit_result.stdout)
+
+    habit_list_result = _run_lifeos(integration_context, "habit", "list", "--with-stats")
+    assert habit_list_result.returncode == 0, habit_list_result.stderr
+    assert habit_id in habit_list_result.stdout
+    assert "Daily Exercise" in habit_list_result.stdout
+
+    habit_show_result = _run_lifeos(integration_context, "habit", "show", habit_id)
+    assert habit_show_result.returncode == 0, habit_show_result.stderr
+    assert f"id: {habit_id}" in habit_show_result.stdout
+    assert "total_actions: 21" in habit_show_result.stdout
+
+    action_list_result = _run_lifeos(
+        integration_context,
+        "habit-action",
+        "list",
+        "--habit-id",
+        habit_id,
+    )
+    assert action_list_result.returncode == 0, action_list_result.stderr
+    action_id = _extract_created_id(action_list_result.stdout)
+
+    action_update_result = _run_lifeos(
+        integration_context,
+        "habit-action",
+        "update",
+        action_id,
+        "--status",
+        "done",
+        "--notes",
+        "Completed before work",
+    )
+    assert action_update_result.returncode == 0, action_update_result.stderr
+    assert f"Updated habit action {action_id}" in action_update_result.stdout
+
+    action_show_result = _run_lifeos(integration_context, "habit-action", "show", action_id)
+    assert action_show_result.returncode == 0, action_show_result.stderr
+    assert "status: done" in action_show_result.stdout
+    assert "notes: Completed before work" in action_show_result.stdout
+
     task_show_result = _run_lifeos(integration_context, "task", "show", task_id)
     assert task_show_result.returncode == 0, task_show_result.stderr
     assert f"id: {task_id}" in task_show_result.stdout

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -68,6 +68,15 @@ def _run_lifeos(
     )
 
 
+def _assert_ok(result: subprocess.CompletedProcess[str]) -> None:
+    assert result.returncode == 0, result.stderr
+
+
+def _assert_missing(result: subprocess.CompletedProcess[str], record_label: str) -> None:
+    assert result.returncode == 1
+    assert record_label in result.stderr
+
+
 def _extract_created_id(output: str) -> str:
     match = _ID_PATTERN.search(output)
     if match is None:
@@ -89,6 +98,21 @@ def _drop_schema(database_url: str, schema_name: str) -> None:
             cursor.execute(
                 sql.SQL("DROP SCHEMA IF EXISTS {} CASCADE").format(sql.Identifier(schema_name))
             )
+
+
+def _init_context(context: IntegrationContext) -> None:
+    init_result = _run_lifeos(
+        context,
+        "init",
+        "--non-interactive",
+        "--database-url",
+        context.database_url,
+        "--schema",
+        context.schema,
+    )
+    _assert_ok(init_result)
+    assert "Database connection succeeded." in init_result.stdout
+    assert "Database migrations are up to date." in init_result.stdout
 
 
 @pytest.fixture
@@ -114,117 +138,254 @@ def integration_context(tmp_path: Path) -> Iterator[IntegrationContext]:
 
 
 def test_real_cli_init_and_db_commands(integration_context: IntegrationContext) -> None:
-    init_result = _run_lifeos(
-        integration_context,
-        "init",
-        "--non-interactive",
-        "--database-url",
-        integration_context.database_url,
-        "--schema",
-        integration_context.schema,
-    )
-    assert init_result.returncode == 0, init_result.stderr
-    assert "Database connection succeeded." in init_result.stdout
-    assert "Database migrations are up to date." in init_result.stdout
+    _init_context(integration_context)
+
     assert integration_context.config_path.exists()
     assert integration_context.schema in integration_context.config_path.read_text(encoding="utf-8")
 
     ping_result = _run_lifeos(integration_context, "db", "ping")
-    assert ping_result.returncode == 0, ping_result.stderr
+    _assert_ok(ping_result)
     assert "Database connection succeeded." in ping_result.stdout
 
     upgrade_result = _run_lifeos(integration_context, "db", "upgrade")
-    assert upgrade_result.returncode == 0, upgrade_result.stderr
+    _assert_ok(upgrade_result)
     assert "Database migrations are up to date." in upgrade_result.stdout
+
+    config_result = _run_lifeos(integration_context, "config", "show")
+    _assert_ok(config_result)
+    assert integration_context.schema in config_result.stdout
 
 
 def test_real_cli_note_workflow(integration_context: IntegrationContext) -> None:
-    init_result = _run_lifeos(
-        integration_context,
-        "init",
-        "--non-interactive",
-        "--database-url",
-        integration_context.database_url,
-        "--schema",
-        integration_context.schema,
-    )
-    assert init_result.returncode == 0, init_result.stderr
+    _init_context(integration_context)
 
-    add_result = _run_lifeos(integration_context, "note", "add", "integration note")
-    assert add_result.returncode == 0, add_result.stderr
-    note_id = _extract_created_id(add_result.stdout)
+    first_add_result = _run_lifeos(integration_context, "note", "add", "integration note")
+    _assert_ok(first_add_result)
+    first_note_id = _extract_created_id(first_add_result.stdout)
+
+    second_add_result = _run_lifeos(
+        integration_context,
+        "note",
+        "add",
+        "--stdin",
+        input_text="first line\nsecond line\n",
+    )
+    _assert_ok(second_add_result)
+    second_note_id = _extract_created_id(second_add_result.stdout)
 
     list_result = _run_lifeos(integration_context, "note", "list")
-    assert list_result.returncode == 0, list_result.stderr
-    assert note_id in list_result.stdout
-    assert "integration note" in list_result.stdout
+    _assert_ok(list_result)
+    assert first_note_id in list_result.stdout
+    assert second_note_id in list_result.stdout
 
-    show_result = _run_lifeos(integration_context, "note", "show", note_id)
-    assert show_result.returncode == 0, show_result.stderr
-    assert f"id: {note_id}" in show_result.stdout
-    assert "content:\nintegration note" in show_result.stdout
+    show_result = _run_lifeos(integration_context, "note", "show", second_note_id)
+    _assert_ok(show_result)
+    assert f"id: {second_note_id}" in show_result.stdout
+    assert "content:\nfirst line\nsecond line" in show_result.stdout
+
+    update_result = _run_lifeos(
+        integration_context,
+        "note",
+        "update",
+        first_note_id,
+        "integration note updated",
+    )
+    _assert_ok(update_result)
+    assert f"Updated note {first_note_id}" in update_result.stdout
 
     search_result = _run_lifeos(integration_context, "note", "search", "integration")
-    assert search_result.returncode == 0, search_result.stderr
-    assert note_id in search_result.stdout
+    _assert_ok(search_result)
+    assert first_note_id in search_result.stdout
 
-    delete_result = _run_lifeos(integration_context, "note", "delete", note_id)
-    assert delete_result.returncode == 0, delete_result.stderr
-    assert f"Soft-deleted note {note_id}" in delete_result.stdout
+    batch_update_result = _run_lifeos(
+        integration_context,
+        "note",
+        "batch",
+        "update-content",
+        "--ids",
+        first_note_id,
+        second_note_id,
+        "--find-text",
+        "line",
+        "--replace-text",
+        "entry",
+    )
+    _assert_ok(batch_update_result)
+    assert "Updated notes: 1" in batch_update_result.stdout
 
-    default_list_result = _run_lifeos(integration_context, "note", "list")
-    assert default_list_result.returncode == 0, default_list_result.stderr
-    assert note_id not in default_list_result.stdout
+    updated_multiline_result = _run_lifeos(integration_context, "note", "show", second_note_id)
+    _assert_ok(updated_multiline_result)
+    assert "content:\nfirst entry\nsecond entry" in updated_multiline_result.stdout
+
+    delete_result = _run_lifeos(integration_context, "note", "delete", first_note_id)
+    _assert_ok(delete_result)
+    assert f"Soft-deleted note {first_note_id}" in delete_result.stdout
+
+    batch_delete_result = _run_lifeos(
+        integration_context,
+        "note",
+        "batch",
+        "delete",
+        "--ids",
+        second_note_id,
+    )
+    _assert_ok(batch_delete_result)
+    assert "Deleted notes: 1" in batch_delete_result.stdout
 
     deleted_list_result = _run_lifeos(integration_context, "note", "list", "--include-deleted")
-    assert deleted_list_result.returncode == 0, deleted_list_result.stderr
-    assert note_id in deleted_list_result.stdout
+    _assert_ok(deleted_list_result)
+    assert first_note_id in deleted_list_result.stdout
+    assert second_note_id in deleted_list_result.stdout
     assert "deleted" in deleted_list_result.stdout
 
-
-def test_real_cli_structured_resource_workflow(integration_context: IntegrationContext) -> None:
-    init_result = _run_lifeos(
+    missing_show_result = _run_lifeos(
         integration_context,
-        "init",
-        "--non-interactive",
-        "--database-url",
-        integration_context.database_url,
-        "--schema",
-        integration_context.schema,
+        "note",
+        "show",
+        "00000000-0000-0000-0000-000000000000",
     )
-    assert init_result.returncode == 0, init_result.stderr
+    _assert_missing(missing_show_result, "00000000-0000-0000-0000-000000000000")
 
-    area_result = _run_lifeos(integration_context, "area", "add", "Health")
-    assert area_result.returncode == 0, area_result.stderr
-    area_id = _extract_created_id(area_result.stdout)
 
-    vision_result = _run_lifeos(
+def test_real_cli_core_resource_workflow(integration_context: IntegrationContext) -> None:
+    _init_context(integration_context)
+
+    area_one_result = _run_lifeos(integration_context, "area", "add", "Health")
+    _assert_ok(area_one_result)
+    area_one_id = _extract_created_id(area_one_result.stdout)
+
+    area_two_result = _run_lifeos(
+        integration_context,
+        "area",
+        "add",
+        "Work",
+        "--inactive",
+    )
+    _assert_ok(area_two_result)
+    area_two_id = _extract_created_id(area_two_result.stdout)
+
+    area_show_result = _run_lifeos(integration_context, "area", "show", area_one_id)
+    _assert_ok(area_show_result)
+    assert f"id: {area_one_id}" in area_show_result.stdout
+
+    area_update_result = _run_lifeos(
+        integration_context,
+        "area",
+        "update",
+        area_one_id,
+        "--description",
+        "Physical wellbeing",
+        "--icon",
+        "heart",
+    )
+    _assert_ok(area_update_result)
+    assert f"Updated area {area_one_id}" in area_update_result.stdout
+
+    area_clear_result = _run_lifeos(
+        integration_context,
+        "area",
+        "update",
+        area_one_id,
+        "--clear-description",
+        "--clear-icon",
+    )
+    _assert_ok(area_clear_result)
+
+    vision_one_result = _run_lifeos(
         integration_context,
         "vision",
         "add",
         "Launch lifeos-cli",
         "--area-id",
-        area_id,
+        area_one_id,
         "--status",
         "active",
     )
-    assert vision_result.returncode == 0, vision_result.stderr
-    vision_id = _extract_created_id(vision_result.stdout)
+    _assert_ok(vision_one_result)
+    vision_one_id = _extract_created_id(vision_one_result.stdout)
 
-    task_result = _run_lifeos(
+    vision_two_result = _run_lifeos(
+        integration_context,
+        "vision",
+        "add",
+        "Improve sleep quality",
+        "--area-id",
+        area_two_id,
+    )
+    _assert_ok(vision_two_result)
+    vision_two_id = _extract_created_id(vision_two_result.stdout)
+
+    vision_show_result = _run_lifeos(integration_context, "vision", "show", vision_one_id)
+    _assert_ok(vision_show_result)
+    assert f"area_id: {area_one_id}" in vision_show_result.stdout
+
+    vision_update_result = _run_lifeos(
+        integration_context,
+        "vision",
+        "update",
+        vision_one_id,
+        "--description",
+        "Deliver the first production-ready release",
+        "--status",
+        "fruit",
+    )
+    _assert_ok(vision_update_result)
+
+    vision_clear_result = _run_lifeos(
+        integration_context,
+        "vision",
+        "update",
+        vision_one_id,
+        "--clear-description",
+        "--clear-area",
+    )
+    _assert_ok(vision_clear_result)
+
+    task_one_result = _run_lifeos(
         integration_context,
         "task",
         "add",
         "Draft release checklist",
         "--vision-id",
-        vision_id,
+        vision_one_id,
         "--status",
         "todo",
     )
-    assert task_result.returncode == 0, task_result.stderr
-    task_id = _extract_created_id(task_result.stdout)
+    _assert_ok(task_one_result)
+    task_one_id = _extract_created_id(task_one_result.stdout)
 
-    people_result = _run_lifeos(
+    task_two_result = _run_lifeos(
+        integration_context,
+        "task",
+        "add",
+        "Write changelog",
+        "--vision-id",
+        vision_one_id,
+        "--parent-task-id",
+        task_one_id,
+        "--estimated-effort",
+        "45",
+    )
+    _assert_ok(task_two_result)
+    task_two_id = _extract_created_id(task_two_result.stdout)
+
+    task_show_result = _run_lifeos(integration_context, "task", "show", task_two_id)
+    _assert_ok(task_show_result)
+    assert f"parent_task_id: {task_one_id}" in task_show_result.stdout
+
+    task_update_result = _run_lifeos(
+        integration_context,
+        "task",
+        "update",
+        task_two_id,
+        "--status",
+        "in_progress",
+        "--clear-parent",
+        "--clear-estimated-effort",
+    )
+    _assert_ok(task_update_result)
+
+    person_one_result = _run_lifeos(
         integration_context,
         "people",
         "add",
@@ -232,10 +393,36 @@ def test_real_cli_structured_resource_workflow(integration_context: IntegrationC
         "--location",
         "Toronto",
     )
-    assert people_result.returncode == 0, people_result.stderr
-    person_id = _extract_created_id(people_result.stdout)
+    _assert_ok(person_one_result)
+    person_one_id = _extract_created_id(person_one_result.stdout)
 
-    tag_result = _run_lifeos(
+    person_two_result = _run_lifeos(
+        integration_context,
+        "people",
+        "add",
+        "Bob",
+        "--location",
+        "Montreal",
+    )
+    _assert_ok(person_two_result)
+    person_two_id = _extract_created_id(person_two_result.stdout)
+
+    person_show_result = _run_lifeos(integration_context, "people", "show", person_one_id)
+    _assert_ok(person_show_result)
+    assert "location: Toronto" in person_show_result.stdout
+
+    people_update_result = _run_lifeos(
+        integration_context,
+        "people",
+        "update",
+        person_one_id,
+        "--nickname",
+        "ally",
+        "--clear-location",
+    )
+    _assert_ok(people_update_result)
+
+    tag_one_result = _run_lifeos(
         integration_context,
         "tag",
         "add",
@@ -245,36 +432,179 @@ def test_real_cli_structured_resource_workflow(integration_context: IntegrationC
         "--category",
         "relation",
     )
-    assert tag_result.returncode == 0, tag_result.stderr
-    tag_id = _extract_created_id(tag_result.stdout)
+    _assert_ok(tag_one_result)
+    tag_one_id = _extract_created_id(tag_one_result.stdout)
 
-    assert area_id in _run_lifeos(integration_context, "area", "list").stdout
+    tag_two_result = _run_lifeos(
+        integration_context,
+        "tag",
+        "add",
+        "friend",
+        "--entity-type",
+        "person",
+        "--category",
+        "relation",
+    )
+    _assert_ok(tag_two_result)
+    tag_two_id = _extract_created_id(tag_two_result.stdout)
+
+    tag_show_result = _run_lifeos(integration_context, "tag", "show", tag_one_id)
+    _assert_ok(tag_show_result)
+    assert "entity_type: person" in tag_show_result.stdout
+
+    tag_update_result = _run_lifeos(
+        integration_context,
+        "tag",
+        "update",
+        tag_one_id,
+        "--description",
+        "Relationship marker",
+        "--color",
+        "#22C55E",
+    )
+    _assert_ok(tag_update_result)
+
+    tag_clear_result = _run_lifeos(
+        integration_context,
+        "tag",
+        "update",
+        tag_one_id,
+        "--clear-description",
+        "--clear-color",
+    )
+    _assert_ok(tag_clear_result)
+
+    assert area_one_id in _run_lifeos(integration_context, "area", "list").stdout
+    assert vision_one_id in _run_lifeos(integration_context, "vision", "list").stdout
     assert (
-        vision_id in _run_lifeos(integration_context, "vision", "list", "--status", "active").stdout
+        task_one_id
+        in _run_lifeos(
+            integration_context,
+            "task",
+            "list",
+            "--vision-id",
+            vision_one_id,
+        ).stdout
     )
     assert (
-        task_id in _run_lifeos(integration_context, "task", "list", "--vision-id", vision_id).stdout
+        person_one_id
+        in _run_lifeos(
+            integration_context,
+            "people",
+            "list",
+            "--search",
+            "Ali",
+        ).stdout
     )
-    assert person_id in _run_lifeos(integration_context, "people", "list").stdout
     assert (
-        tag_id in _run_lifeos(integration_context, "tag", "list", "--entity-type", "person").stdout
+        tag_one_id
+        in _run_lifeos(
+            integration_context,
+            "tag",
+            "list",
+            "--entity-type",
+            "person",
+        ).stdout
     )
+
+    people_delete_result = _run_lifeos(
+        integration_context,
+        "people",
+        "delete",
+        person_one_id,
+    )
+    _assert_ok(people_delete_result)
+    assert f"Soft-deleted person {person_one_id}" in people_delete_result.stdout
+
+    people_batch_delete_result = _run_lifeos(
+        integration_context,
+        "people",
+        "batch",
+        "delete",
+        "--ids",
+        person_two_id,
+    )
+    _assert_ok(people_batch_delete_result)
+    assert "Deleted people: 1" in people_batch_delete_result.stdout
+
+    tag_delete_result = _run_lifeos(integration_context, "tag", "delete", tag_one_id)
+    _assert_ok(tag_delete_result)
+    assert f"Soft-deleted tag {tag_one_id}" in tag_delete_result.stdout
+
+    tag_batch_delete_result = _run_lifeos(
+        integration_context,
+        "tag",
+        "batch",
+        "delete",
+        "--ids",
+        tag_two_id,
+    )
+    _assert_ok(tag_batch_delete_result)
+    assert "Deleted tags: 1" in tag_batch_delete_result.stdout
+
+    task_delete_result = _run_lifeos(integration_context, "task", "delete", task_two_id)
+    _assert_ok(task_delete_result)
+    assert f"Soft-deleted task {task_two_id}" in task_delete_result.stdout
+
+    task_batch_delete_result = _run_lifeos(
+        integration_context,
+        "task",
+        "batch",
+        "delete",
+        "--ids",
+        task_one_id,
+    )
+    _assert_ok(task_batch_delete_result)
+    assert "Deleted tasks: 1" in task_batch_delete_result.stdout
+
+    vision_delete_result = _run_lifeos(integration_context, "vision", "delete", vision_one_id)
+    _assert_ok(vision_delete_result)
+    assert f"Soft-deleted vision {vision_one_id}" in vision_delete_result.stdout
+
+    vision_batch_delete_result = _run_lifeos(
+        integration_context,
+        "vision",
+        "batch",
+        "delete",
+        "--ids",
+        vision_two_id,
+    )
+    _assert_ok(vision_batch_delete_result)
+    assert "Deleted visions: 1" in vision_batch_delete_result.stdout
+
+    area_delete_result = _run_lifeos(integration_context, "area", "delete", area_one_id)
+    _assert_ok(area_delete_result)
+    assert f"Soft-deleted area {area_one_id}" in area_delete_result.stdout
+
+    area_batch_delete_result = _run_lifeos(
+        integration_context,
+        "area",
+        "batch",
+        "delete",
+        "--ids",
+        area_two_id,
+    )
+    _assert_ok(area_batch_delete_result)
+    assert "Deleted areas: 1" in area_batch_delete_result.stdout
+
+    deleted_area_result = _run_lifeos(
+        integration_context,
+        "area",
+        "list",
+        "--include-deleted",
+        "--include-inactive",
+    )
+    _assert_ok(deleted_area_result)
+    assert area_one_id in deleted_area_result.stdout
+    assert area_two_id in deleted_area_result.stdout
+    assert "deleted" in deleted_area_result.stdout
 
 
 def test_real_cli_habit_workflow(integration_context: IntegrationContext) -> None:
-    init_result = _run_lifeos(
-        integration_context,
-        "init",
-        "--non-interactive",
-        "--database-url",
-        integration_context.database_url,
-        "--schema",
-        integration_context.schema,
-    )
-    assert init_result.returncode == 0, init_result.stderr
+    _init_context(integration_context)
 
     vision_result = _run_lifeos(integration_context, "vision", "add", "Improve fitness")
-    assert vision_result.returncode == 0, vision_result.stderr
+    _assert_ok(vision_result)
     vision_id = _extract_created_id(vision_result.stdout)
 
     task_result = _run_lifeos(
@@ -285,10 +615,10 @@ def test_real_cli_habit_workflow(integration_context: IntegrationContext) -> Non
         "--vision-id",
         vision_id,
     )
-    assert task_result.returncode == 0, task_result.stderr
+    _assert_ok(task_result)
     task_id = _extract_created_id(task_result.stdout)
 
-    habit_result = _run_lifeos(
+    first_habit_result = _run_lifeos(
         integration_context,
         "habit",
         "add",
@@ -300,28 +630,83 @@ def test_real_cli_habit_workflow(integration_context: IntegrationContext) -> Non
         "--task-id",
         task_id,
     )
-    assert habit_result.returncode == 0, habit_result.stderr
-    habit_id = _extract_created_id(habit_result.stdout)
+    _assert_ok(first_habit_result)
+    first_habit_id = _extract_created_id(first_habit_result.stdout)
+
+    second_habit_result = _run_lifeos(
+        integration_context,
+        "habit",
+        "add",
+        "Morning Review",
+        "--start-date",
+        "2026-04-09",
+        "--duration-days",
+        "100",
+    )
+    _assert_ok(second_habit_result)
+    second_habit_id = _extract_created_id(second_habit_result.stdout)
 
     habit_list_result = _run_lifeos(integration_context, "habit", "list", "--with-stats")
-    assert habit_list_result.returncode == 0, habit_list_result.stderr
-    assert habit_id in habit_list_result.stdout
-    assert "Daily Exercise" in habit_list_result.stdout
+    _assert_ok(habit_list_result)
+    assert first_habit_id in habit_list_result.stdout
+    assert second_habit_id in habit_list_result.stdout
 
-    habit_show_result = _run_lifeos(integration_context, "habit", "show", habit_id)
-    assert habit_show_result.returncode == 0, habit_show_result.stderr
-    assert f"id: {habit_id}" in habit_show_result.stdout
+    habit_show_result = _run_lifeos(integration_context, "habit", "show", first_habit_id)
+    _assert_ok(habit_show_result)
+    assert f"id: {first_habit_id}" in habit_show_result.stdout
     assert "total_actions: 21" in habit_show_result.stdout
+
+    task_association_result = _run_lifeos(
+        integration_context,
+        "habit",
+        "task-associations",
+    )
+    _assert_ok(task_association_result)
+    assert first_habit_id in task_association_result.stdout
+    assert task_id in task_association_result.stdout
+
+    habit_update_result = _run_lifeos(
+        integration_context,
+        "habit",
+        "update",
+        first_habit_id,
+        "--description",
+        "Move every day",
+        "--status",
+        "paused",
+    )
+    _assert_ok(habit_update_result)
+    assert f"Updated habit {first_habit_id}" in habit_update_result.stdout
+
+    habit_clear_result = _run_lifeos(
+        integration_context,
+        "habit",
+        "update",
+        first_habit_id,
+        "--clear-description",
+        "--clear-task",
+        "--status",
+        "active",
+    )
+    _assert_ok(habit_clear_result)
+
+    habit_stats_result = _run_lifeos(integration_context, "habit", "stats", first_habit_id)
+    _assert_ok(habit_stats_result)
+    assert f"habit_id: {first_habit_id}" in habit_stats_result.stdout
 
     action_list_result = _run_lifeos(
         integration_context,
         "habit-action",
         "list",
         "--habit-id",
-        habit_id,
+        first_habit_id,
     )
-    assert action_list_result.returncode == 0, action_list_result.stderr
+    _assert_ok(action_list_result)
     action_id = _extract_created_id(action_list_result.stdout)
+
+    action_show_result = _run_lifeos(integration_context, "habit-action", "show", action_id)
+    _assert_ok(action_show_result)
+    assert f"id: {action_id}" in action_show_result.stdout
 
     action_update_result = _run_lifeos(
         integration_context,
@@ -333,54 +718,61 @@ def test_real_cli_habit_workflow(integration_context: IntegrationContext) -> Non
         "--notes",
         "Completed before work",
     )
-    assert action_update_result.returncode == 0, action_update_result.stderr
+    _assert_ok(action_update_result)
     assert f"Updated habit action {action_id}" in action_update_result.stdout
 
-    action_show_result = _run_lifeos(integration_context, "habit-action", "show", action_id)
-    assert action_show_result.returncode == 0, action_show_result.stderr
-    assert "status: done" in action_show_result.stdout
-    assert "notes: Completed before work" in action_show_result.stdout
-
-    task_show_result = _run_lifeos(integration_context, "task", "show", task_id)
-    assert task_show_result.returncode == 0, task_show_result.stderr
-    assert f"id: {task_id}" in task_show_result.stdout
-    assert f"vision_id: {vision_id}" in task_show_result.stdout
-
-    delete_result = _run_lifeos(integration_context, "task", "batch", "delete", "--ids", task_id)
-    assert delete_result.returncode == 0, delete_result.stderr
-    assert "Deleted tasks: 1" in delete_result.stdout
-
-    deleted_result = _run_lifeos(
+    action_clear_result = _run_lifeos(
         integration_context,
-        "task",
-        "list",
-        "--vision-id",
-        vision_id,
-        "--include-deleted",
+        "habit-action",
+        "update",
+        action_id,
+        "--status",
+        "skip",
+        "--clear-notes",
     )
-    assert deleted_result.returncode == 0, deleted_result.stderr
-    assert task_id in deleted_result.stdout
-    assert "deleted" in deleted_result.stdout
+    _assert_ok(action_clear_result)
+
+    action_date_result = _run_lifeos(
+        integration_context,
+        "habit-action",
+        "list",
+        "--action-date",
+        "2026-04-09",
+    )
+    _assert_ok(action_date_result)
+    assert action_id in action_date_result.stdout
+
+    habit_delete_result = _run_lifeos(integration_context, "habit", "delete", first_habit_id)
+    _assert_ok(habit_delete_result)
+    assert f"Soft-deleted habit {first_habit_id}" in habit_delete_result.stdout
+
+    habit_batch_delete_result = _run_lifeos(
+        integration_context,
+        "habit",
+        "batch",
+        "delete",
+        "--ids",
+        second_habit_id,
+    )
+    _assert_ok(habit_batch_delete_result)
+    assert "Deleted habits: 1" in habit_batch_delete_result.stdout
+
+    deleted_habit_result = _run_lifeos(integration_context, "habit", "list", "--include-deleted")
+    _assert_ok(deleted_habit_result)
+    assert first_habit_id in deleted_habit_result.stdout
+    assert second_habit_id in deleted_habit_result.stdout
+    assert "deleted" in deleted_habit_result.stdout
 
 
 def test_real_cli_event_and_timelog_workflow(integration_context: IntegrationContext) -> None:
-    init_result = _run_lifeos(
-        integration_context,
-        "init",
-        "--non-interactive",
-        "--database-url",
-        integration_context.database_url,
-        "--schema",
-        integration_context.schema,
-    )
-    assert init_result.returncode == 0, init_result.stderr
+    _init_context(integration_context)
 
     area_result = _run_lifeos(integration_context, "area", "add", "Health")
-    assert area_result.returncode == 0, area_result.stderr
+    _assert_ok(area_result)
     area_id = _extract_created_id(area_result.stdout)
 
     vision_result = _run_lifeos(integration_context, "vision", "add", "Improve fitness")
-    assert vision_result.returncode == 0, vision_result.stderr
+    _assert_ok(vision_result)
     vision_id = _extract_created_id(vision_result.stdout)
 
     task_result = _run_lifeos(
@@ -391,11 +783,11 @@ def test_real_cli_event_and_timelog_workflow(integration_context: IntegrationCon
         "--vision-id",
         vision_id,
     )
-    assert task_result.returncode == 0, task_result.stderr
+    _assert_ok(task_result)
     task_id = _extract_created_id(task_result.stdout)
 
     person_result = _run_lifeos(integration_context, "people", "add", "Coach")
-    assert person_result.returncode == 0, person_result.stderr
+    _assert_ok(person_result)
     person_id = _extract_created_id(person_result.stdout)
 
     event_tag_result = _run_lifeos(
@@ -408,7 +800,7 @@ def test_real_cli_event_and_timelog_workflow(integration_context: IntegrationCon
         "--category",
         "context",
     )
-    assert event_tag_result.returncode == 0, event_tag_result.stderr
+    _assert_ok(event_tag_result)
     event_tag_id = _extract_created_id(event_tag_result.stdout)
 
     timelog_tag_result = _run_lifeos(
@@ -421,10 +813,10 @@ def test_real_cli_event_and_timelog_workflow(integration_context: IntegrationCon
         "--category",
         "context",
     )
-    assert timelog_tag_result.returncode == 0, timelog_tag_result.stderr
+    _assert_ok(timelog_tag_result)
     timelog_tag_id = _extract_created_id(timelog_tag_result.stdout)
 
-    event_result = _run_lifeos(
+    first_event_result = _run_lifeos(
         integration_context,
         "event",
         "add",
@@ -442,8 +834,21 @@ def test_real_cli_event_and_timelog_workflow(integration_context: IntegrationCon
         "--tag-id",
         event_tag_id,
     )
-    assert event_result.returncode == 0, event_result.stderr
-    event_id = _extract_created_id(event_result.stdout)
+    _assert_ok(first_event_result)
+    first_event_id = _extract_created_id(first_event_result.stdout)
+
+    second_event_result = _run_lifeos(
+        integration_context,
+        "event",
+        "add",
+        "Recovery block",
+        "--start-time",
+        "2026-04-10T18:00:00-04:00",
+        "--end-time",
+        "2026-04-10T19:00:00-04:00",
+    )
+    _assert_ok(second_event_result)
+    second_event_id = _extract_created_id(second_event_result.stdout)
 
     event_list_result = _run_lifeos(
         integration_context,
@@ -452,11 +857,11 @@ def test_real_cli_event_and_timelog_workflow(integration_context: IntegrationCon
         "--task-id",
         task_id,
     )
-    assert event_list_result.returncode == 0, event_list_result.stderr
-    assert event_id in event_list_result.stdout
+    _assert_ok(event_list_result)
+    assert first_event_id in event_list_result.stdout
 
-    event_show_result = _run_lifeos(integration_context, "event", "show", event_id)
-    assert event_show_result.returncode == 0, event_show_result.stderr
+    event_show_result = _run_lifeos(integration_context, "event", "show", first_event_id)
+    _assert_ok(event_show_result)
     assert "people: Coach" in event_show_result.stdout
     assert "tags: calendar" in event_show_result.stdout
 
@@ -464,15 +869,25 @@ def test_real_cli_event_and_timelog_workflow(integration_context: IntegrationCon
         integration_context,
         "event",
         "update",
-        event_id,
+        first_event_id,
         "--status",
         "completed",
         "--clear-task",
+        "--clear-area",
+        "--clear-tags",
+        "--clear-people",
+        "--clear-end-time",
     )
-    assert event_update_result.returncode == 0, event_update_result.stderr
-    assert f"Updated event {event_id}" in event_update_result.stdout
+    _assert_ok(event_update_result)
 
-    timelog_result = _run_lifeos(
+    updated_event_result = _run_lifeos(integration_context, "event", "show", first_event_id)
+    _assert_ok(updated_event_result)
+    assert "task_id: -" in updated_event_result.stdout
+    assert "area_id: -" in updated_event_result.stdout
+    assert "tags: -" in updated_event_result.stdout
+    assert "people: -" in updated_event_result.stdout
+
+    first_timelog_result = _run_lifeos(
         integration_context,
         "timelog",
         "add",
@@ -492,8 +907,21 @@ def test_real_cli_event_and_timelog_workflow(integration_context: IntegrationCon
         "--energy-level",
         "4",
     )
-    assert timelog_result.returncode == 0, timelog_result.stderr
-    timelog_id = _extract_created_id(timelog_result.stdout)
+    _assert_ok(first_timelog_result)
+    first_timelog_id = _extract_created_id(first_timelog_result.stdout)
+
+    second_timelog_result = _run_lifeos(
+        integration_context,
+        "timelog",
+        "add",
+        "Stretching",
+        "--start-time",
+        "2026-04-10T19:10:00-04:00",
+        "--end-time",
+        "2026-04-10T19:25:00-04:00",
+    )
+    _assert_ok(second_timelog_result)
+    second_timelog_id = _extract_created_id(second_timelog_result.stdout)
 
     timelog_list_result = _run_lifeos(
         integration_context,
@@ -504,11 +932,12 @@ def test_real_cli_event_and_timelog_workflow(integration_context: IntegrationCon
         "--window-end",
         "2026-04-10T23:59:59-04:00",
     )
-    assert timelog_list_result.returncode == 0, timelog_list_result.stderr
-    assert timelog_id in timelog_list_result.stdout
+    _assert_ok(timelog_list_result)
+    assert first_timelog_id in timelog_list_result.stdout
+    assert second_timelog_id in timelog_list_result.stdout
 
-    timelog_show_result = _run_lifeos(integration_context, "timelog", "show", timelog_id)
-    assert timelog_show_result.returncode == 0, timelog_show_result.stderr
+    timelog_show_result = _run_lifeos(integration_context, "timelog", "show", first_timelog_id)
+    _assert_ok(timelog_show_result)
     assert "people: Coach" in timelog_show_result.stdout
     assert "tags: tracked" in timelog_show_result.stdout
 
@@ -516,19 +945,81 @@ def test_real_cli_event_and_timelog_workflow(integration_context: IntegrationCon
         integration_context,
         "timelog",
         "update",
-        timelog_id,
+        first_timelog_id,
         "--notes",
         "Felt strong",
         "--clear-task",
+        "--clear-area",
+        "--clear-tags",
+        "--clear-people",
+        "--clear-energy-level",
     )
-    assert timelog_update_result.returncode == 0, timelog_update_result.stderr
-    assert f"Updated timelog {timelog_id}" in timelog_update_result.stdout
+    _assert_ok(timelog_update_result)
 
-    timelog_delete_result = _run_lifeos(integration_context, "timelog", "delete", timelog_id)
-    assert timelog_delete_result.returncode == 0, timelog_delete_result.stderr
-    assert f"Soft-deleted timelog {timelog_id}" in timelog_delete_result.stdout
+    updated_timelog_result = _run_lifeos(
+        integration_context,
+        "timelog",
+        "show",
+        first_timelog_id,
+    )
+    _assert_ok(updated_timelog_result)
+    assert "task_id: -" in updated_timelog_result.stdout
+    assert "area_id: -" in updated_timelog_result.stdout
+    assert "tags: -" in updated_timelog_result.stdout
+    assert "people: -" in updated_timelog_result.stdout
 
-    timelog_deleted_list = _run_lifeos(
+    event_delete_result = _run_lifeos(
+        integration_context,
+        "event",
+        "delete",
+        first_event_id,
+    )
+    _assert_ok(event_delete_result)
+    assert f"Soft-deleted event {first_event_id}" in event_delete_result.stdout
+
+    event_batch_delete_result = _run_lifeos(
+        integration_context,
+        "event",
+        "batch",
+        "delete",
+        "--ids",
+        second_event_id,
+    )
+    _assert_ok(event_batch_delete_result)
+    assert "Deleted events: 1" in event_batch_delete_result.stdout
+
+    timelog_delete_result = _run_lifeos(
+        integration_context,
+        "timelog",
+        "delete",
+        first_timelog_id,
+    )
+    _assert_ok(timelog_delete_result)
+    assert f"Soft-deleted timelog {first_timelog_id}" in timelog_delete_result.stdout
+
+    timelog_batch_delete_result = _run_lifeos(
+        integration_context,
+        "timelog",
+        "batch",
+        "delete",
+        "--ids",
+        second_timelog_id,
+    )
+    _assert_ok(timelog_batch_delete_result)
+    assert "Deleted timelogs: 1" in timelog_batch_delete_result.stdout
+
+    deleted_event_result = _run_lifeos(
+        integration_context,
+        "event",
+        "list",
+        "--include-deleted",
+    )
+    _assert_ok(deleted_event_result)
+    assert first_event_id in deleted_event_result.stdout
+    assert second_event_id in deleted_event_result.stdout
+    assert "deleted" in deleted_event_result.stdout
+
+    deleted_timelog_result = _run_lifeos(
         integration_context,
         "timelog",
         "list",
@@ -538,6 +1029,7 @@ def test_real_cli_event_and_timelog_workflow(integration_context: IntegrationCon
         "--window-end",
         "2026-04-10T23:59:59-04:00",
     )
-    assert timelog_deleted_list.returncode == 0, timelog_deleted_list.stderr
-    assert timelog_id in timelog_deleted_list.stdout
-    assert "deleted" in timelog_deleted_list.stdout
+    _assert_ok(deleted_timelog_result)
+    assert first_timelog_id in deleted_timelog_result.stdout
+    assert second_timelog_id in deleted_timelog_result.stdout
+    assert "deleted" in deleted_timelog_result.stdout

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -361,3 +361,183 @@ def test_real_cli_habit_workflow(integration_context: IntegrationContext) -> Non
     assert deleted_result.returncode == 0, deleted_result.stderr
     assert task_id in deleted_result.stdout
     assert "deleted" in deleted_result.stdout
+
+
+def test_real_cli_event_and_timelog_workflow(integration_context: IntegrationContext) -> None:
+    init_result = _run_lifeos(
+        integration_context,
+        "init",
+        "--non-interactive",
+        "--database-url",
+        integration_context.database_url,
+        "--schema",
+        integration_context.schema,
+    )
+    assert init_result.returncode == 0, init_result.stderr
+
+    area_result = _run_lifeos(integration_context, "area", "add", "Health")
+    assert area_result.returncode == 0, area_result.stderr
+    area_id = _extract_created_id(area_result.stdout)
+
+    vision_result = _run_lifeos(integration_context, "vision", "add", "Improve fitness")
+    assert vision_result.returncode == 0, vision_result.stderr
+    vision_id = _extract_created_id(vision_result.stdout)
+
+    task_result = _run_lifeos(
+        integration_context,
+        "task",
+        "add",
+        "Morning run",
+        "--vision-id",
+        vision_id,
+    )
+    assert task_result.returncode == 0, task_result.stderr
+    task_id = _extract_created_id(task_result.stdout)
+
+    person_result = _run_lifeos(integration_context, "people", "add", "Coach")
+    assert person_result.returncode == 0, person_result.stderr
+    person_id = _extract_created_id(person_result.stdout)
+
+    event_tag_result = _run_lifeos(
+        integration_context,
+        "tag",
+        "add",
+        "calendar",
+        "--entity-type",
+        "event",
+        "--category",
+        "context",
+    )
+    assert event_tag_result.returncode == 0, event_tag_result.stderr
+    event_tag_id = _extract_created_id(event_tag_result.stdout)
+
+    timelog_tag_result = _run_lifeos(
+        integration_context,
+        "tag",
+        "add",
+        "tracked",
+        "--entity-type",
+        "timelog",
+        "--category",
+        "context",
+    )
+    assert timelog_tag_result.returncode == 0, timelog_tag_result.stderr
+    timelog_tag_id = _extract_created_id(timelog_tag_result.stdout)
+
+    event_result = _run_lifeos(
+        integration_context,
+        "event",
+        "add",
+        "Morning run block",
+        "--start-time",
+        "2026-04-10T07:00:00-04:00",
+        "--end-time",
+        "2026-04-10T07:45:00-04:00",
+        "--area-id",
+        area_id,
+        "--task-id",
+        task_id,
+        "--person-id",
+        person_id,
+        "--tag-id",
+        event_tag_id,
+    )
+    assert event_result.returncode == 0, event_result.stderr
+    event_id = _extract_created_id(event_result.stdout)
+
+    event_list_result = _run_lifeos(
+        integration_context,
+        "event",
+        "list",
+        "--task-id",
+        task_id,
+    )
+    assert event_list_result.returncode == 0, event_list_result.stderr
+    assert event_id in event_list_result.stdout
+
+    event_show_result = _run_lifeos(integration_context, "event", "show", event_id)
+    assert event_show_result.returncode == 0, event_show_result.stderr
+    assert "people: Coach" in event_show_result.stdout
+    assert "tags: calendar" in event_show_result.stdout
+
+    event_update_result = _run_lifeos(
+        integration_context,
+        "event",
+        "update",
+        event_id,
+        "--status",
+        "completed",
+        "--clear-task",
+    )
+    assert event_update_result.returncode == 0, event_update_result.stderr
+    assert f"Updated event {event_id}" in event_update_result.stdout
+
+    timelog_result = _run_lifeos(
+        integration_context,
+        "timelog",
+        "add",
+        "Morning run",
+        "--start-time",
+        "2026-04-10T07:02:00-04:00",
+        "--end-time",
+        "2026-04-10T07:41:00-04:00",
+        "--area-id",
+        area_id,
+        "--task-id",
+        task_id,
+        "--person-id",
+        person_id,
+        "--tag-id",
+        timelog_tag_id,
+        "--energy-level",
+        "4",
+    )
+    assert timelog_result.returncode == 0, timelog_result.stderr
+    timelog_id = _extract_created_id(timelog_result.stdout)
+
+    timelog_list_result = _run_lifeos(
+        integration_context,
+        "timelog",
+        "list",
+        "--window-start",
+        "2026-04-10T00:00:00-04:00",
+        "--window-end",
+        "2026-04-10T23:59:59-04:00",
+    )
+    assert timelog_list_result.returncode == 0, timelog_list_result.stderr
+    assert timelog_id in timelog_list_result.stdout
+
+    timelog_show_result = _run_lifeos(integration_context, "timelog", "show", timelog_id)
+    assert timelog_show_result.returncode == 0, timelog_show_result.stderr
+    assert "people: Coach" in timelog_show_result.stdout
+    assert "tags: tracked" in timelog_show_result.stdout
+
+    timelog_update_result = _run_lifeos(
+        integration_context,
+        "timelog",
+        "update",
+        timelog_id,
+        "--notes",
+        "Felt strong",
+        "--clear-task",
+    )
+    assert timelog_update_result.returncode == 0, timelog_update_result.stderr
+    assert f"Updated timelog {timelog_id}" in timelog_update_result.stdout
+
+    timelog_delete_result = _run_lifeos(integration_context, "timelog", "delete", timelog_id)
+    assert timelog_delete_result.returncode == 0, timelog_delete_result.stderr
+    assert f"Soft-deleted timelog {timelog_id}" in timelog_delete_result.stdout
+
+    timelog_deleted_list = _run_lifeos(
+        integration_context,
+        "timelog",
+        "list",
+        "--include-deleted",
+        "--window-start",
+        "2026-04-10T00:00:00-04:00",
+        "--window-end",
+        "2026-04-10T23:59:59-04:00",
+    )
+    assert timelog_deleted_list.returncode == 0, timelog_deleted_list.stderr
+    assert timelog_id in timelog_deleted_list.stdout
+    assert "deleted" in timelog_deleted_list.stdout

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -85,8 +85,9 @@ def test_cli_top_level_help_describes_command_grammar(capsys) -> None:
 
     assert "lifeos <resource> <action> [arguments] [options]" in captured.out
     assert "resources:" in captured.out
-    assert "init      Initialize local configuration" in captured.out
-    assert "people    Manage people and relationships" in captured.out
+    assert "init          Initialize local configuration" in captured.out
+    assert "people        Manage people and relationships" in captured.out
+    assert "habit-action  Manage dated habit actions" in captured.out
     assert 'lifeos note add "Capture an idea"' in captured.out
 
 
@@ -243,6 +244,59 @@ def test_cli_parser_supports_task_update_clear_parent_command() -> None:
     assert args.clear_parent is True
 
 
+def test_cli_parser_supports_habit_add_command() -> None:
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "habit",
+            "add",
+            "Daily Exercise",
+            "--start-date",
+            "2026-04-09",
+            "--duration-days",
+            "21",
+        ]
+    )
+
+    assert args.resource == "habit"
+    assert args.habit_command == "add"
+    assert args.title == "Daily Exercise"
+    assert args.duration_days == 21
+
+
+def test_cli_parser_supports_habit_update_clear_task_command() -> None:
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "habit",
+            "update",
+            "11111111-1111-1111-1111-111111111111",
+            "--clear-task",
+        ]
+    )
+
+    assert args.resource == "habit"
+    assert args.habit_command == "update"
+    assert str(args.habit_id) == "11111111-1111-1111-1111-111111111111"
+    assert args.clear_task is True
+
+
+def test_cli_parser_supports_habit_action_list_by_date_command() -> None:
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "habit-action",
+            "list",
+            "--action-date",
+            "2026-04-09",
+        ]
+    )
+
+    assert args.resource == "habit-action"
+    assert args.habit_action_command == "list"
+    assert str(args.action_date) == "2026-04-09"
+
+
 @pytest.mark.parametrize(
     ("argv",),
     [
@@ -312,6 +366,18 @@ def test_cli_parser_supports_task_update_clear_parent_command() -> None:
                 "--hard",
             ],
         ),
+        (["habit", "delete", "11111111-1111-1111-1111-111111111111", "--hard"],),
+        (
+            [
+                "habit",
+                "batch",
+                "delete",
+                "--ids",
+                "11111111-1111-1111-1111-111111111111",
+                "--hard",
+            ],
+        ),
+        (["habit-action", "delete", "11111111-1111-1111-1111-111111111111", "--hard"],),
     ],
 )
 def test_cli_parser_rejects_hard_delete_flags(argv: list[str]) -> None:

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -86,8 +86,10 @@ def test_cli_top_level_help_describes_command_grammar(capsys) -> None:
     assert "lifeos <resource> <action> [arguments] [options]" in captured.out
     assert "resources:" in captured.out
     assert "init          Initialize local configuration" in captured.out
+    assert "event         Manage planned schedule events" in captured.out
     assert "people        Manage people and relationships" in captured.out
     assert "habit-action  Manage dated habit actions" in captured.out
+    assert "timelog       Manage actual time records" in captured.out
     assert 'lifeos note add "Capture an idea"' in captured.out
 
 
@@ -115,6 +117,26 @@ def test_cli_parser_supports_area_update_clear_icon_command() -> None:
     assert args.resource == "area"
     assert args.area_command == "update"
     assert args.clear_icon is True
+
+
+def test_cli_parser_supports_event_add_command() -> None:
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "event",
+            "add",
+            "Doctor appointment",
+            "--start-time",
+            "2026-04-10T09:00:00-04:00",
+            "--person-id",
+            "11111111-1111-1111-1111-111111111111",
+        ]
+    )
+
+    assert args.resource == "event"
+    assert args.event_command == "add"
+    assert args.title == "Doctor appointment"
+    assert len(args.person_ids) == 1
 
 
 def test_cli_parser_supports_people_add_command() -> None:
@@ -162,6 +184,28 @@ def test_cli_parser_supports_task_add_command() -> None:
     assert args.content == "Draft release checklist"
     assert str(args.vision_id) == "11111111-1111-1111-1111-111111111111"
     assert args.priority == 3
+
+
+def test_cli_parser_supports_timelog_add_command() -> None:
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "timelog",
+            "add",
+            "Deep work",
+            "--start-time",
+            "2026-04-10T13:00:00-04:00",
+            "--end-time",
+            "2026-04-10T14:30:00-04:00",
+            "--tracking-method",
+            "manual",
+        ]
+    )
+
+    assert args.resource == "timelog"
+    assert args.timelog_command == "add"
+    assert args.title == "Deep work"
+    assert args.tracking_method == "manual"
 
 
 def test_cli_parser_supports_vision_update_clear_area_command() -> None:
@@ -297,6 +341,38 @@ def test_cli_parser_supports_habit_action_list_by_date_command() -> None:
     assert str(args.action_date) == "2026-04-09"
 
 
+def test_cli_parser_supports_event_update_clear_people_command() -> None:
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "event",
+            "update",
+            "11111111-1111-1111-1111-111111111111",
+            "--clear-people",
+        ]
+    )
+
+    assert args.resource == "event"
+    assert args.event_command == "update"
+    assert args.clear_people is True
+
+
+def test_cli_parser_supports_timelog_update_clear_notes_command() -> None:
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "timelog",
+            "update",
+            "11111111-1111-1111-1111-111111111111",
+            "--clear-notes",
+        ]
+    )
+
+    assert args.resource == "timelog"
+    assert args.timelog_command == "update"
+    assert args.clear_notes is True
+
+
 @pytest.mark.parametrize(
     ("argv",),
     [
@@ -378,6 +454,28 @@ def test_cli_parser_supports_habit_action_list_by_date_command() -> None:
             ],
         ),
         (["habit-action", "delete", "11111111-1111-1111-1111-111111111111", "--hard"],),
+        (["event", "delete", "11111111-1111-1111-1111-111111111111", "--hard"],),
+        (
+            [
+                "event",
+                "batch",
+                "delete",
+                "--ids",
+                "11111111-1111-1111-1111-111111111111",
+                "--hard",
+            ],
+        ),
+        (["timelog", "delete", "11111111-1111-1111-1111-111111111111", "--hard"],),
+        (
+            [
+                "timelog",
+                "batch",
+                "delete",
+                "--ids",
+                "11111111-1111-1111-1111-111111111111",
+                "--hard",
+            ],
+        ),
     ],
 )
 def test_cli_parser_rejects_hard_delete_flags(argv: list[str]) -> None:

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -85,7 +85,8 @@ def test_cli_top_level_help_describes_command_grammar(capsys) -> None:
 
     assert "lifeos <resource> <action> [arguments] [options]" in captured.out
     assert "resources:" in captured.out
-    assert "init          Initialize local configuration" in captured.out
+    assert "init" in captured.out
+    assert "Initialize local configuration" in captured.out
     assert "event         Manage planned schedule events" in captured.out
     assert "people        Manage people and relationships" in captured.out
     assert "habit-action  Manage dated habit actions" in captured.out

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -87,10 +87,14 @@ def test_cli_top_level_help_describes_command_grammar(capsys) -> None:
     assert "resources:" in captured.out
     assert "init" in captured.out
     assert "Initialize local configuration" in captured.out
-    assert "event         Manage planned schedule events" in captured.out
-    assert "people        Manage people and relationships" in captured.out
-    assert "habit-action  Manage dated habit actions" in captured.out
-    assert "timelog       Manage actual time records" in captured.out
+    assert "event" in captured.out
+    assert "Manage planned schedule events" in captured.out
+    assert "people" in captured.out
+    assert "Manage people and relationships" in captured.out
+    assert "habit-action" in captured.out
+    assert "Manage dated habit actions" in captured.out
+    assert "timelog" in captured.out
+    assert "Manage actual time records" in captured.out
     assert 'lifeos note add "Capture an idea"' in captured.out
 
 

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -95,12 +95,23 @@ def test_cli_top_level_help_describes_command_grammar(capsys) -> None:
 
 def test_cli_parser_supports_area_add_command() -> None:
     parser = build_parser()
-    args = parser.parse_args(["area", "add", "Health", "--display-order", "2"])
+    args = parser.parse_args(
+        [
+            "area",
+            "add",
+            "Health",
+            "--display-order",
+            "2",
+            "--person-id",
+            "11111111-1111-1111-1111-111111111111",
+        ]
+    )
 
     assert args.resource == "area"
     assert args.area_command == "add"
     assert args.name == "Health"
     assert args.display_order == 2
+    assert len(args.person_ids) == 1
 
 
 def test_cli_parser_supports_area_update_clear_icon_command() -> None:
@@ -186,6 +197,22 @@ def test_cli_parser_supports_task_add_command() -> None:
     assert args.priority == 3
 
 
+def test_cli_parser_supports_task_list_person_filter() -> None:
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "task",
+            "list",
+            "--person-id",
+            "11111111-1111-1111-1111-111111111111",
+        ]
+    )
+
+    assert args.resource == "task"
+    assert args.task_command == "list"
+    assert str(args.person_id) == "11111111-1111-1111-1111-111111111111"
+
+
 def test_cli_parser_supports_timelog_add_command() -> None:
     parser = build_parser()
     args = parser.parse_args(
@@ -224,6 +251,22 @@ def test_cli_parser_supports_vision_update_clear_area_command() -> None:
     assert args.clear_area is True
 
 
+def test_cli_parser_supports_vision_update_clear_people_command() -> None:
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "vision",
+            "update",
+            "11111111-1111-1111-1111-111111111111",
+            "--clear-people",
+        ]
+    )
+
+    assert args.resource == "vision"
+    assert args.vision_command == "update"
+    assert args.clear_people is True
+
+
 def test_cli_vision_update_help_lists_valid_statuses(capsys) -> None:
     parser = build_parser()
 
@@ -250,6 +293,22 @@ def test_cli_parser_supports_tag_update_clear_color_command() -> None:
     assert args.resource == "tag"
     assert args.tag_command == "update"
     assert args.clear_color is True
+
+
+def test_cli_parser_supports_tag_list_person_filter() -> None:
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "tag",
+            "list",
+            "--person-id",
+            "11111111-1111-1111-1111-111111111111",
+        ]
+    )
+
+    assert args.resource == "tag"
+    assert args.tag_command == "list"
+    assert str(args.person_id) == "11111111-1111-1111-1111-111111111111"
 
 
 def test_cli_parser_supports_task_batch_delete_command() -> None:
@@ -286,6 +345,22 @@ def test_cli_parser_supports_task_update_clear_parent_command() -> None:
     assert args.task_command == "update"
     assert str(args.task_id) == "11111111-1111-1111-1111-111111111111"
     assert args.clear_parent is True
+
+
+def test_cli_parser_supports_task_update_clear_people_command() -> None:
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "task",
+            "update",
+            "11111111-1111-1111-1111-111111111111",
+            "--clear-people",
+        ]
+    )
+
+    assert args.resource == "task"
+    assert args.task_command == "update"
+    assert args.clear_people is True
 
 
 def test_cli_parser_supports_habit_add_command() -> None:

--- a/tests/test_domain_services.py
+++ b/tests/test_domain_services.py
@@ -9,7 +9,15 @@ from uuid import UUID
 
 import pytest
 
-from lifeos_cli.db.services import areas, people, tags, task_mutations, tasks, visions
+from lifeos_cli.db.services import (
+    areas,
+    habits,
+    people,
+    tags,
+    task_mutations,
+    tasks,
+    visions,
+)
 
 
 def test_create_person_flushes_without_committing(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -383,4 +391,88 @@ def test_update_vision_can_clear_optional_fields(monkeypatch: pytest.MonkeyPatch
     assert updated_vision.area_id is None
     assert updated_vision.experience_rate_per_hour is None
     session.flush.assert_awaited_once()
+    session.commit.assert_not_called()
+
+
+def test_create_habit_generates_actions_without_committing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = SimpleNamespace(
+        add=None,
+        flush=AsyncMock(),
+        refresh=AsyncMock(),
+        commit=AsyncMock(),
+    )
+    added_records: list[object] = []
+
+    def fake_add(record: object) -> None:
+        if getattr(record, "id", None) is None:
+            cast(Any, record).id = UUID("99999999-9999-9999-9999-999999999999")
+        added_records.append(record)
+
+    async def fake_ensure_active_capacity(_: object, **__: object) -> None:
+        return None
+
+    async def fake_ensure_task_exists(_: object, __: UUID | None) -> None:
+        return None
+
+    async def fake_refresh_habit_expiration(_: object, *, habit_id: UUID | None = None) -> int:
+        assert habit_id == UUID("99999999-9999-9999-9999-999999999999")
+        return 0
+
+    session.add = fake_add
+    monkeypatch.setattr(habits, "ensure_active_capacity", fake_ensure_active_capacity)
+    monkeypatch.setattr(habits, "ensure_task_exists", fake_ensure_task_exists)
+    monkeypatch.setattr(habits, "refresh_habit_expiration", fake_refresh_habit_expiration)
+
+    habit = asyncio.run(
+        habits.create_habit(
+            cast(Any, session),
+            title="Daily Exercise",
+            start_date=date(2026, 4, 9),
+            duration_days=7,
+        )
+    )
+
+    assert habit.title == "Daily Exercise"
+    assert len(added_records) == 8
+    session.flush.assert_awaited()
+    session.commit.assert_not_called()
+
+
+def test_update_habit_can_clear_task_without_committing(monkeypatch: pytest.MonkeyPatch) -> None:
+    habit = SimpleNamespace(
+        id=UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        title="Daily Exercise",
+        description="Move every day",
+        start_date=date(2026, 4, 9),
+        duration_days=21,
+        status="active",
+        task_id=UUID("11111111-1111-1111-1111-111111111111"),
+    )
+    session = SimpleNamespace(flush=AsyncMock(), refresh=AsyncMock(), commit=AsyncMock())
+
+    async def fake_get_habit(_: object, *, habit_id: UUID, include_deleted: bool = False) -> object:
+        assert habit_id == UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+        assert include_deleted is False
+        return habit
+
+    async def fake_refresh_habit_expiration(_: object, *, habit_id: UUID | None = None) -> int:
+        assert habit_id == UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+        return 0
+
+    monkeypatch.setattr(habits, "get_habit", fake_get_habit)
+    monkeypatch.setattr(habits, "refresh_habit_expiration", fake_refresh_habit_expiration)
+
+    updated_habit = asyncio.run(
+        habits.update_habit(
+            cast(Any, session),
+            habit_id=UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+            clear_task=True,
+        )
+    )
+
+    assert updated_habit.task_id is None
+    session.flush.assert_awaited_once()
+    session.refresh.assert_awaited_once_with(habit)
     session.commit.assert_not_called()

--- a/tests/test_domain_services.py
+++ b/tests/test_domain_services.py
@@ -11,13 +11,16 @@ import pytest
 
 from lifeos_cli.db.services import (
     areas,
+    events,
     habits,
     people,
     tags,
     task_mutations,
     tasks,
+    timelogs,
     visions,
 )
+from tests.support import utc_datetime
 
 
 def test_create_person_flushes_without_committing(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -41,6 +44,83 @@ def test_create_person_flushes_without_committing(monkeypatch: pytest.MonkeyPatc
     person = asyncio.run(people.create_person(cast(Any, session), name="Alice"))
 
     assert person.name == "Alice"
+    session.flush.assert_awaited_once()
+    session.commit.assert_not_called()
+
+
+def test_create_event_flushes_without_committing(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = SimpleNamespace(
+        add=None,
+        flush=AsyncMock(),
+        refresh=AsyncMock(),
+        commit=AsyncMock(),
+    )
+
+    def fake_add(event: object) -> None:
+        session.added_event = event
+
+    async def fake_ensure_area_exists(_: object, __: UUID | None) -> None:
+        return None
+
+    async def fake_ensure_task_exists(_: object, __: UUID | None) -> None:
+        return None
+
+    async def fake_attach_event_links(_: object, event: object) -> object:
+        return event
+
+    session.add = fake_add
+    monkeypatch.setattr(events, "ensure_event_area_exists", fake_ensure_area_exists)
+    monkeypatch.setattr(events, "ensure_event_task_exists", fake_ensure_task_exists)
+    monkeypatch.setattr(events, "_attach_event_links", fake_attach_event_links)
+
+    event = asyncio.run(
+        events.create_event(
+            cast(Any, session),
+            title="Doctor appointment",
+            start_time=utc_datetime(2026, 4, 10, 13, 0),
+        )
+    )
+
+    assert event.title == "Doctor appointment"
+    session.flush.assert_awaited_once()
+    session.commit.assert_not_called()
+
+
+def test_create_timelog_flushes_without_committing(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = SimpleNamespace(
+        add=None,
+        flush=AsyncMock(),
+        refresh=AsyncMock(),
+        commit=AsyncMock(),
+    )
+
+    def fake_add(timelog: object) -> None:
+        session.added_timelog = timelog
+
+    async def fake_ensure_area_exists(_: object, __: UUID | None) -> None:
+        return None
+
+    async def fake_ensure_task_exists(_: object, __: UUID | None) -> None:
+        return None
+
+    async def fake_attach_timelog_links(_: object, timelog: object) -> object:
+        return timelog
+
+    session.add = fake_add
+    monkeypatch.setattr(timelogs, "ensure_timelog_area_exists", fake_ensure_area_exists)
+    monkeypatch.setattr(timelogs, "ensure_timelog_task_exists", fake_ensure_task_exists)
+    monkeypatch.setattr(timelogs, "_attach_timelog_links", fake_attach_timelog_links)
+
+    timelog = asyncio.run(
+        timelogs.create_timelog(
+            cast(Any, session),
+            title="Deep work",
+            start_time=utc_datetime(2026, 4, 10, 13, 0),
+            end_time=utc_datetime(2026, 4, 10, 14, 0),
+        )
+    )
+
+    assert timelog.title == "Deep work"
     session.flush.assert_awaited_once()
     session.commit.assert_not_called()
 
@@ -475,4 +555,121 @@ def test_update_habit_can_clear_task_without_committing(monkeypatch: pytest.Monk
     assert updated_habit.task_id is None
     session.flush.assert_awaited_once()
     session.refresh.assert_awaited_once_with(habit)
+    session.commit.assert_not_called()
+
+
+def test_update_event_can_clear_optional_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    event = SimpleNamespace(
+        id=UUID("abababab-abab-abab-abab-abababababab"),
+        title="Doctor appointment",
+        description="Checkup",
+        start_time=utc_datetime(2026, 4, 10, 9, 0),
+        end_time=utc_datetime(2026, 4, 10, 10, 0),
+        priority=3,
+        status="planned",
+        is_all_day=False,
+        area_id=UUID("11111111-1111-1111-1111-111111111111"),
+        task_id=UUID("22222222-2222-2222-2222-222222222222"),
+    )
+    session = SimpleNamespace(flush=AsyncMock(), refresh=AsyncMock(), commit=AsyncMock())
+
+    async def fake_get_event(_: object, *, event_id: UUID, include_deleted: bool = False) -> object:
+        assert event_id == UUID("abababab-abab-abab-abab-abababababab")
+        assert include_deleted is False
+        return event
+
+    async def fake_attach_event_links(_: object, event_record: object) -> object:
+        return event_record
+
+    async def fake_sync_tags(_: object, **__: object) -> None:
+        return None
+
+    async def fake_sync_people(_: object, **__: object) -> None:
+        return None
+
+    monkeypatch.setattr(events, "get_event", fake_get_event)
+    monkeypatch.setattr(events, "_attach_event_links", fake_attach_event_links)
+    monkeypatch.setattr(events, "sync_entity_tags", fake_sync_tags)
+    monkeypatch.setattr(events, "sync_entity_people", fake_sync_people)
+
+    updated_event = asyncio.run(
+        events.update_event(
+            cast(Any, session),
+            event_id=UUID("abababab-abab-abab-abab-abababababab"),
+            clear_description=True,
+            clear_end_time=True,
+            clear_area=True,
+            clear_task=True,
+            clear_tags=True,
+            clear_people=True,
+        )
+    )
+
+    assert updated_event.description is None
+    assert updated_event.end_time is None
+    assert updated_event.area_id is None
+    assert updated_event.task_id is None
+    session.flush.assert_awaited_once()
+    session.commit.assert_not_called()
+
+
+def test_update_timelog_can_clear_optional_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    timelog = SimpleNamespace(
+        id=UUID("cdcdcdcd-cdcd-cdcd-cdcd-cdcdcdcdcdcd"),
+        title="Deep work",
+        start_time=utc_datetime(2026, 4, 10, 13, 0),
+        end_time=utc_datetime(2026, 4, 10, 14, 0),
+        tracking_method="manual",
+        location="Desk",
+        energy_level=4,
+        notes="Focused",
+        area_id=UUID("11111111-1111-1111-1111-111111111111"),
+        task_id=UUID("22222222-2222-2222-2222-222222222222"),
+    )
+    session = SimpleNamespace(flush=AsyncMock(), refresh=AsyncMock(), commit=AsyncMock())
+
+    async def fake_get_timelog(
+        _: object,
+        *,
+        timelog_id: UUID,
+        include_deleted: bool = False,
+    ) -> object:
+        assert timelog_id == UUID("cdcdcdcd-cdcd-cdcd-cdcd-cdcdcdcdcdcd")
+        assert include_deleted is False
+        return timelog
+
+    async def fake_attach_timelog_links(_: object, timelog_record: object) -> object:
+        return timelog_record
+
+    async def fake_sync_tags(_: object, **__: object) -> None:
+        return None
+
+    async def fake_sync_people(_: object, **__: object) -> None:
+        return None
+
+    monkeypatch.setattr(timelogs, "get_timelog", fake_get_timelog)
+    monkeypatch.setattr(timelogs, "_attach_timelog_links", fake_attach_timelog_links)
+    monkeypatch.setattr(timelogs, "sync_entity_tags", fake_sync_tags)
+    monkeypatch.setattr(timelogs, "sync_entity_people", fake_sync_people)
+
+    updated_timelog = asyncio.run(
+        timelogs.update_timelog(
+            cast(Any, session),
+            timelog_id=UUID("cdcdcdcd-cdcd-cdcd-cdcd-cdcdcdcdcdcd"),
+            clear_location=True,
+            clear_energy_level=True,
+            clear_notes=True,
+            clear_area=True,
+            clear_task=True,
+            clear_tags=True,
+            clear_people=True,
+        )
+    )
+
+    assert updated_timelog.location is None
+    assert updated_timelog.energy_level is None
+    assert updated_timelog.notes is None
+    assert updated_timelog.area_id is None
+    assert updated_timelog.task_id is None
+    session.flush.assert_awaited_once()
     session.commit.assert_not_called()

--- a/tests/test_domain_services.py
+++ b/tests/test_domain_services.py
@@ -157,8 +157,13 @@ def test_create_task_flushes_without_committing(monkeypatch: pytest.MonkeyPatch)
     def fake_add(task: object) -> None:
         session.added_task = task
 
+    async def fake_load_people(_: object, **kwargs: object) -> dict[UUID, list[object]]:
+        task_id = cast(Any, session.added_task).id
+        return {task_id: []} if task_id is not None else {}
+
     monkeypatch.setattr(task_mutations, "ensure_vision_exists", fake_ensure_vision_exists)
     monkeypatch.setattr(task_mutations, "validate_parent_task", fake_validate_parent_task)
+    monkeypatch.setattr(task_mutations, "load_people_for_entities", fake_load_people)
     session.add = fake_add
 
     task = asyncio.run(
@@ -218,6 +223,11 @@ def test_update_task_can_clear_parent_without_committing(
 
     monkeypatch.setattr(task_mutations, "get_task", fake_get_task)
     monkeypatch.setattr(task_mutations, "validate_parent_task", fake_validate_parent_task)
+    monkeypatch.setattr(
+        task_mutations,
+        "load_people_for_entities",
+        AsyncMock(return_value={task.id: []}),
+    )
 
     updated_task = asyncio.run(
         task_mutations.update_task(
@@ -277,6 +287,11 @@ def test_update_task_can_clear_optional_fields_without_committing(
 
     monkeypatch.setattr(task_mutations, "get_task", fake_get_task)
     monkeypatch.setattr(task_mutations, "validate_parent_task", fake_validate_parent_task)
+    monkeypatch.setattr(
+        task_mutations,
+        "load_people_for_entities",
+        AsyncMock(return_value={task.id: []}),
+    )
 
     updated_task = asyncio.run(
         task_mutations.update_task(
@@ -293,6 +308,74 @@ def test_update_task_can_clear_optional_fields_without_committing(
     assert updated_task.planning_cycle_type is None
     assert updated_task.planning_cycle_days is None
     assert updated_task.planning_cycle_start_date is None
+    session.flush.assert_awaited_once()
+    session.refresh.assert_awaited_once_with(task)
+    session.commit.assert_not_called()
+
+
+def test_update_task_can_clear_people_without_committing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    task = SimpleNamespace(
+        id=UUID("99999999-9999-9999-9999-999999999999"),
+        vision_id=UUID("11111111-1111-1111-1111-111111111111"),
+        parent_task_id=None,
+        content="Existing task",
+        description=None,
+        status="todo",
+        priority=0,
+        display_order=0,
+        estimated_effort=None,
+        planning_cycle_type=None,
+        planning_cycle_days=None,
+        planning_cycle_start_date=None,
+    )
+    session = SimpleNamespace(
+        flush=AsyncMock(),
+        refresh=AsyncMock(),
+        commit=AsyncMock(),
+    )
+
+    async def fake_get_task(
+        _: object,
+        *,
+        task_id: UUID,
+        include_deleted: bool = False,
+    ) -> object:
+        assert task_id == UUID("99999999-9999-9999-9999-999999999999")
+        assert include_deleted is False
+        return task
+
+    async def fake_validate_parent_task(
+        _: object,
+        *,
+        vision_id: UUID,
+        parent_task_id: UUID | None,
+    ) -> None:
+        assert vision_id == UUID("11111111-1111-1111-1111-111111111111")
+        assert parent_task_id is None
+
+    async def fake_sync_people(_: object, **kwargs: object) -> None:
+        assert kwargs["entity_type"] == "task"
+        assert kwargs["desired_person_ids"] == []
+
+    async def fake_load_people(_: object, **kwargs: object) -> dict[UUID, list[object]]:
+        return {task.id: []}
+
+    monkeypatch.setattr(task_mutations, "get_task", fake_get_task)
+    monkeypatch.setattr(task_mutations, "validate_parent_task", fake_validate_parent_task)
+    monkeypatch.setattr(task_mutations, "sync_entity_people", fake_sync_people)
+    monkeypatch.setattr(task_mutations, "load_people_for_entities", fake_load_people)
+
+    updated_task = asyncio.run(
+        task_mutations.update_task(
+            cast(Any, session),
+            task_id=UUID("99999999-9999-9999-9999-999999999999"),
+            clear_people=True,
+        )
+    )
+
+    assert updated_task.people == []
     session.flush.assert_awaited_once()
     session.refresh.assert_awaited_once_with(task)
     session.commit.assert_not_called()
@@ -316,6 +399,11 @@ def test_update_area_can_clear_optional_fields(monkeypatch: pytest.MonkeyPatch) 
         return area
 
     monkeypatch.setattr(areas, "get_area", fake_get_area)
+    monkeypatch.setattr(
+        areas,
+        "load_people_for_entities",
+        AsyncMock(return_value={area.id: []}),
+    )
 
     updated_area = asyncio.run(
         areas.update_area(
@@ -328,6 +416,43 @@ def test_update_area_can_clear_optional_fields(monkeypatch: pytest.MonkeyPatch) 
 
     assert updated_area.description is None
     assert updated_area.icon is None
+    session.flush.assert_awaited_once()
+    session.commit.assert_not_called()
+
+
+def test_create_area_syncs_people_without_committing(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = SimpleNamespace(
+        add=None,
+        flush=AsyncMock(),
+        refresh=AsyncMock(),
+        commit=AsyncMock(),
+        execute=AsyncMock(return_value=SimpleNamespace(scalar_one_or_none=lambda: None)),
+    )
+
+    def fake_add(area: object) -> None:
+        session.added_area = area
+
+    async def fake_sync_people(_: object, **kwargs: object) -> None:
+        assert kwargs["entity_type"] == "area"
+        assert kwargs["desired_person_ids"] == [UUID("11111111-1111-1111-1111-111111111111")]
+
+    async def fake_load_people(_: object, **kwargs: object) -> dict[UUID, list[object]]:
+        area_id = cast(Any, session.added_area).id
+        return {area_id: [SimpleNamespace(name="Alice")]}
+
+    session.add = fake_add
+    monkeypatch.setattr(areas, "sync_entity_people", fake_sync_people)
+    monkeypatch.setattr(areas, "load_people_for_entities", fake_load_people)
+
+    area = asyncio.run(
+        areas.create_area(
+            cast(Any, session),
+            name="Health",
+            person_ids=[UUID("11111111-1111-1111-1111-111111111111")],
+        )
+    )
+
+    assert len(area.people) == 1
     session.flush.assert_awaited_once()
     session.commit.assert_not_called()
 
@@ -354,6 +479,11 @@ def test_update_tag_can_clear_optional_fields(monkeypatch: pytest.MonkeyPatch) -
         return tag
 
     monkeypatch.setattr(tags, "get_tag", fake_get_tag)
+    monkeypatch.setattr(
+        tags,
+        "load_people_for_entities",
+        AsyncMock(return_value={tag.id: []}),
+    )
 
     updated_tag = asyncio.run(
         tags.update_tag(
@@ -366,6 +496,51 @@ def test_update_tag_can_clear_optional_fields(monkeypatch: pytest.MonkeyPatch) -
 
     assert updated_tag.description is None
     assert updated_tag.color is None
+    session.flush.assert_awaited_once()
+    session.commit.assert_not_called()
+
+
+def test_update_tag_can_clear_people(monkeypatch: pytest.MonkeyPatch) -> None:
+    tag = SimpleNamespace(
+        id=UUID("22222222-2222-2222-2222-222222222222"),
+        name="urgent",
+        entity_type="task",
+        category="general",
+        description=None,
+        color=None,
+    )
+    session = SimpleNamespace(
+        flush=AsyncMock(),
+        refresh=AsyncMock(),
+        commit=AsyncMock(),
+        execute=AsyncMock(return_value=SimpleNamespace(scalar_one_or_none=lambda: None)),
+    )
+
+    async def fake_get_tag(_: object, *, tag_id: UUID, include_deleted: bool = False) -> object:
+        assert tag_id == UUID("22222222-2222-2222-2222-222222222222")
+        assert include_deleted is False
+        return tag
+
+    async def fake_sync_people(_: object, **kwargs: object) -> None:
+        assert kwargs["entity_type"] == "tag"
+        assert kwargs["desired_person_ids"] == []
+
+    async def fake_load_people(_: object, **kwargs: object) -> dict[UUID, list[object]]:
+        return {tag.id: []}
+
+    monkeypatch.setattr(tags, "get_tag", fake_get_tag)
+    monkeypatch.setattr(tags, "sync_entity_people", fake_sync_people)
+    monkeypatch.setattr(tags, "load_people_for_entities", fake_load_people)
+
+    updated_tag = asyncio.run(
+        tags.update_tag(
+            cast(Any, session),
+            tag_id=UUID("22222222-2222-2222-2222-222222222222"),
+            clear_people=True,
+        )
+    )
+
+    assert updated_tag.people == []
     session.flush.assert_awaited_once()
     session.commit.assert_not_called()
 
@@ -456,6 +631,11 @@ def test_update_vision_can_clear_optional_fields(monkeypatch: pytest.MonkeyPatch
         return vision
 
     monkeypatch.setattr(visions, "get_vision", fake_get_vision)
+    monkeypatch.setattr(
+        visions,
+        "load_people_for_entities",
+        AsyncMock(return_value={vision.id: []}),
+    )
 
     updated_vision = asyncio.run(
         visions.update_vision(
@@ -470,6 +650,49 @@ def test_update_vision_can_clear_optional_fields(monkeypatch: pytest.MonkeyPatch
     assert updated_vision.description is None
     assert updated_vision.area_id is None
     assert updated_vision.experience_rate_per_hour is None
+    session.flush.assert_awaited_once()
+    session.commit.assert_not_called()
+
+
+def test_create_vision_syncs_people_without_committing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = SimpleNamespace(
+        add=None,
+        flush=AsyncMock(),
+        refresh=AsyncMock(),
+        commit=AsyncMock(),
+        execute=AsyncMock(return_value=SimpleNamespace(scalar_one_or_none=lambda: None)),
+    )
+
+    def fake_add(vision: object) -> None:
+        session.added_vision = vision
+
+    async def fake_ensure_area_exists(_: object, __: UUID | None) -> None:
+        return None
+
+    async def fake_sync_people(_: object, **kwargs: object) -> None:
+        assert kwargs["entity_type"] == "vision"
+        assert kwargs["desired_person_ids"] == [UUID("11111111-1111-1111-1111-111111111111")]
+
+    async def fake_load_people(_: object, **kwargs: object) -> dict[UUID, list[object]]:
+        vision_id = cast(Any, session.added_vision).id
+        return {vision_id: [SimpleNamespace(name="Alice")]}
+
+    session.add = fake_add
+    monkeypatch.setattr(visions, "_ensure_area_exists", fake_ensure_area_exists)
+    monkeypatch.setattr(visions, "sync_entity_people", fake_sync_people)
+    monkeypatch.setattr(visions, "load_people_for_entities", fake_load_people)
+
+    vision = asyncio.run(
+        visions.create_vision(
+            cast(Any, session),
+            name="Launch lifeos-cli",
+            person_ids=[UUID("11111111-1111-1111-1111-111111111111")],
+        )
+    )
+
+    assert len(vision.people) == 1
     session.flush.assert_awaited_once()
     session.commit.assert_not_called()
 


### PR DESCRIPTION
## 概述

本 PR 基于现有 `note`、`area`、`tag`、`people`、`vision`、`task` 等基础，进一步补齐三组能力：

- `habit` / `habit-action`
- `event`
- `timelog`
- 核心资源上的 `person_associations` 扩展

其中时间相关领域统一采用更清晰且对外一致的命名：

- `event`: 计划日程对象
- `timelog`: 实际时间记录对象

Closes #13

## 模块变更

### 1. habit / habit-action

- 引入 `habit` 与 `habit_action` 的 PostgreSQL models 与 Alembic migration
- 实现 async-only services
- 提供顶层 CLI：`lifeos habit ...` / `lifeos habit-action ...`
- 支持 habit 自动生成 action rows、状态更新、统计与 task associations

### 2. event

- 引入 `event` model、service、CLI、文档与测试
- 明确 `event` 语义为计划日程对象，而不是 todo
- 支持 `area` / `task` / `tag` / `people` 关联
- 支持 `add` / `list` / `show` / `update` / `delete` / `batch delete`

### 3. timelog

- 引入 `timelog` model、service、CLI、文档与测试
- 明确 `timelog` 语义为实际时间记录对象
- 支持 `area` / `task` / `tag` / `people` 关联
- 支持 `add` / `list` / `show` / `update` / `delete` / `batch delete`
- 当前先不实现 `event` 与 `timelog` 的深度联动

### 4. person associations 扩展

- 在现有泛化 `person_associations` 基础上，扩展到 `area` / `tag` / `vision` / `task`
- 为这些资源补充 `--person-id` / `--clear-people` 语义
- 为这些资源补充 `list --person-id` 过滤能力
- `show` 详情输出增加关联 people 展示
- guarded purge 路径同步清理这些资源的 `person_associations`

### 5. 维护与边界

- 继续复用 `tag_associations` 与 `person_associations` 的泛化关联方式
- 更新内部 purge 维护脚本，使其支持 `event` / `timelog` / `habit` / `habit-action`，并同步清理关联记录
- 继续保持公共 CLI 仅支持软删除，不暴露硬删除

### 6. 文档与 CLI help

- 更新 `README.md`
- 更新 `docs/cli.md`
- 更新顶层 help 与资源级 help，使 `task / event / timelog / habit / habit-action` 的语义与示例保持一致
- 同步补充跨资源 people 关联的 CLI 用法说明

### 7. 测试与验证

- 补充 parser / handler / service tests
- 补充真实 `uv run lifeos` integration tests
- 收敛顶层 help 测试，避免依赖 `argparse` 在不同 Python 版本下的空格对齐差异
- 已完成验证：
  - `bash ./scripts/doctor.sh` -> `124 passed, 5 skipped`
  - `LIFEOS_RUN_INTEGRATION=1 uv run pytest tests/test_cli_integration.py -q` -> `5 passed`

## 说明

- 本 PR 范围较大，主要原因是当前分支先后完成了 `habit` / `habit-action`、`event` / `timelog`，以及后续补充的跨资源 people 关联能力，并一并补齐了 CLI、文档、测试与维护边界。
- 命名上不再引入 `actual_event` / `planned_event` 这组历史术语，避免 CLI 与代码维护中出现双重语义。
- `#13` 追踪的是 `event` / `timelog` 领域；`habit` / `habit-action` 与后续的 people 关联扩展按本轮约束未单独新建 issue，因此本 PR 保持 `Closes #13`，不额外增加 issue 关联。
