### PR TITLE
chore: prefer a single Dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,29 +5,12 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 1
     commit-message:
       prefix: "deps"
     labels:
       - "dependencies"
     groups:
-      uv-minor-and-patch:
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
-
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 3
-    commit-message:
-      prefix: "deps"
-    labels:
-      - "dependencies"
-    groups:
-      github-actions:
+      uv-all-updates:
         patterns:
           - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
+    labels:
+      - "dependencies"
+    groups:
+      uv-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "deps"
+    labels:
+      - "dependencies"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ For complete CLI usage, workflows, and output conventions, see [docs/cli.md](doc
    bash ./scripts/doctor.sh
    ```
 
+4. Use the repository dependency workflows intentionally:
+
+   - `.github/dependabot.yml` opens weekly grouped version-update PRs for `uv` and GitHub Actions.
+   - `bash ./scripts/dependency_health.sh` remains the explicit maintainer audit flow for outdated packages and dev vulnerability review.
+
 ## Project Policies
 
 - Contribution workflow: [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ For complete CLI usage, workflows, and output conventions, see [docs/cli.md](doc
 
 4. Use the repository dependency workflows intentionally:
 
-   - `.github/dependabot.yml` opens weekly grouped version-update PRs for `uv` and GitHub Actions.
+   - `.github/dependabot.yml` opens a single weekly grouped version-update PR for `uv`.
    - `bash ./scripts/dependency_health.sh` remains the explicit maintainer audit flow for outdated packages and dev vulnerability review.
 
 ## Project Policies

--- a/tests/test_repository_contracts.py
+++ b/tests/test_repository_contracts.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+DEPENDABOT_TEXT = Path(".github/dependabot.yml").read_text()
+README_TEXT = Path("README.md").read_text()
+DOCTOR_TEXT = Path("scripts/doctor.sh").read_text()
+DEPENDENCY_HEALTH_TEXT = Path("scripts/dependency_health.sh").read_text()
+
+
+def test_dependabot_configuration_covers_uv_and_github_actions() -> None:
+    assert 'package-ecosystem: "uv"' in DEPENDABOT_TEXT
+    assert 'package-ecosystem: "github-actions"' in DEPENDABOT_TEXT
+    assert "open-pull-requests-limit: 5" in DEPENDABOT_TEXT
+    assert "open-pull-requests-limit: 3" in DEPENDABOT_TEXT
+    assert "uv-minor-and-patch" in DEPENDABOT_TEXT
+
+
+def test_readme_documents_dependabot_and_dependency_audit_split() -> None:
+    assert "weekly grouped version-update PRs" in README_TEXT
+    assert "bash ./scripts/dependency_health.sh" in README_TEXT
+
+
+def test_dependency_scripts_keep_separate_scopes() -> None:
+    assert "uv run pytest" in DOCTOR_TEXT
+    assert "uv pip list --outdated" not in DOCTOR_TEXT
+    assert "uv pip list --outdated" in DEPENDENCY_HEALTH_TEXT
+    assert "uv run pip-audit" in DEPENDENCY_HEALTH_TEXT
+    assert "uv run pytest" not in DEPENDENCY_HEALTH_TEXT

--- a/tests/test_repository_contracts.py
+++ b/tests/test_repository_contracts.py
@@ -6,16 +6,15 @@ DOCTOR_TEXT = Path("scripts/doctor.sh").read_text()
 DEPENDENCY_HEALTH_TEXT = Path("scripts/dependency_health.sh").read_text()
 
 
-def test_dependabot_configuration_covers_uv_and_github_actions() -> None:
+def test_dependabot_configuration_prefers_a_single_grouped_uv_pr() -> None:
     assert 'package-ecosystem: "uv"' in DEPENDABOT_TEXT
-    assert 'package-ecosystem: "github-actions"' in DEPENDABOT_TEXT
-    assert "open-pull-requests-limit: 5" in DEPENDABOT_TEXT
-    assert "open-pull-requests-limit: 3" in DEPENDABOT_TEXT
-    assert "uv-minor-and-patch" in DEPENDABOT_TEXT
+    assert 'package-ecosystem: "github-actions"' not in DEPENDABOT_TEXT
+    assert "open-pull-requests-limit: 1" in DEPENDABOT_TEXT
+    assert "uv-all-updates" in DEPENDABOT_TEXT
 
 
 def test_readme_documents_dependabot_and_dependency_audit_split() -> None:
-    assert "weekly grouped version-update PRs" in README_TEXT
+    assert "single weekly grouped version-update PR for `uv`" in README_TEXT
     assert "bash ./scripts/dependency_health.sh" in README_TEXT
 
 


### PR DESCRIPTION
## 概要

将 Dependabot 配置进一步收敛为单 PR 风格：仅保留 `uv` 自动版本更新，并将可升级项合并为单个每周 PR；继续保留仓库脚本作为显式依赖巡检与审计入口。

## 变更

### `.github`

- 更新 `.github/dependabot.yml`
- 移除 `github-actions` 的 Dependabot 自动更新
- 将 `uv` 的并发 PR 上限收敛为 1
- 将 `uv` 的全部版本更新合并到单个 group，避免拆分多个升级 PR

### `README`

- 更新开发说明
- 明确 `.github/dependabot.yml` 采用单个每周 `uv` 升级 PR 的策略
- 继续强调 `bash ./scripts/dependency_health.sh` 是显式审计入口

### `tests`

- 更新 `tests/test_repository_contracts.py`
- 将仓库契约断言改为单 PR 偏好：不再允许 `github-actions` ecosystem，要求 `uv` 配置只保留一个分组与 1 个并发 PR

## 验证

- `uv run pytest tests/test_repository_contracts.py`
- `bash ./scripts/doctor.sh`
- `bash ./scripts/dependency_health.sh`
- `uv export --format requirements.txt --no-dev --locked --no-emit-project --output-file /tmp/runtime-requirements.txt >/dev/null && uv run pip-audit --requirement /tmp/runtime-requirements.txt`
- `rm -rf build dist && uv build --no-sources`

## 关联

- Closes #18
