### PR TITLE
feat: add schedule views and recurring event series support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,3 +39,14 @@ The following rules apply to coding agent collaboration in this repository. Thes
 - Never commit secrets, tokens, private keys, or `.env` contents.
 - Ensure logs and examples do not expose credentials or sensitive local paths unintentionally.
 - Update [SECURITY.md](SECURITY.md), [README.md](README.md), and release-related docs when changing publishing, dependency, or security-sensitive behavior.
+
+## 6. CLI Help and Tests
+
+- Treat CLI help as the primary command reference:
+  - `lifeos --help`
+  - `lifeos <resource> --help`
+  - `lifeos <resource> <action> --help`
+- Command-specific facts such as examples, argument constraints, behavioral notes, and scope rules must be updated in help when CLI behavior changes.
+- Repository-level CLI docs should summarize cross-command concepts and must not become a second source of truth for command-level details.
+- For CLI feature work, review the related help text and tests before considering the task complete.
+- Do not ship CLI behavior changes with source-only updates; update the relevant help text and add or adjust tests that cover the user-visible command shape and behavior.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,3 +74,10 @@ Update docs together with code whenever you change:
 - validation or dependency workflows
 - release or publishing behavior
 - security or disclosure guidance
+
+For CLI-facing changes:
+
+- Treat CLI help as the primary command reference.
+- Update `lifeos --help`, `lifeos <resource> --help`, or `lifeos <resource> <action> --help` when command behavior, examples, arguments, or constraints change.
+- Keep repository CLI docs focused on cross-command guidance rather than duplicating command-level facts.
+- Review and update the related CLI tests so help text and user-visible behavior stay covered together.

--- a/alembic/versions/20260410_1200_add_event_recurrence_support.py
+++ b/alembic/versions/20260410_1200_add_event_recurrence_support.py
@@ -1,0 +1,168 @@
+"""Add recurring event support and occurrence exceptions."""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260410_1200"
+down_revision = "20260410_0900"
+branch_labels = None
+depends_on = None
+
+
+def _schema_name() -> str:
+    context = op.get_context()
+    return context.version_table_schema or "lifeos"
+
+
+def upgrade() -> None:
+    schema_name = _schema_name()
+
+    op.add_column(
+        "events",
+        sa.Column("recurrence_frequency", sa.String(length=16), nullable=True),
+        schema=schema_name,
+    )
+    op.add_column(
+        "events",
+        sa.Column("recurrence_interval", sa.Integer(), nullable=True),
+        schema=schema_name,
+    )
+    op.add_column(
+        "events",
+        sa.Column("recurrence_count", sa.Integer(), nullable=True),
+        schema=schema_name,
+    )
+    op.add_column(
+        "events",
+        sa.Column("recurrence_until", sa.DateTime(timezone=True), nullable=True),
+        schema=schema_name,
+    )
+    op.add_column(
+        "events",
+        sa.Column("recurrence_parent_event_id", sa.Uuid(), nullable=True),
+        schema=schema_name,
+    )
+    op.add_column(
+        "events",
+        sa.Column("recurrence_instance_start", sa.DateTime(timezone=True), nullable=True),
+        schema=schema_name,
+    )
+    op.create_index(
+        op.f("ix_events_recurrence_frequency"),
+        "events",
+        ["recurrence_frequency"],
+        unique=False,
+        schema=schema_name,
+    )
+    op.create_index(
+        op.f("ix_events_recurrence_until"),
+        "events",
+        ["recurrence_until"],
+        unique=False,
+        schema=schema_name,
+    )
+    op.create_index(
+        "ix_events_recurrence_parent_event_id",
+        "events",
+        ["recurrence_parent_event_id"],
+        unique=False,
+        schema=schema_name,
+    )
+    op.create_index(
+        "ix_events_recurrence_instance_start",
+        "events",
+        ["recurrence_instance_start"],
+        unique=False,
+        schema=schema_name,
+    )
+    op.create_foreign_key(
+        op.f("fk_events_recurrence_parent_event_id_events"),
+        "events",
+        "events",
+        ["recurrence_parent_event_id"],
+        ["id"],
+        source_schema=schema_name,
+        referent_schema=schema_name,
+        ondelete="CASCADE",
+    )
+
+    op.create_table(
+        "event_occurrence_exceptions",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("master_event_id", sa.Uuid(), nullable=False),
+        sa.Column("action", sa.String(length=20), nullable=False),
+        sa.Column("instance_start", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["master_event_id"],
+            [f"{schema_name}.events.id"],
+            name=op.f("fk_event_occurrence_exceptions_master_event_id_events"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_event_occurrence_exceptions")),
+        schema=schema_name,
+    )
+    op.create_index(
+        "ix_event_occurrence_exceptions_master_event_id",
+        "event_occurrence_exceptions",
+        ["master_event_id"],
+        unique=False,
+        schema=schema_name,
+    )
+    op.create_index(
+        "ix_event_occurrence_exceptions_instance_start",
+        "event_occurrence_exceptions",
+        ["instance_start"],
+        unique=False,
+        schema=schema_name,
+    )
+    op.create_index(
+        "uq_event_occurrence_exceptions_master_event_id_instance_start_active",
+        "event_occurrence_exceptions",
+        ["master_event_id", "instance_start"],
+        unique=True,
+        schema=schema_name,
+        postgresql_where=sa.text("deleted_at IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    schema_name = _schema_name()
+
+    op.drop_index(
+        "uq_event_occurrence_exceptions_master_event_id_instance_start_active",
+        table_name="event_occurrence_exceptions",
+        schema=schema_name,
+    )
+    op.drop_index(
+        "ix_event_occurrence_exceptions_instance_start",
+        table_name="event_occurrence_exceptions",
+        schema=schema_name,
+    )
+    op.drop_index(
+        "ix_event_occurrence_exceptions_master_event_id",
+        table_name="event_occurrence_exceptions",
+        schema=schema_name,
+    )
+    op.drop_table("event_occurrence_exceptions", schema=schema_name)
+
+    op.drop_constraint(
+        op.f("fk_events_recurrence_parent_event_id_events"),
+        "events",
+        schema=schema_name,
+        type_="foreignkey",
+    )
+    op.drop_index("ix_events_recurrence_instance_start", table_name="events", schema=schema_name)
+    op.drop_index("ix_events_recurrence_parent_event_id", table_name="events", schema=schema_name)
+    op.drop_index(op.f("ix_events_recurrence_until"), table_name="events", schema=schema_name)
+    op.drop_index(op.f("ix_events_recurrence_frequency"), table_name="events", schema=schema_name)
+    op.drop_column("events", "recurrence_instance_start", schema=schema_name)
+    op.drop_column("events", "recurrence_parent_event_id", schema=schema_name)
+    op.drop_column("events", "recurrence_until", schema=schema_name)
+    op.drop_column("events", "recurrence_count", schema=schema_name)
+    op.drop_column("events", "recurrence_interval", schema=schema_name)
+    op.drop_column("events", "recurrence_frequency", schema=schema_name)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,65 +1,49 @@
 # CLI Guide
 
-This document describes the current `lifeos` command structure exposed by the branch.
-It is intended for both human operators and agents that need stable command patterns.
+This document is a secondary overview of the current `lifeos` CLI.
+
+Command-specific facts such as arguments, examples, constraints, and command notes must live in
+`lifeos --help`, `lifeos <resource> --help`, and `lifeos <resource> <action> --help`.
+
+Use this document for cross-command guidance only. Do not treat it as the source of truth for
+resource-level command details.
 
 ## Command Grammar
 
-The CLI follows a consistent grammar:
+The CLI follows one stable grammar:
 
 ```text
 lifeos <resource> <action> [arguments] [options]
 ```
 
-Command design conventions:
+The public command tree prefers:
 
-- resource names stay short and stable; most are singular nouns such as `note` or `task`
-- use natural exceptions such as `people` when they are clearer than forced regular forms
-- action names stay short verbs, such as `add`, `list`, `show`, `search`, and `delete`
-- when one command targets multiple records, it should live under a grouped namespace such as
-  `batch`
-- for structured resources, `list` is the primary query entrypoint and should grow richer filters
-  over time
-- the public CLI only performs soft deletion; permanent cleanup is reserved for internal
-  maintenance scripts
+- short resource names
+- short action verbs such as `add`, `list`, `show`, `update`, and `delete`
+- `list` as the main query entrypoint for structured resources
+- grouped namespaces such as `batch` for multi-record writes
 
-## Operating Model
+## Documentation Model
 
-The CLI is designed around a few stable patterns:
+To avoid duplicate maintenance, the documentation boundary is:
 
-- create a record with `add`
-- inspect collections with `list`
-- inspect one record with `show`
-- mutate one record with `update`
-- soft-delete records with `delete`
-- group multi-record write operations under `batch`
+- Help is the primary command reference.
+- Repository docs summarize cross-resource concepts and operating rules.
+- When command behavior changes, update help first.
+- Only update this file when a cross-command model, workflow, or policy changes.
 
-For structured resources such as `area`, `tag`, `people`, `vision`, `task`, `event`, and `timelog`:
+Practical rule:
 
-- prefer `list` as the main query command
-- expect future filtering and pagination growth on `list`
-- do not expect a separate public `search` command yet
-
-For text-heavy resources such as `note`:
-
-- `search` exists because it is a distinct retrieval mode
-- `show` is the correct way to inspect full multi-line content
+- If a user needs to know how to run one command correctly, that information belongs in help.
 
 ## Output Conventions
 
-The current CLI output is intentionally simple and scriptable.
+The current CLI output stays intentionally simple and scriptable.
 
-- `list` commands print tab-separated summary rows
-- `show` commands print labeled detail fields
-- `add` and `update` commands print a short confirmation plus the resulting identifier
-- `delete` and `batch delete` commands print soft-delete results only
-
-Practical guidance:
-
-- use `list` when a human or agent needs compact summaries
-- use `show` when exact field values or multi-line content matter
-- keep identifiers from `add` or `list` output and feed them into later commands
-- do not assume `list` output preserves multi-line formatting; use `show` for that
+- `list` commands print compact summary rows
+- `show` commands print labeled fields
+- `add` and `update` commands print short confirmation messages
+- public `delete` commands report soft-delete results only
 
 ## Installation and Initialization
 
@@ -69,413 +53,86 @@ Install the published CLI:
 uv tool install lifeos-cli
 ```
 
-Initialize local configuration and database access:
+Initialize local configuration:
 
 ```bash
 lifeos init
 ```
 
-Initialize while persisting user preferences:
-
-```bash
-lifeos init --timezone America/Toronto --language zh-Hans --day-starts-at 04:00 --week-starts-on sunday --vision-experience-rate-per-hour 120
-```
-
-Re-run `lifeos init` to edit stored preferences later.
-
-Inspect the effective configuration:
+Inspect the effective runtime configuration:
 
 ```bash
 lifeos config show
 ```
 
-Check database connectivity and apply migrations:
+Check database connectivity and migrations:
 
 ```bash
 lifeos db ping
 lifeos db upgrade
 ```
 
-Recommended first-run flow:
+## Runtime Preferences
 
-```bash
-lifeos init
-lifeos db ping
-lifeos db upgrade
-```
+The CLI persists a small set of runtime preferences:
 
-Current persisted preference keys:
+- `timezone`
+- `language`
+- `day_starts_at`
+- `week_starts_on`
+- `vision_experience_rate_per_hour`
 
-- `timezone`: default IANA timezone used for local timestamp rendering and local day boundaries
-- `language`: preferred language tag such as `en`, `en-CA`, or `zh-Hans`
-- `day_starts_at`: local day boundary in `HH:MM` for date-based event/timelog queries and habit
-  day semantics
-- `week_starts_on`: preferred first day of the week (`monday` or `sunday`) for weekly habit stats
-- `vision_experience_rate_per_hour`: default vision experience points gained per hour of actual
-  effort, used when a vision does not define its own rate
+Time-oriented behavior follows these rules:
 
-Time storage and rendering rules:
+- `event` and `timelog` datetimes are stored in UTC-normalized form
+- CLI timestamp rendering uses the configured `timezone`
+- date-based queries also use the configured `day_starts_at`
+- weekly habit summaries use the configured `week_starts_on`
 
-- `event` and `timelog` datetimes are stored in UTC-normalized form in PostgreSQL
-- CLI output renders timestamps in the configured `timezone`
-- `event list --date` and `timelog list --date` use the configured `timezone` and
-  `day_starts_at` together
-- habit "today" and weekly stats use the configured local operational day instead of raw server
-  midnight
-- vision experience sync uses `vision_experience_rate_per_hour` unless the vision has a
-  per-record `experience_rate_per_hour` override
+## Resource Map
 
-## Notes
+Use help as the first-stop reference for each command family:
 
-Create a note from inline content:
+- `lifeos area --help`
+- `lifeos event --help`
+- `lifeos schedule --help`
+- `lifeos habit --help`
+- `lifeos habit-action --help`
+- `lifeos tag --help`
+- `lifeos people --help`
+- `lifeos vision --help`
+- `lifeos task --help`
+- `lifeos timelog --help`
+- `lifeos note --help`
 
-```bash
-lifeos note add "a new note"
-```
+Current high-level domain roles:
 
-Create a multi-line note from standard input:
+- `event`: planned schedule blocks
+- `schedule`: aggregated day and range read model
+- `timelog`: actual time records
+- `habit`: recurring intention that generates dated habit actions
+- `habit-action`: one dated habit execution row
+- `task`: execution unit with planning-cycle and hierarchy support
+- `vision`: longer-horizon outcome and experience container
 
-```bash
-cat <<'EOF' | lifeos note add --stdin
-This is a multi-line note.
-The second line stays intact.
-EOF
-```
+## Safety Model
 
-Create a note from a file:
+The public CLI is intentionally conservative.
 
-```bash
-lifeos note add --file ./note.md
-```
+- public `delete` commands only soft-delete records
+- public `batch delete` commands also only soft-delete records
+- hard delete stays outside the public CLI
 
-List notes:
+This boundary should remain stable as more resources are added.
 
-```bash
-lifeos note list
-lifeos note list --limit 20 --offset 20
-lifeos note list --include-deleted
-```
+## Agent Guidance
 
-Show the full note body with preserved line breaks:
-
-```bash
-lifeos note show 11111111-1111-1111-1111-111111111111
-```
-
-Update or delete a note:
-
-```bash
-lifeos note update 11111111-1111-1111-1111-111111111111 "updated content"
-lifeos note delete 11111111-1111-1111-1111-111111111111
-```
-
-Minimal note workflow:
-
-```bash
-lifeos note add "capture an idea"
-lifeos note list
-lifeos note show <note-id>
-lifeos note update <note-id> "capture a better idea"
-lifeos note delete <note-id>
-```
-
-## Note Search
-
-Search currently uses PostgreSQL-backed `ILIKE` token matching against note content.
-
-```bash
-lifeos note search "meeting notes"
-lifeos note search "budget q2" --limit 20
-lifeos note search "archived idea" --include-deleted
-```
-
-Current behavior:
-
-- multi-word queries are split into tokens
-- tokens are matched with OR semantics
-- results use the same summary format as `lifeos note list`
-
-## Core Domains
-
-The branch now exposes early CRUD-oriented command families for several additional domains:
-
-- `lifeos area ...`
-- `lifeos event ...`
-- `lifeos schedule ...`
-- `lifeos habit ...`
-- `lifeos habit-action ...`
-- `lifeos tag ...`
-- `lifeos people ...`
-- `lifeos task ...`
-- `lifeos timelog ...`
-- `lifeos vision ...`
-
-Examples:
-
-```bash
-lifeos area add "Health"
-lifeos event add "Doctor appointment" --start-time 2026-04-10T09:00:00-04:00
-lifeos schedule show --date 2026-04-10
-lifeos habit add "Daily Exercise" --start-date 2026-04-09 --duration-days 21
-lifeos habit-action list --action-date 2026-04-09
-lifeos tag add "family" --entity-type person --category relation
-lifeos people add "Alice" --nickname ally --location Toronto
-lifeos vision add "Launch lifeos-cli"
-lifeos task add "Draft release checklist" --vision-id <vision-id>
-lifeos timelog add "Deep work" --start-time 2026-04-10T13:00:00-04:00 --end-time 2026-04-10T14:30:00-04:00
-lifeos task batch delete --ids <task-id-1> <task-id-2>
-```
-
-Current intent:
-
-- `list` is the query entrypoint for these structured resources
-- standalone `search` is intentionally deferred for now
-- `batch` is the grouped namespace for multi-record write operations
-- `habit-action` is a top-level resource instead of a nested `habit action` command tree
-- repeated `--person-id` flags attach people to supported resources such as `tag`, `vision`,
-  `task`, `event`, and `timelog`
-
-## Structured Resource Workflows
-
-These examples show the current intended command shape for the new structured resources.
-
-### Area
-
-```bash
-lifeos area add "Health" --description "Long-term wellbeing" --icon heart
-lifeos area list
-lifeos area show <area-id>
-lifeos area update <area-id> --name "Fitness" --clear-icon
-lifeos area delete <area-id>
-```
-
-### Tag
-
-```bash
-lifeos tag add "family" --entity-type person --category relation --color green
-lifeos tag update <tag-id> --person-id <person-id>
-lifeos tag list --person-id <person-id>
-lifeos tag list
-lifeos tag show <tag-id>
-lifeos tag update <tag-id> --clear-color
-lifeos tag delete <tag-id>
-```
-
-### Event
-
-```bash
-lifeos event add "Doctor appointment" --start-time 2026-04-10T09:00:00-04:00
-lifeos event add "Daily review" --start-time 2026-04-10T09:00:00-04:00 --recurrence-frequency daily --recurrence-count 5
-lifeos event list --window-start 2026-04-10T00:00:00-04:00 --window-end 2026-04-10T23:59:59-04:00
-lifeos event list --date 2026-04-10
-lifeos event show <event-id>
-lifeos event update <event-id> --scope single --instance-start 2026-04-10T09:00:00-04:00 --status completed
-lifeos event delete <event-id> --scope all_future --instance-start 2026-04-10T09:00:00-04:00
-```
-
-Current event notes:
-
-- `event` is the planned schedule object, not the todo object
-- in Compass backend terms, `event` is the simplified public equivalent of `planned_event`
-- use `--window-start` and `--window-end` to query overlapping calendar ranges
-- use `--date` to query one configured local day
-- recurring series are expanded for bounded window queries and schedule views
-- use repeated `--tag-id` and `--person-id` flags to attach tags and people
-- recurring series currently support `daily` and `weekly` cadence
-- use `event update|delete --scope single|all_future|all --instance-start ...` for recurring series
-
-### Schedule
-
-```bash
-lifeos schedule show --date 2026-04-10
-lifeos schedule list --start-date 2026-04-10 --end-date 2026-04-16
-```
-
-Current schedule notes:
-
-- `schedule` is a read model, not a stored domain entity
-- output is grouped by local date
-- each date includes `tasks`, `habit_actions`, and `events`
-- task inclusion currently uses planning-cycle overlap
-- event inclusion covers overlapping one-off events and expanded recurring event occurrences
-
-### Habit
-
-```bash
-lifeos habit add "Daily Exercise" --start-date 2026-04-09 --duration-days 21
-lifeos habit list --with-stats
-lifeos habit list --status active --count
-lifeos habit show <habit-id>
-lifeos habit update <habit-id> --status paused
-lifeos habit stats <habit-id>
-lifeos habit task-associations
-lifeos habit delete <habit-id>
-```
-
-Current habit notes:
-
-- a habit generates one dated `habit-action` row per day in its duration
-- updating start dates or duration automatically reconciles generated action rows
-- current-day and weekly stats use the configured timezone, `day_starts_at`, and `week_starts_on`
-- task associations include non-deleted habits linked to non-deleted tasks
-- habit deletion is soft deletion only in the public CLI
-
-### Habit Action
-
-```bash
-lifeos habit-action list --habit-id <habit-id>
-lifeos habit-action list --action-date 2026-04-09 --count
-lifeos habit-action show <action-id>
-lifeos habit-action update <action-id> --status done
-lifeos habit-action log --habit-id <habit-id> --action-date 2026-04-09 --status done
-lifeos habit-action update <action-id> --clear-notes
-```
-
-Current habit-action notes:
-
-- public CLI does not create or delete habit actions directly
-- use `list` for both per-habit and by-date inspection flows
-- use `log` to update one action by habit and date without first looking up the action ID
-- updates respect the habit-action editable window enforced by the service layer
-
-### People
-
-```bash
-lifeos people add "Alice" --nickname ally --location Toronto
-lifeos people list
-lifeos people show <person-id>
-lifeos people update <person-id> --clear-location
-lifeos people delete <person-id>
-```
-
-### Vision
-
-```bash
-lifeos vision add "Launch lifeos-cli" --area-id <area-id> --status active
-lifeos vision update <vision-id> --person-id <person-id-1> --person-id <person-id-2>
-lifeos vision list --person-id <person-id>
-lifeos vision list --status active
-lifeos vision show <vision-id>
-lifeos vision with-tasks <vision-id>
-lifeos vision stats <vision-id>
-lifeos vision update <vision-id> --status archived --clear-area
-lifeos vision sync-experience <vision-id>
-lifeos vision add-experience <vision-id> --points 120
-lifeos vision harvest <vision-id>
-lifeos vision delete <vision-id>
-```
-
-### Task
-
-```bash
-lifeos task add "Draft release checklist" --vision-id <vision-id> --status todo
-lifeos task update <task-id> --person-id <person-id>
-lifeos task list --person-id <person-id>
-lifeos task list --vision-id <vision-id>
-lifeos task list --status-in todo,in_progress --exclude-status cancelled
-lifeos task list --planning-cycle-type week --planning-cycle-start-date 2026-04-10
-lifeos task show <task-id>
-lifeos task with-subtasks <task-id>
-lifeos task hierarchy <vision-id>
-lifeos task stats <task-id>
-lifeos task move <task-id> --new-parent-task-id <parent-task-id> --new-display-order 1
-lifeos task reorder --order <task-id-1>:0 --order <task-id-2>:1
-lifeos task update <task-id> --status in_progress
-lifeos task update <child-task-id> --clear-parent
-lifeos task delete <task-id>
-```
-
-Current task notes:
-
-- `task` is the execution unit and supports tree structure through parent-child links
-- use `with-subtasks`, `hierarchy`, and `stats` for task-tree read models
-- use `--clear-parent` to move a child task back to the root level
-- use `move` for parent or vision changes and `reorder` for display order changes
-- repeated `--person-id` flags link a task to one or more people without changing its place in
-  the task tree
-- use `--clear-*` flags when a field should become empty instead of being replaced
-
-### Timelog
-
-```bash
-lifeos timelog add "Deep work" --start-time 2026-04-10T13:00:00-04:00 --end-time 2026-04-10T14:30:00-04:00
-lifeos timelog list --window-start 2026-04-10T00:00:00-04:00 --window-end 2026-04-10T23:59:59-04:00
-lifeos timelog list --date 2026-04-10
-lifeos timelog list --query "deep work" --count
-lifeos timelog list --area-name Work --without-task
-lifeos timelog show <timelog-id>
-lifeos timelog update <timelog-id> --notes "Felt strong" --clear-task
-lifeos timelog batch update --ids <timelog-id-1> <timelog-id-2> --clear-task
-lifeos timelog batch update --ids <timelog-id-1> --find-title-text "deep" --replace-title-text "focused"
-lifeos timelog delete <timelog-id>
-lifeos timelog restore <timelog-id>
-lifeos timelog batch restore --ids <timelog-id-1> <timelog-id-2>
-```
-
-Current timelog notes:
-
-- `timelog` is the actual time record and represents what really happened
-- in Compass backend terms, `timelog` is the simplified public equivalent of `actual_event`
-- use `--date` to query one configured local day
-- use `--query` to search timelog titles and notes
-- use `batch update` for repeated relation cleanup or title find/replace
-- use `restore` or `batch restore` to recover soft-deleted timelogs
-- use repeated `--tag-id` and `--person-id` flags to attach tags and people
-- timelog end time is currently required because the record models completed time spent
-
-## Note Batch Operations
-
-The first grouped bulk namespace is `lifeos note batch`.
-
-Bulk content find/replace:
-
-```bash
-lifeos note batch update-content --ids \
-  11111111-1111-1111-1111-111111111111 \
-  22222222-2222-2222-2222-222222222222 \
-  --find-text "draft" \
-  --replace-text "final"
-```
-
-Bulk delete:
-
-```bash
-lifeos note batch delete --ids \
-  11111111-1111-1111-1111-111111111111 \
-  22222222-2222-2222-2222-222222222222
-```
-
-Internal maintenance purge:
-
-```bash
-uv run python scripts/purge_deleted_records.py note \
-  --ids \
-  11111111-1111-1111-1111-111111111111 \
-  22222222-2222-2222-2222-222222222222 \
-  --confirm permanently-delete-soft-deleted-records
-```
-
-Structured resources also expose batch soft delete:
-
-```bash
-lifeos area batch delete --ids <area-id-1> <area-id-2>
-lifeos event batch delete --ids <event-id-1> <event-id-2>
-lifeos tag batch delete --ids <tag-id-1> <tag-id-2>
-lifeos people batch delete --ids <person-id-1> <person-id-2>
-lifeos vision batch delete --ids <vision-id-1> <vision-id-2>
-lifeos task batch delete --ids <task-id-1> <task-id-2>
-lifeos timelog batch delete --ids <timelog-id-1> <timelog-id-2>
-```
-
-## Agent Usage Patterns
-
-If the caller is an agent or another automation layer, prefer these patterns:
+If the caller is an agent or another automation layer:
 
 - start from `list` to discover identifiers
-- switch to `show` before making a destructive or state-changing update
-- treat all public `delete` commands as soft delete only
-- use `batch delete` for coordinated cleanup instead of issuing many single deletes
-- keep command flows id-driven instead of name-driven after discovery
+- use `show` before destructive or state-changing operations
+- treat help as the only authoritative command-level reference
+- keep flows identifier-driven after discovery
 
 Example pattern:
 
@@ -484,63 +141,3 @@ lifeos people list
 lifeos people show <person-id>
 lifeos people update <person-id> --location "Montreal"
 ```
-
-## Safety Model
-
-The public CLI is intentionally conservative:
-
-- public `delete` commands only soft-delete records
-- public `batch delete` commands also only soft-delete records
-- public CLI commands do not expose hard delete
-- permanent cleanup requires internal maintenance scripts and explicit confirmation text
-
-This separation is intentional and should remain stable as more domains are added.
-
-## Scope on This Branch
-
-Currently implemented:
-
-- `lifeos init`
-- `lifeos config show`
-- `lifeos db ping`
-- `lifeos db upgrade`
-- `lifeos area add|list|show|update|delete`
-- `lifeos area batch delete`
-- `lifeos event add|list|show|update|delete`
-- `lifeos event batch delete`
-- `lifeos schedule show|list`
-- `lifeos tag add|list|show|update|delete`
-- `lifeos tag batch delete`
-- `lifeos people add|list|show|update|delete`
-- `lifeos people batch delete`
-- `lifeos vision add|list|show|update|delete`
-- `lifeos vision with-tasks|stats`
-- `lifeos vision add-experience|sync-experience|harvest`
-- `lifeos vision batch delete`
-- `lifeos task add|list|show|with-subtasks|hierarchy|stats|move|reorder|update|delete`
-- `lifeos task batch delete`
-- `lifeos habit add|list|show|stats|task-associations|update|delete`
-- `lifeos habit batch delete`
-- `lifeos habit-action list|show|update|log`
-- `lifeos timelog add|list|show|update|delete|restore`
-- `lifeos timelog batch update`
-- `lifeos timelog batch restore`
-- `lifeos timelog batch delete`
-- `lifeos note add`
-- `lifeos note list`
-- `lifeos note search`
-- `lifeos note show`
-- `lifeos note update`
-- `lifeos note delete`
-- `lifeos note batch update-content`
-- `lifeos note batch delete`
-
-Not implemented yet:
-
-- note tags
-- note-to-task or note-to-person associations
-- batch update operations for the remaining structured resources
-- direct event-to-timelog conversion
-- note ingestion jobs
-- richer search ranking or association-aware note search
-- public CLI access to hard delete

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -201,6 +201,7 @@ The branch now exposes early CRUD-oriented command families for several addition
 
 - `lifeos area ...`
 - `lifeos event ...`
+- `lifeos schedule ...`
 - `lifeos habit ...`
 - `lifeos habit-action ...`
 - `lifeos tag ...`
@@ -214,6 +215,7 @@ Examples:
 ```bash
 lifeos area add "Health"
 lifeos event add "Doctor appointment" --start-time 2026-04-10T09:00:00-04:00
+lifeos schedule show --date 2026-04-10
 lifeos habit add "Daily Exercise" --start-date 2026-04-09 --duration-days 21
 lifeos habit-action list --action-date 2026-04-09
 lifeos tag add "family" --entity-type person --category relation
@@ -273,9 +275,27 @@ lifeos event delete <event-id>
 Current event notes:
 
 - `event` is the planned schedule object, not the todo object
+- in Compass backend terms, `event` is the simplified public equivalent of `planned_event`
 - use `--window-start` and `--window-end` to query overlapping calendar ranges
 - use `--date` to query one configured local day
 - use repeated `--tag-id` and `--person-id` flags to attach tags and people
+- recurring series currently support `daily` and `weekly` cadence
+- use `event update|delete --scope single|all_future|all --instance-start ...` for recurring series
+
+### Schedule
+
+```bash
+lifeos schedule show --date 2026-04-10
+lifeos schedule list --start-date 2026-04-10 --end-date 2026-04-16
+```
+
+Current schedule notes:
+
+- `schedule` is a read model, not a stored domain entity
+- output is grouped by local date
+- each date includes `tasks`, `habit_actions`, and `events`
+- task inclusion currently uses planning-cycle overlap
+- event inclusion currently covers one-off events only; recurring event expansion is not implemented
 
 ### Habit
 
@@ -393,6 +413,7 @@ lifeos timelog batch restore --ids <timelog-id-1> <timelog-id-2>
 Current timelog notes:
 
 - `timelog` is the actual time record and represents what really happened
+- in Compass backend terms, `timelog` is the simplified public equivalent of `actual_event`
 - use `--date` to query one configured local day
 - use `--query` to search timelog titles and notes
 - use `batch update` for repeated relation cleanup or title find/replace
@@ -485,6 +506,7 @@ Currently implemented:
 - `lifeos area batch delete`
 - `lifeos event add|list|show|update|delete`
 - `lifeos event batch delete`
+- `lifeos schedule show|list`
 - `lifeos tag add|list|show|update|delete`
 - `lifeos tag batch delete`
 - `lifeos people add|list|show|update|delete`
@@ -516,7 +538,7 @@ Not implemented yet:
 - note tags
 - note-to-task or note-to-person associations
 - batch update operations for the remaining structured resources
-- event/timelog recurrence or direct event-to-timelog conversion
+- direct event-to-timelog conversion
 - note ingestion jobs
 - richer search ranking or association-aware note search
 - public CLI access to hard delete

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -265,11 +265,12 @@ lifeos tag delete <tag-id>
 
 ```bash
 lifeos event add "Doctor appointment" --start-time 2026-04-10T09:00:00-04:00
+lifeos event add "Daily review" --start-time 2026-04-10T09:00:00-04:00 --recurrence-frequency daily --recurrence-count 5
 lifeos event list --window-start 2026-04-10T00:00:00-04:00 --window-end 2026-04-10T23:59:59-04:00
 lifeos event list --date 2026-04-10
 lifeos event show <event-id>
-lifeos event update <event-id> --status completed --clear-task
-lifeos event delete <event-id>
+lifeos event update <event-id> --scope single --instance-start 2026-04-10T09:00:00-04:00 --status completed
+lifeos event delete <event-id> --scope all_future --instance-start 2026-04-10T09:00:00-04:00
 ```
 
 Current event notes:
@@ -278,6 +279,7 @@ Current event notes:
 - in Compass backend terms, `event` is the simplified public equivalent of `planned_event`
 - use `--window-start` and `--window-end` to query overlapping calendar ranges
 - use `--date` to query one configured local day
+- recurring series are expanded for bounded window queries and schedule views
 - use repeated `--tag-id` and `--person-id` flags to attach tags and people
 - recurring series currently support `daily` and `weekly` cadence
 - use `event update|delete --scope single|all_future|all --instance-start ...` for recurring series
@@ -295,7 +297,7 @@ Current schedule notes:
 - output is grouped by local date
 - each date includes `tasks`, `habit_actions`, and `events`
 - task inclusion currently uses planning-cycle overlap
-- event inclusion currently covers one-off events only; recurring event expansion is not implemented
+- event inclusion covers overlapping one-off events and expanded recurring event occurrences
 
 ### Habit
 

--- a/src/lifeos_cli/cli_support/parser.py
+++ b/src/lifeos_cli/cli_support/parser.py
@@ -80,6 +80,8 @@ def build_parser() -> argparse.ArgumentParser:
                 "For structured resources, prefer `list` with filters and pagination over "
                 "separate query verbs.",
                 "Use sub-namespaces such as `batch` when a resource needs grouped bulk operations.",
+                "Use `lifeos <resource> --help` and `lifeos <resource> <action> --help` as the "
+                "primary command reference.",
                 "Each resource help page should explain scope, actions, and examples.",
                 "Run `lifeos init` before using database-backed resource commands.",
             ),

--- a/src/lifeos_cli/cli_support/parser.py
+++ b/src/lifeos_cli/cli_support/parser.py
@@ -16,6 +16,7 @@ from lifeos_cli.cli_support.resources.habit.parser import build_habit_parser
 from lifeos_cli.cli_support.resources.habit_action.parser import build_habit_action_parser
 from lifeos_cli.cli_support.resources.note.parser import build_note_parser
 from lifeos_cli.cli_support.resources.people.parser import build_people_parser
+from lifeos_cli.cli_support.resources.schedule.parser import build_schedule_parser
 from lifeos_cli.cli_support.resources.tag.parser import build_tag_parser
 from lifeos_cli.cli_support.resources.task.parser import build_task_parser
 from lifeos_cli.cli_support.resources.timelog.parser import build_timelog_parser
@@ -48,6 +49,7 @@ def build_parser() -> argparse.ArgumentParser:
             "Resources model domains such as areas, people, visions, tasks, and notes.\n"
             "Time-oriented domains use `event` for planned schedule blocks and `timelog` "
             "for actual time records.\n"
+            "Use `schedule` for aggregated day and range views across planned work.\n"
             "Habits and habit actions are exposed as separate top-level resources.\n"
             "System commands such as init, config, and db manage runtime setup.\n"
             "Actions are short verbs that operate on records or runtime state."
@@ -62,6 +64,7 @@ def build_parser() -> argparse.ArgumentParser:
                 'lifeos vision add "Launch lifeos-cli" --area-id <area-id>',
                 'lifeos task add "Draft release plan" --vision-id <vision-id>',
                 'lifeos event add "Doctor appointment" --start-time 2026-04-10T09:00:00-04:00',
+                "lifeos schedule show --date 2026-04-10",
                 'lifeos timelog add "Deep work" --start-time 2026-04-10T13:00:00-04:00 '
                 "--end-time 2026-04-10T14:30:00-04:00",
                 'lifeos habit add "Daily Exercise" --start-date 2026-04-09 --duration-days 21',
@@ -90,6 +93,7 @@ def build_parser() -> argparse.ArgumentParser:
     build_db_parser(subparsers)
     build_area_parser(subparsers)
     build_event_parser(subparsers)
+    build_schedule_parser(subparsers)
     build_tag_parser(subparsers)
     build_people_parser(subparsers)
     build_vision_parser(subparsers)

--- a/src/lifeos_cli/cli_support/resources/event/handlers.py
+++ b/src/lifeos_cli/cli_support/resources/event/handlers.py
@@ -4,23 +4,23 @@ from __future__ import annotations
 
 import argparse
 import sys
+from typing import Any
 
 from lifeos_cli.cli_support.output_utils import format_timestamp, print_batch_result
 from lifeos_cli.cli_support.runtime_utils import run_async
 from lifeos_cli.db import session as db_session
-from lifeos_cli.db.models.event import Event
 from lifeos_cli.db.services import events as event_services
 
 
-def _format_event_summary(event: Event) -> str:
-    status = "deleted" if event.deleted_at is not None else event.status
+def _format_event_summary(event: Any) -> str:
+    status = "deleted" if getattr(event, "deleted_at", None) is not None else event.status
     return (
         f"{event.id}\t{status}\t{format_timestamp(event.start_time)}\t"
         f"{format_timestamp(event.end_time)}\t{event.task_id or '-'}\t{event.title}"
     )
 
 
-def _format_event_detail(event: Event) -> str:
+def _format_event_detail(event: Any) -> str:
     tag_names = ", ".join(tag.name for tag in event.tags) if getattr(event, "tags", None) else "-"
     people_names = (
         ", ".join(person.name for person in event.people) if getattr(event, "people", None) else "-"
@@ -35,6 +35,14 @@ def _format_event_detail(event: Event) -> str:
             f"is_all_day: {event.is_all_day}",
             f"start_time: {format_timestamp(event.start_time)}",
             f"end_time: {format_timestamp(event.end_time)}",
+            f"recurrence_frequency: {getattr(event, 'recurrence_frequency', None) or '-'}",
+            f"recurrence_interval: {getattr(event, 'recurrence_interval', None) or '-'}",
+            f"recurrence_count: {getattr(event, 'recurrence_count', None) or '-'}",
+            f"recurrence_until: {format_timestamp(getattr(event, 'recurrence_until', None))}",
+            "recurrence_parent_event_id: "
+            f"{getattr(event, 'recurrence_parent_event_id', None) or '-'}",
+            "recurrence_instance_start: "
+            f"{format_timestamp(getattr(event, 'recurrence_instance_start', None))}",
             f"area_id: {event.area_id or '-'}",
             f"task_id: {event.task_id or '-'}",
             f"tags: {tag_names}",
@@ -67,6 +75,10 @@ async def handle_event_add_async(args: argparse.Namespace) -> int:
                 task_id=args.task_id,
                 tag_ids=args.tag_ids,
                 person_ids=args.person_ids,
+                recurrence_frequency=args.recurrence_frequency,
+                recurrence_interval=args.recurrence_interval,
+                recurrence_count=args.recurrence_count,
+                recurrence_until=args.recurrence_until,
             )
         except (
             event_services.EventAreaReferenceNotFoundError,
@@ -153,6 +165,20 @@ async def handle_event_update_async(args: argparse.Namespace) -> int:
         (args.clear_task and args.task_id is not None, "--task-id", "--clear-task"),
         (args.clear_tags and args.tag_ids is not None, "--tag-id", "--clear-tags"),
         (args.clear_people and args.person_ids is not None, "--person-id", "--clear-people"),
+        (
+            args.clear_recurrence
+            and any(
+                value is not None
+                for value in (
+                    args.recurrence_frequency,
+                    args.recurrence_interval,
+                    args.recurrence_count,
+                    args.recurrence_until,
+                )
+            ),
+            "--recurrence-*",
+            "--clear-recurrence",
+        ),
     )
     for is_conflict, value_flag, clear_flag in conflicts:
         if is_conflict:
@@ -180,6 +206,13 @@ async def handle_event_update_async(args: argparse.Namespace) -> int:
                 clear_tags=args.clear_tags,
                 person_ids=args.person_ids,
                 clear_people=args.clear_people,
+                recurrence_frequency=args.recurrence_frequency,
+                recurrence_interval=args.recurrence_interval,
+                recurrence_count=args.recurrence_count,
+                recurrence_until=args.recurrence_until,
+                clear_recurrence=args.clear_recurrence,
+                scope=args.scope,
+                instance_start=args.instance_start,
             )
         except (
             event_services.EventNotFoundError,
@@ -200,8 +233,15 @@ def handle_event_update(args: argparse.Namespace) -> int:
 async def handle_event_delete_async(args: argparse.Namespace) -> int:
     async with db_session.session_scope() as session:
         try:
-            await event_services.delete_event(session, event_id=args.event_id)
+            await event_services.delete_event(
+                session,
+                event_id=args.event_id,
+                scope=args.scope,
+                instance_start=args.instance_start,
+            )
         except event_services.EventNotFoundError as exc:
+            return _print_event_error(exc)
+        except event_services.EventValidationError as exc:
             return _print_event_error(exc)
     print(f"Soft-deleted event {args.event_id}")
     return 0

--- a/src/lifeos_cli/cli_support/resources/event/parser.py
+++ b/src/lifeos_cli/cli_support/resources/event/parser.py
@@ -71,6 +71,7 @@ def build_event_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentP
             notes=(
                 "Use repeated `--tag-id` and `--person-id` flags to attach tags and people.",
                 "If `--end-time` is omitted, the event is treated as open-ended.",
+                "Use recurrence flags to create a recurring series without renaming the resource.",
             ),
         ),
     )
@@ -88,6 +89,25 @@ def build_event_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentP
     )
     add_parser.add_argument("--area-id", type=UUID, help="Optional linked area identifier")
     add_parser.add_argument("--task-id", type=UUID, help="Optional linked task identifier")
+    add_parser.add_argument(
+        "--recurrence-frequency",
+        help="Optional recurrence frequency: daily or weekly",
+    )
+    add_parser.add_argument(
+        "--recurrence-interval",
+        type=int,
+        help="Optional recurrence interval, default 1",
+    )
+    add_parser.add_argument(
+        "--recurrence-count",
+        type=int,
+        help="Optional total occurrence count",
+    )
+    add_parser.add_argument(
+        "--recurrence-until",
+        type=_datetime_value,
+        help="Optional final allowed occurrence start time",
+    )
     add_parser.add_argument(
         "--tag-id",
         dest="tag_ids",
@@ -181,6 +201,7 @@ def build_event_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentP
             notes=(
                 "Use `--clear-*` flags to explicitly remove optional values.",
                 "Do not mix a value flag with the matching clear flag in the same command.",
+                "Use `--scope single|all_future|all` for recurring series updates.",
             ),
         ),
     )
@@ -203,6 +224,33 @@ def build_event_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentP
     update_parser.add_argument("--clear-area", action="store_true", help="Clear linked area")
     update_parser.add_argument("--task-id", type=UUID, help="Updated linked task identifier")
     update_parser.add_argument("--clear-task", action="store_true", help="Clear linked task")
+    update_parser.add_argument("--recurrence-frequency", help="Updated recurrence frequency")
+    update_parser.add_argument(
+        "--recurrence-interval",
+        type=int,
+        help="Updated recurrence interval",
+    )
+    update_parser.add_argument("--recurrence-count", type=int, help="Updated recurrence count")
+    update_parser.add_argument(
+        "--recurrence-until",
+        type=_datetime_value,
+        help="Updated recurrence until datetime",
+    )
+    update_parser.add_argument(
+        "--clear-recurrence",
+        action="store_true",
+        help="Remove recurrence from the event",
+    )
+    update_parser.add_argument(
+        "--scope",
+        default="all",
+        help="Update scope for recurring events: single, all_future, or all",
+    )
+    update_parser.add_argument(
+        "--instance-start",
+        type=_datetime_value,
+        help="Instance start time for single or all_future recurring updates",
+    )
     update_parser.add_argument(
         "--tag-id",
         dest="tag_ids",
@@ -229,10 +277,24 @@ def build_event_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentP
         help_content=HelpContent(
             summary="Delete an event",
             description="Soft-delete one event.",
-            examples=("lifeos event delete 11111111-1111-1111-1111-111111111111",),
+            examples=(
+                "lifeos event delete 11111111-1111-1111-1111-111111111111",
+                "lifeos event delete 11111111-1111-1111-1111-111111111111 "
+                "--scope single --instance-start 2026-04-10T09:00:00-04:00",
+            ),
         ),
     )
     delete_parser.add_argument("event_id", type=UUID, help="Event identifier")
+    delete_parser.add_argument(
+        "--scope",
+        default="all",
+        help="Delete scope for recurring events: single, all_future, or all",
+    )
+    delete_parser.add_argument(
+        "--instance-start",
+        type=_datetime_value,
+        help="Instance start time for single or all_future recurring deletes",
+    )
     delete_parser.set_defaults(handler=handle_event_delete)
 
     batch_parser = add_documented_parser(

--- a/src/lifeos_cli/cli_support/resources/event/parser.py
+++ b/src/lifeos_cli/cli_support/resources/event/parser.py
@@ -146,6 +146,7 @@ def build_event_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentP
                 "When both window flags are given, overlapping events are returned.",
                 "Use `--date` to query one configured local day using your timezone and "
                 "`day_starts_at` preference.",
+                "Recurring series are expanded for bounded window queries and schedule views.",
                 "Use `--title-contains` for lightweight text filtering instead of a "
                 "separate search command.",
             ),
@@ -202,6 +203,7 @@ def build_event_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentP
                 "Use `--clear-*` flags to explicitly remove optional values.",
                 "Do not mix a value flag with the matching clear flag in the same command.",
                 "Use `--scope single|all_future|all` for recurring series updates.",
+                "`--scope single` and `--scope all_future` require `--instance-start`.",
             ),
         ),
     )
@@ -281,6 +283,12 @@ def build_event_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentP
                 "lifeos event delete 11111111-1111-1111-1111-111111111111",
                 "lifeos event delete 11111111-1111-1111-1111-111111111111 "
                 "--scope single --instance-start 2026-04-10T09:00:00-04:00",
+                "lifeos event delete 11111111-1111-1111-1111-111111111111 "
+                "--scope all_future --instance-start 2026-04-10T09:00:00-04:00",
+            ),
+            notes=(
+                "Use `--scope single|all_future|all` for recurring series deletes.",
+                "`--scope single` and `--scope all_future` require `--instance-start`.",
             ),
         ),
     )

--- a/src/lifeos_cli/cli_support/resources/schedule/__init__.py
+++ b/src/lifeos_cli/cli_support/resources/schedule/__init__.py
@@ -1,0 +1,1 @@
+"""Schedule CLI resource package."""

--- a/src/lifeos_cli/cli_support/resources/schedule/handlers.py
+++ b/src/lifeos_cli/cli_support/resources/schedule/handlers.py
@@ -1,0 +1,79 @@
+"""CLI handlers for the schedule resource."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from lifeos_cli.cli_support.output_utils import format_timestamp
+from lifeos_cli.cli_support.runtime_utils import run_async
+from lifeos_cli.db import session as db_session
+from lifeos_cli.db.services import schedules as schedule_services
+
+
+def _format_schedule_task(item: schedule_services.ScheduleTaskItem) -> str:
+    return (
+        f"  {item.id}\t{item.status}\t{item.planning_cycle_type}\t"
+        f"{item.planning_cycle_start_date}\t{item.planning_cycle_end_date}\t{item.content}"
+    )
+
+
+def _format_schedule_habit_action(item: schedule_services.ScheduleHabitActionItem) -> str:
+    return f"  {item.id}\t{item.status}\t{item.habit_id}\t{item.habit_title}"
+
+
+def _format_schedule_event(item: schedule_services.ScheduleEventItem) -> str:
+    return (
+        f"  {item.id}\t{item.status}\t{format_timestamp(item.start_time)}\t"
+        f"{format_timestamp(item.end_time)}\t{item.task_id or '-'}\t{item.title}"
+    )
+
+
+def _format_schedule_day(day: schedule_services.ScheduleDay) -> str:
+    lines = [f"date: {day.local_date}", "tasks:"]
+    if day.tasks:
+        lines.extend(_format_schedule_task(item) for item in day.tasks)
+    else:
+        lines.append("  -")
+
+    lines.append("habit_actions:")
+    if day.habit_actions:
+        lines.extend(_format_schedule_habit_action(item) for item in day.habit_actions)
+    else:
+        lines.append("  -")
+
+    lines.append("events:")
+    if day.events:
+        lines.extend(_format_schedule_event(item) for item in day.events)
+    else:
+        lines.append("  -")
+    return "\n".join(lines)
+
+
+async def handle_schedule_show_async(args: argparse.Namespace) -> int:
+    async with db_session.session_scope() as session:
+        day = await schedule_services.get_schedule_for_date(session, target_date=args.target_date)
+    print(_format_schedule_day(day))
+    return 0
+
+
+def handle_schedule_show(args: argparse.Namespace) -> int:
+    return run_async(handle_schedule_show_async(args))
+
+
+async def handle_schedule_list_async(args: argparse.Namespace) -> int:
+    if args.end_date < args.start_date:
+        print("--end-date must be on or after --start-date.", file=sys.stderr)
+        return 1
+    async with db_session.session_scope() as session:
+        days = await schedule_services.list_schedule_in_range(
+            session,
+            start_date=args.start_date,
+            end_date=args.end_date,
+        )
+    print("\n\n".join(_format_schedule_day(day) for day in days))
+    return 0
+
+
+def handle_schedule_list(args: argparse.Namespace) -> int:
+    return run_async(handle_schedule_list_async(args))

--- a/src/lifeos_cli/cli_support/resources/schedule/parser.py
+++ b/src/lifeos_cli/cli_support/resources/schedule/parser.py
@@ -1,0 +1,84 @@
+"""Schedule resource parser construction."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import date
+
+from lifeos_cli.cli_support.help_utils import HelpContent, add_documented_parser, make_help_handler
+from lifeos_cli.cli_support.resources.schedule.handlers import (
+    handle_schedule_list,
+    handle_schedule_show,
+)
+
+
+def build_schedule_parser(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
+    """Build the schedule command tree."""
+    schedule_parser = add_documented_parser(
+        subparsers,
+        "schedule",
+        help_content=HelpContent(
+            summary="Inspect aggregated schedule views",
+            description=(
+                "Show schedule views grouped by local date.\n\n"
+                "Schedule is a CLI read model built from tasks, habit actions, and events."
+            ),
+            examples=(
+                "lifeos schedule show --date 2026-04-10",
+                "lifeos schedule list --start-date 2026-04-10 --end-date 2026-04-16",
+            ),
+            notes=(
+                "Use `show` for one exact local day.",
+                "Use `list` for multi-day ranges.",
+                "Schedule reads from existing domains and does not create a new stored entity.",
+            ),
+        ),
+    )
+    schedule_parser.set_defaults(handler=make_help_handler(schedule_parser))
+    schedule_subparsers = schedule_parser.add_subparsers(
+        dest="schedule_command", title="actions", metavar="action"
+    )
+
+    show_parser = add_documented_parser(
+        schedule_subparsers,
+        "show",
+        help_content=HelpContent(
+            summary="Show one schedule day",
+            description="Show the aggregated schedule for one local day.",
+            examples=("lifeos schedule show --date 2026-04-10",),
+        ),
+    )
+    show_parser.add_argument(
+        "--date",
+        dest="target_date",
+        required=True,
+        type=date.fromisoformat,
+        help="Target local date in YYYY-MM-DD format",
+    )
+    show_parser.set_defaults(handler=handle_schedule_show)
+
+    list_parser = add_documented_parser(
+        schedule_subparsers,
+        "list",
+        help_content=HelpContent(
+            summary="List a schedule range",
+            description="Show the aggregated schedule for a local-date range.",
+            examples=("lifeos schedule list --start-date 2026-04-10 --end-date 2026-04-16",),
+            notes=("The range is inclusive on both start and end dates.",),
+        ),
+    )
+    list_parser.add_argument(
+        "--start-date",
+        required=True,
+        type=date.fromisoformat,
+        help="Range start date in YYYY-MM-DD format",
+    )
+    list_parser.add_argument(
+        "--end-date",
+        required=True,
+        type=date.fromisoformat,
+        help="Range end date in YYYY-MM-DD format",
+    )
+    list_parser.set_defaults(handler=handle_schedule_list)

--- a/src/lifeos_cli/cli_support/resources/schedule/parser.py
+++ b/src/lifeos_cli/cli_support/resources/schedule/parser.py
@@ -23,7 +23,8 @@ def build_schedule_parser(
             summary="Inspect aggregated schedule views",
             description=(
                 "Show schedule views grouped by local date.\n\n"
-                "Schedule is a CLI read model built from tasks, habit actions, and events."
+                "Schedule is a CLI read model built from tasks, habit actions, and events, "
+                "including expanded recurring event occurrences."
             ),
             examples=(
                 "lifeos schedule show --date 2026-04-10",
@@ -32,6 +33,7 @@ def build_schedule_parser(
             notes=(
                 "Use `show` for one exact local day.",
                 "Use `list` for multi-day ranges.",
+                "Dates use the configured timezone and `day_starts_at` preference.",
                 "Schedule reads from existing domains and does not create a new stored entity.",
             ),
         ),
@@ -48,6 +50,7 @@ def build_schedule_parser(
             summary="Show one schedule day",
             description="Show the aggregated schedule for one local day.",
             examples=("lifeos schedule show --date 2026-04-10",),
+            notes=("The output groups tasks, habit actions, and event occurrences for the day.",),
         ),
     )
     show_parser.add_argument(
@@ -66,7 +69,10 @@ def build_schedule_parser(
             summary="List a schedule range",
             description="Show the aggregated schedule for a local-date range.",
             examples=("lifeos schedule list --start-date 2026-04-10 --end-date 2026-04-16",),
-            notes=("The range is inclusive on both start and end dates.",),
+            notes=(
+                "The range is inclusive on both start and end dates.",
+                "Recurring event occurrences are expanded inside the requested range.",
+            ),
         ),
     )
     list_parser.add_argument(

--- a/src/lifeos_cli/db/models/__init__.py
+++ b/src/lifeos_cli/db/models/__init__.py
@@ -2,6 +2,7 @@
 
 from .area import Area
 from .event import Event
+from .event_occurrence_exception import EventOccurrenceException
 from .habit import Habit
 from .habit_action import HabitAction
 from .note import Note
@@ -14,6 +15,7 @@ from .vision import Vision
 __all__ = [
     "Area",
     "Event",
+    "EventOccurrenceException",
     "Habit",
     "HabitAction",
     "Note",

--- a/src/lifeos_cli/db/models/event.py
+++ b/src/lifeos_cli/db/models/event.py
@@ -24,6 +24,8 @@ class Event(UUIDPrimaryKeyMixin, TimestampedMixin, SoftDeleteMixin, Base):
         Index("ix_events_status_start_time", "status", "start_time"),
         Index("ix_events_area_id", "area_id"),
         Index("ix_events_task_id", "task_id"),
+        Index("ix_events_recurrence_parent_event_id", "recurrence_parent_event_id"),
+        Index("ix_events_recurrence_instance_start", "recurrence_instance_start"),
     )
 
     title: Mapped[str] = mapped_column(String(200), nullable=False, index=True)
@@ -37,6 +39,12 @@ class Event(UUIDPrimaryKeyMixin, TimestampedMixin, SoftDeleteMixin, Base):
     priority: Mapped[int] = mapped_column(Integer, nullable=False, default=0, index=True)
     status: Mapped[str] = mapped_column(String(20), nullable=False, default="planned", index=True)
     is_all_day: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    recurrence_frequency: Mapped[str | None] = mapped_column(String(16), nullable=True, index=True)
+    recurrence_interval: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    recurrence_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    recurrence_until: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True, index=True
+    )
     area_id: Mapped[UUID | None] = mapped_column(
         Uuid,
         ForeignKey("areas.id", ondelete="SET NULL"),
@@ -47,9 +55,18 @@ class Event(UUIDPrimaryKeyMixin, TimestampedMixin, SoftDeleteMixin, Base):
         ForeignKey("tasks.id", ondelete="SET NULL"),
         nullable=True,
     )
+    recurrence_parent_event_id: Mapped[UUID | None] = mapped_column(
+        Uuid,
+        ForeignKey("events.id", ondelete="CASCADE"),
+        nullable=True,
+    )
+    recurrence_instance_start: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
     area = relationship("Area", foreign_keys=[area_id])
     task = relationship("Task", foreign_keys=[task_id])
+    recurrence_parent_event = relationship("Event", remote_side="Event.id")
 
     if TYPE_CHECKING:
         tags: list[Tag]

--- a/src/lifeos_cli/db/models/event_occurrence_exception.py
+++ b/src/lifeos_cli/db/models/event_occurrence_exception.py
@@ -1,0 +1,44 @@
+"""Event occurrence exception model for recurring event series."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import DateTime, ForeignKey, Index, String, Uuid, text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from lifeos_cli.db.base import Base, SoftDeleteMixin, TimestampedMixin, UUIDPrimaryKeyMixin
+
+
+class EventOccurrenceException(UUIDPrimaryKeyMixin, TimestampedMixin, SoftDeleteMixin, Base):
+    """Exception row describing a skipped recurring event instance."""
+
+    __tablename__ = "event_occurrence_exceptions"
+    __table_args__ = (
+        Index("ix_event_occurrence_exceptions_master_event_id", "master_event_id"),
+        Index("ix_event_occurrence_exceptions_instance_start", "instance_start"),
+        Index(
+            "uq_event_occurrence_exceptions_master_event_id_instance_start_active",
+            "master_event_id",
+            "instance_start",
+            unique=True,
+            postgresql_where=text("deleted_at IS NULL"),
+        ),
+    )
+
+    master_event_id: Mapped[UUID] = mapped_column(
+        Uuid,
+        ForeignKey("events.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    action: Mapped[str] = mapped_column(String(20), nullable=False, default="skip")
+    instance_start: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+    master_event = relationship("Event", foreign_keys=[master_event_id])
+
+    def __repr__(self) -> str:
+        return (
+            "EventOccurrenceException("
+            f"id={self.id!s}, master_event_id={self.master_event_id!s}, action={self.action!r})"
+        )

--- a/src/lifeos_cli/db/services/event_support.py
+++ b/src/lifeos_cli/db/services/event_support.py
@@ -2,16 +2,20 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
+from typing import Any
 from uuid import UUID
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from lifeos_cli.db.models.area import Area
+from lifeos_cli.db.models.event import Event
 from lifeos_cli.db.models.task import Task
 
 VALID_EVENT_STATUSES = {"planned", "cancelled", "completed"}
+VALID_EVENT_RECURRENCE_FREQUENCIES = {"daily", "weekly"}
+VALID_EVENT_OPERATION_SCOPES = {"single", "all_future", "all"}
 
 
 class EventNotFoundError(LookupError):
@@ -28,6 +32,17 @@ class EventTaskReferenceNotFoundError(LookupError):
 
 class EventValidationError(ValueError):
     """Raised when event data is invalid."""
+
+
+def validate_event_scope(scope: str) -> str:
+    """Validate an event operation scope."""
+    normalized = scope.strip().lower()
+    if normalized not in VALID_EVENT_OPERATION_SCOPES:
+        allowed = ", ".join(sorted(VALID_EVENT_OPERATION_SCOPES))
+        raise EventValidationError(
+            f"Invalid event scope {normalized!r}. Expected one of: {allowed}"
+        )
+    return normalized
 
 
 def validate_event_status(status: str) -> str:
@@ -70,11 +85,146 @@ def normalize_event_datetime(value: datetime, *, field_name: str) -> datetime:
     return value.astimezone(timezone.utc)
 
 
+def normalize_optional_event_datetime(
+    value: datetime | None,
+    *,
+    field_name: str,
+) -> datetime | None:
+    """Normalize an optional event datetime to UTC for storage."""
+    if value is None:
+        return None
+    return normalize_event_datetime(value, field_name=field_name)
+
+
 def validate_event_priority(priority: int) -> int:
     """Validate event priority."""
     if priority < 0 or priority > 5:
         raise EventValidationError("Event priority must be between 0 and 5")
     return priority
+
+
+def validate_event_recurrence(
+    *,
+    start_time: datetime,
+    recurrence_frequency: str | None,
+    recurrence_interval: int | None,
+    recurrence_count: int | None,
+    recurrence_until: datetime | None,
+) -> tuple[str | None, int | None, int | None, datetime | None]:
+    """Validate recurrence fields and normalize defaults."""
+    if recurrence_frequency is None:
+        if any(
+            value is not None for value in (recurrence_interval, recurrence_count, recurrence_until)
+        ):
+            raise EventValidationError(
+                "Recurrence interval, count, and until require recurrence_frequency."
+            )
+        return None, None, None, None
+
+    normalized_frequency = recurrence_frequency.strip().lower()
+    if normalized_frequency not in VALID_EVENT_RECURRENCE_FREQUENCIES:
+        allowed = ", ".join(sorted(VALID_EVENT_RECURRENCE_FREQUENCIES))
+        raise EventValidationError(
+            f"Invalid recurrence frequency {normalized_frequency!r}. Expected one of: {allowed}"
+        )
+
+    normalized_interval = 1 if recurrence_interval is None else recurrence_interval
+    if normalized_interval <= 0:
+        raise EventValidationError("Recurrence interval must be greater than zero")
+    if recurrence_count is not None and recurrence_count <= 0:
+        raise EventValidationError("Recurrence count must be greater than zero")
+    if recurrence_until is not None and recurrence_until < start_time:
+        raise EventValidationError(
+            "Recurrence until must be on or after the first event start time"
+        )
+    return normalized_frequency, normalized_interval, recurrence_count, recurrence_until
+
+
+def event_is_recurring(event: Event | Any) -> bool:
+    """Return whether the event is a recurring master event."""
+    return (
+        getattr(event, "recurrence_parent_event_id", None) is None
+        and getattr(event, "recurrence_frequency", None) is not None
+    )
+
+
+def event_recurrence_step(event: Event | Any) -> timedelta:
+    """Return the recurrence step for a recurring event."""
+    frequency = getattr(event, "recurrence_frequency", None)
+    interval = getattr(event, "recurrence_interval", None) or 1
+    if frequency == "daily":
+        return timedelta(days=interval)
+    if frequency == "weekly":
+        return timedelta(weeks=interval)
+    raise EventValidationError("Recurring events require a supported recurrence frequency")
+
+
+def get_event_occurrence_index(event: Event | Any, *, instance_start: datetime) -> int:
+    """Return the zero-based occurrence index for one recurring event instance."""
+    start_time = event.start_time
+    if instance_start < start_time:
+        raise EventValidationError("Instance start must be on or after the master event start time")
+    step = event_recurrence_step(event)
+    delta_seconds = (instance_start - start_time).total_seconds()
+    step_seconds = step.total_seconds()
+    if delta_seconds % step_seconds != 0:
+        raise EventValidationError("Instance start does not match the recurring event cadence")
+    return int(delta_seconds // step_seconds)
+
+
+def validate_event_instance_start(event: Event | Any, *, instance_start: datetime) -> None:
+    """Validate one recurring event instance start."""
+    if not event_is_recurring(event):
+        raise EventValidationError("Instance-level operations require a recurring master event")
+    occurrence_index = get_event_occurrence_index(event, instance_start=instance_start)
+    recurrence_count = getattr(event, "recurrence_count", None)
+    recurrence_until = getattr(event, "recurrence_until", None)
+    if recurrence_count is not None and occurrence_index >= recurrence_count:
+        raise EventValidationError("Instance start falls outside the recurring series")
+    if recurrence_until is not None and instance_start > recurrence_until:
+        raise EventValidationError("Instance start falls outside the recurring series")
+
+
+def get_previous_event_occurrence_start(
+    event: Event | Any, *, instance_start: datetime
+) -> datetime | None:
+    """Return the previous occurrence start for one recurring event instance."""
+    validate_event_instance_start(event, instance_start=instance_start)
+    if instance_start == event.start_time:
+        return None
+    return instance_start - event_recurrence_step(event)
+
+
+def get_event_occurrence_starts_in_range(
+    event: Event | Any,
+    *,
+    window_start: datetime,
+    window_end: datetime,
+) -> list[datetime]:
+    """Return occurrence start times that overlap the requested window."""
+    if not event_is_recurring(event):
+        return []
+
+    starts: list[datetime] = []
+    current_start = event.start_time
+    recurrence_count = getattr(event, "recurrence_count", None)
+    recurrence_until = getattr(event, "recurrence_until", None)
+    end_time = getattr(event, "end_time", None)
+    duration = end_time - current_start if end_time is not None else None
+    step = event_recurrence_step(event)
+    occurrence_index = 0
+
+    while current_start <= window_end:
+        if recurrence_count is not None and occurrence_index >= recurrence_count:
+            break
+        if recurrence_until is not None and current_start > recurrence_until:
+            break
+        current_end = current_start + duration if duration is not None else None
+        if current_start <= window_end and (current_end is None or current_end >= window_start):
+            starts.append(current_start)
+        current_start += step
+        occurrence_index += 1
+    return starts
 
 
 async def ensure_event_area_exists(session: AsyncSession, area_id: UUID | None) -> None:

--- a/src/lifeos_cli/db/services/events.py
+++ b/src/lifeos_cli/db/services/events.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, datetime, timedelta
 from typing import Any, cast
 from uuid import UUID
 
@@ -340,6 +340,12 @@ async def list_event_occurrences(
     *,
     window_start: datetime,
     window_end: datetime,
+    title_contains: str | None = None,
+    status: str | None = None,
+    area_id: UUID | None = None,
+    task_id: UUID | None = None,
+    person_id: UUID | None = None,
+    tag_id: UUID | None = None,
     include_deleted: bool = False,
 ) -> list[EventOccurrence]:
     """List expanded event occurrences that overlap one time window."""
@@ -354,6 +360,26 @@ async def list_event_occurrences(
     )
     if not include_deleted:
         master_stmt = master_stmt.where(Event.deleted_at.is_(None))
+    if title_contains:
+        master_stmt = master_stmt.where(Event.title.ilike(f"%{title_contains.strip()}%"))
+    if status is not None:
+        master_stmt = master_stmt.where(Event.status == validate_event_status(status))
+    if area_id is not None:
+        master_stmt = master_stmt.where(Event.area_id == area_id)
+    if task_id is not None:
+        master_stmt = master_stmt.where(Event.task_id == task_id)
+    if person_id is not None:
+        master_stmt = master_stmt.join(
+            person_associations,
+            (person_associations.c.entity_id == Event.id)
+            & (person_associations.c.entity_type == "event"),
+        ).where(person_associations.c.person_id == person_id)
+    if tag_id is not None:
+        master_stmt = master_stmt.join(
+            tag_associations,
+            (tag_associations.c.entity_id == Event.id)
+            & (tag_associations.c.entity_type == "event"),
+        ).where(tag_associations.c.tag_id == tag_id)
     masters = list((await session.execute(master_stmt)).scalars())
     master_ids = [event.id for event in masters if event_is_recurring(event)]
     skip_map = await _load_skip_exceptions(session, master_event_ids=master_ids)
@@ -365,6 +391,26 @@ async def list_event_occurrences(
     )
     if not include_deleted:
         override_stmt = override_stmt.where(Event.deleted_at.is_(None))
+    if title_contains:
+        override_stmt = override_stmt.where(Event.title.ilike(f"%{title_contains.strip()}%"))
+    if status is not None:
+        override_stmt = override_stmt.where(Event.status == validate_event_status(status))
+    if area_id is not None:
+        override_stmt = override_stmt.where(Event.area_id == area_id)
+    if task_id is not None:
+        override_stmt = override_stmt.where(Event.task_id == task_id)
+    if person_id is not None:
+        override_stmt = override_stmt.join(
+            person_associations,
+            (person_associations.c.entity_id == Event.id)
+            & (person_associations.c.entity_type == "event"),
+        ).where(person_associations.c.person_id == person_id)
+    if tag_id is not None:
+        override_stmt = override_stmt.join(
+            tag_associations,
+            (tag_associations.c.entity_id == Event.id)
+            & (tag_associations.c.entity_type == "event"),
+        ).where(tag_associations.c.tag_id == tag_id)
     overrides = list((await session.execute(override_stmt)).scalars())
     override_keys = {
         (override.recurrence_parent_event_id, override.recurrence_instance_start): override
@@ -458,24 +504,19 @@ async def list_events(
         window_start = local_window_start
         window_end = local_window_end_exclusive - timedelta(microseconds=1)
 
-    if window_start is not None or window_end is not None:
-        normalized_window_start = window_start or datetime.min.replace(tzinfo=timezone.utc)
-        normalized_window_end = window_end or datetime.max.replace(tzinfo=timezone.utc)
+    if window_start is not None and window_end is not None:
         occurrences = await list_event_occurrences(
             session,
-            window_start=normalized_window_start,
-            window_end=normalized_window_end,
+            window_start=window_start,
+            window_end=window_end,
+            title_contains=title_contains,
+            status=status,
+            area_id=area_id,
+            task_id=task_id,
+            person_id=person_id,
+            tag_id=tag_id,
             include_deleted=include_deleted,
         )
-        if title_contains:
-            normalized_title = title_contains.strip().lower()
-            occurrences = [item for item in occurrences if normalized_title in item.title.lower()]
-        if status is not None:
-            occurrences = [
-                item for item in occurrences if item.status == validate_event_status(status)
-            ]
-        if task_id is not None:
-            occurrences = [item for item in occurrences if item.task_id == task_id]
         return list(occurrences[offset : offset + limit])
 
     stmt = select(Event).options(selectinload(Event.area), selectinload(Event.task))
@@ -489,6 +530,10 @@ async def list_events(
         stmt = stmt.where(Event.area_id == area_id)
     if task_id is not None:
         stmt = stmt.where(Event.task_id == task_id)
+    if window_start is not None:
+        stmt = stmt.where(or_(Event.end_time.is_(None), Event.end_time >= window_start))
+    if window_end is not None:
+        stmt = stmt.where(Event.start_time <= window_end)
     if person_id is not None:
         stmt = stmt.join(
             person_associations,

--- a/src/lifeos_cli/db/services/events.py
+++ b/src/lifeos_cli/db/services/events.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from datetime import date, datetime, timedelta
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+from typing import Any, cast
 from uuid import UUID
 
 from sqlalchemy import or_, select
@@ -11,6 +13,7 @@ from sqlalchemy.orm import selectinload
 
 from lifeos_cli.application.time_preferences import get_utc_window_for_local_date
 from lifeos_cli.db.models.event import Event
+from lifeos_cli.db.models.event_occurrence_exception import EventOccurrenceException
 from lifeos_cli.db.models.person_association import person_associations
 from lifeos_cli.db.models.tag_association import tag_associations
 from lifeos_cli.db.services.batching import BatchDeleteResult, batch_delete_records
@@ -24,12 +27,36 @@ from lifeos_cli.db.services.event_support import (
     deduplicate_event_ids,
     ensure_event_area_exists,
     ensure_event_task_exists,
+    event_is_recurring,
+    get_event_occurrence_index,
+    get_event_occurrence_starts_in_range,
+    get_previous_event_occurrence_start,
     normalize_event_datetime,
+    normalize_optional_event_datetime,
+    validate_event_instance_start,
     validate_event_priority,
+    validate_event_recurrence,
+    validate_event_scope,
     validate_event_status,
     validate_event_time_range,
     validate_event_title,
 )
+
+
+@dataclass(frozen=True)
+class EventOccurrence:
+    """Expanded event occurrence read model."""
+
+    id: UUID
+    title: str
+    status: str
+    start_time: datetime
+    end_time: datetime | None
+    task_id: UUID | None
+    deleted_at: datetime | None
+    source_event_id: UUID
+    instance_start: datetime
+    is_override: bool
 
 
 async def _attach_event_links(session: AsyncSession, event: Event) -> Event:
@@ -52,6 +79,165 @@ async def _attach_event_links_for_many(session: AsyncSession, events: list[Event
     return events
 
 
+def _event_duration(event: Event | Any) -> timedelta | None:
+    end_time = getattr(event, "end_time", None)
+    if end_time is None:
+        return None
+    return cast(datetime, end_time) - cast(datetime, event.start_time)
+
+
+def _event_overlaps_window(
+    event: Event | Any,
+    *,
+    window_start: datetime,
+    window_end: datetime,
+) -> bool:
+    end_time = getattr(event, "end_time", None)
+    return event.start_time <= window_end and (end_time is None or end_time >= window_start)
+
+
+def _event_occurrence_end(event: Event | Any, *, occurrence_start: datetime) -> datetime | None:
+    duration = _event_duration(event)
+    return occurrence_start + duration if duration is not None else None
+
+
+async def _record_skip_exception(
+    session: AsyncSession,
+    *,
+    master_event_id: UUID,
+    instance_start: datetime,
+) -> None:
+    stmt = (
+        select(EventOccurrenceException)
+        .where(
+            EventOccurrenceException.master_event_id == master_event_id,
+            EventOccurrenceException.instance_start == instance_start,
+        )
+        .limit(1)
+    )
+    existing = (await session.execute(stmt)).scalar_one_or_none()
+    if existing is not None:
+        existing.action = "skip"
+        existing.deleted_at = None
+        return
+    session.add(
+        EventOccurrenceException(
+            master_event_id=master_event_id,
+            action="skip",
+            instance_start=instance_start,
+        )
+    )
+
+
+async def _load_skip_exceptions(
+    session: AsyncSession,
+    *,
+    master_event_ids: list[UUID],
+) -> dict[UUID, set[datetime]]:
+    if not master_event_ids:
+        return {}
+    stmt = select(EventOccurrenceException).where(
+        EventOccurrenceException.master_event_id.in_(master_event_ids),
+        EventOccurrenceException.deleted_at.is_(None),
+    )
+    rows = list((await session.execute(stmt)).scalars())
+    result: dict[UUID, set[datetime]] = {}
+    for row in rows:
+        result.setdefault(row.master_event_id, set()).add(row.instance_start)
+    return result
+
+
+async def _get_override_event_for_instance(
+    session: AsyncSession,
+    *,
+    master_event_id: UUID,
+    instance_start: datetime,
+) -> Event | None:
+    stmt = (
+        select(Event)
+        .where(
+            Event.deleted_at.is_(None),
+            Event.recurrence_parent_event_id == master_event_id,
+            Event.recurrence_instance_start == instance_start,
+        )
+        .limit(1)
+    )
+    return (await session.execute(stmt)).scalar_one_or_none()
+
+
+def _resolve_link_ids(
+    *,
+    explicit_ids: list[UUID] | None,
+    clear_flag: bool,
+    existing_items: list[Any] | None,
+) -> list[UUID]:
+    if clear_flag:
+        return []
+    if explicit_ids is not None:
+        return explicit_ids
+    return [item.id for item in (existing_items or [])]
+
+
+async def _apply_event_links(
+    session: AsyncSession,
+    *,
+    event: Event,
+    tag_ids: list[UUID] | None,
+    person_ids: list[UUID] | None,
+) -> None:
+    if tag_ids is not None:
+        await sync_entity_tags(
+            session,
+            entity_id=event.id,
+            entity_type="event",
+            desired_tag_ids=tag_ids,
+        )
+    if person_ids is not None:
+        await sync_entity_people(
+            session,
+            entity_id=event.id,
+            entity_type="event",
+            desired_person_ids=person_ids,
+        )
+
+
+def _build_event_values(
+    *,
+    title: str,
+    start_time: datetime,
+    end_time: datetime | None,
+    description: str | None,
+    priority: int,
+    status: str,
+    is_all_day: bool,
+    area_id: UUID | None,
+    task_id: UUID | None,
+    recurrence_frequency: str | None,
+    recurrence_interval: int | None,
+    recurrence_count: int | None,
+    recurrence_until: datetime | None,
+    recurrence_parent_event_id: UUID | None,
+    recurrence_instance_start: datetime | None,
+) -> dict[str, object]:
+    return {
+        "title": title,
+        "start_time": start_time,
+        "end_time": end_time,
+        "description": description,
+        "priority": priority,
+        "status": status,
+        "is_all_day": is_all_day,
+        "area_id": area_id,
+        "task_id": task_id,
+        "recurrence_frequency": recurrence_frequency,
+        "recurrence_interval": recurrence_interval,
+        "recurrence_count": recurrence_count,
+        "recurrence_until": recurrence_until,
+        "recurrence_parent_event_id": recurrence_parent_event_id,
+        "recurrence_instance_start": recurrence_instance_start,
+    }
+
+
 async def create_event(
     session: AsyncSession,
     *,
@@ -66,39 +252,64 @@ async def create_event(
     task_id: UUID | None = None,
     tag_ids: list[UUID] | None = None,
     person_ids: list[UUID] | None = None,
+    recurrence_frequency: str | None = None,
+    recurrence_interval: int | None = None,
+    recurrence_count: int | None = None,
+    recurrence_until: datetime | None = None,
+    recurrence_parent_event_id: UUID | None = None,
+    recurrence_instance_start: datetime | None = None,
 ) -> Event:
     """Create a new event."""
     normalized_start_time = normalize_event_datetime(start_time, field_name="start_time")
-    normalized_end_time = (
-        normalize_event_datetime(end_time, field_name="end_time") if end_time is not None else None
+    normalized_end_time = normalize_optional_event_datetime(end_time, field_name="end_time")
+    normalized_recurrence_until = normalize_optional_event_datetime(
+        recurrence_until,
+        field_name="recurrence_until",
+    )
+    normalized_instance_start = normalize_optional_event_datetime(
+        recurrence_instance_start,
+        field_name="recurrence_instance_start",
     )
     normalized_title = validate_event_title(title)
     validate_event_time_range(start_time=normalized_start_time, end_time=normalized_end_time)
     normalized_priority = validate_event_priority(priority)
     normalized_status = validate_event_status(status)
+    (
+        normalized_recurrence_frequency,
+        normalized_recurrence_interval,
+        normalized_recurrence_count,
+        normalized_recurrence_until,
+    ) = validate_event_recurrence(
+        start_time=normalized_start_time,
+        recurrence_frequency=recurrence_frequency,
+        recurrence_interval=recurrence_interval,
+        recurrence_count=recurrence_count,
+        recurrence_until=normalized_recurrence_until,
+    )
     await ensure_event_area_exists(session, area_id)
     await ensure_event_task_exists(session, task_id)
     event = Event(
-        title=normalized_title,
-        description=description,
-        start_time=normalized_start_time,
-        end_time=normalized_end_time,
-        priority=normalized_priority,
-        status=normalized_status,
-        is_all_day=is_all_day,
-        area_id=area_id,
-        task_id=task_id,
+        **_build_event_values(
+            title=normalized_title,
+            start_time=normalized_start_time,
+            end_time=normalized_end_time,
+            description=description,
+            priority=normalized_priority,
+            status=normalized_status,
+            is_all_day=is_all_day,
+            area_id=area_id,
+            task_id=task_id,
+            recurrence_frequency=normalized_recurrence_frequency,
+            recurrence_interval=normalized_recurrence_interval,
+            recurrence_count=normalized_recurrence_count,
+            recurrence_until=normalized_recurrence_until,
+            recurrence_parent_event_id=recurrence_parent_event_id,
+            recurrence_instance_start=normalized_instance_start,
+        )
     )
     session.add(event)
     await session.flush()
-    if tag_ids is not None:
-        await sync_entity_tags(
-            session, entity_id=event.id, entity_type="event", desired_tag_ids=tag_ids
-        )
-    if person_ids is not None:
-        await sync_entity_people(
-            session, entity_id=event.id, entity_type="event", desired_person_ids=person_ids
-        )
+    await _apply_event_links(session, event=event, tag_ids=tag_ids, person_ids=person_ids)
     await session.refresh(event)
     return await _attach_event_links(session, event)
 
@@ -124,6 +335,107 @@ async def get_event(
     return await _attach_event_links(session, event)
 
 
+async def list_event_occurrences(
+    session: AsyncSession,
+    *,
+    window_start: datetime,
+    window_end: datetime,
+    include_deleted: bool = False,
+) -> list[EventOccurrence]:
+    """List expanded event occurrences that overlap one time window."""
+    master_stmt = select(Event).where(
+        Event.recurrence_parent_event_id.is_(None),
+        Event.start_time <= window_end,
+        or_(
+            Event.recurrence_frequency.is_not(None),
+            Event.end_time.is_(None),
+            Event.end_time >= window_start,
+        ),
+    )
+    if not include_deleted:
+        master_stmt = master_stmt.where(Event.deleted_at.is_(None))
+    masters = list((await session.execute(master_stmt)).scalars())
+    master_ids = [event.id for event in masters if event_is_recurring(event)]
+    skip_map = await _load_skip_exceptions(session, master_event_ids=master_ids)
+
+    override_stmt = select(Event).where(
+        Event.recurrence_parent_event_id.is_not(None),
+        Event.start_time <= window_end,
+        or_(Event.end_time.is_(None), Event.end_time >= window_start),
+    )
+    if not include_deleted:
+        override_stmt = override_stmt.where(Event.deleted_at.is_(None))
+    overrides = list((await session.execute(override_stmt)).scalars())
+    override_keys = {
+        (override.recurrence_parent_event_id, override.recurrence_instance_start): override
+        for override in overrides
+        if override.recurrence_parent_event_id is not None
+        and override.recurrence_instance_start is not None
+    }
+
+    occurrences: list[EventOccurrence] = []
+    for master in masters:
+        if not event_is_recurring(master):
+            if _event_overlaps_window(master, window_start=window_start, window_end=window_end):
+                occurrences.append(
+                    EventOccurrence(
+                        id=master.id,
+                        title=master.title,
+                        status=master.status,
+                        start_time=master.start_time,
+                        end_time=master.end_time,
+                        task_id=master.task_id,
+                        deleted_at=master.deleted_at,
+                        source_event_id=master.id,
+                        instance_start=master.start_time,
+                        is_override=False,
+                    )
+                )
+            continue
+
+        for occurrence_start in get_event_occurrence_starts_in_range(
+            master,
+            window_start=window_start,
+            window_end=window_end,
+        ):
+            if occurrence_start in skip_map.get(master.id, set()):
+                continue
+            if (master.id, occurrence_start) in override_keys:
+                continue
+            occurrences.append(
+                EventOccurrence(
+                    id=master.id,
+                    title=master.title,
+                    status=master.status,
+                    start_time=occurrence_start,
+                    end_time=_event_occurrence_end(master, occurrence_start=occurrence_start),
+                    task_id=master.task_id,
+                    deleted_at=master.deleted_at,
+                    source_event_id=master.id,
+                    instance_start=occurrence_start,
+                    is_override=False,
+                )
+            )
+
+    for override in overrides:
+        occurrences.append(
+            EventOccurrence(
+                id=override.id,
+                title=override.title,
+                status=override.status,
+                start_time=override.start_time,
+                end_time=override.end_time,
+                task_id=override.task_id,
+                deleted_at=override.deleted_at,
+                source_event_id=override.recurrence_parent_event_id or override.id,
+                instance_start=override.recurrence_instance_start or override.start_time,
+                is_override=True,
+            )
+        )
+
+    return sorted(occurrences, key=lambda item: (item.start_time, item.id))
+
+
 async def list_events(
     session: AsyncSession,
     *,
@@ -139,12 +451,33 @@ async def list_events(
     include_deleted: bool = False,
     limit: int = 100,
     offset: int = 0,
-) -> list[Event]:
+) -> list[object]:
     """List events with optional filters."""
     if local_date is not None:
         local_window_start, local_window_end_exclusive = get_utc_window_for_local_date(local_date)
         window_start = local_window_start
         window_end = local_window_end_exclusive - timedelta(microseconds=1)
+
+    if window_start is not None or window_end is not None:
+        normalized_window_start = window_start or datetime.min.replace(tzinfo=timezone.utc)
+        normalized_window_end = window_end or datetime.max.replace(tzinfo=timezone.utc)
+        occurrences = await list_event_occurrences(
+            session,
+            window_start=normalized_window_start,
+            window_end=normalized_window_end,
+            include_deleted=include_deleted,
+        )
+        if title_contains:
+            normalized_title = title_contains.strip().lower()
+            occurrences = [item for item in occurrences if normalized_title in item.title.lower()]
+        if status is not None:
+            occurrences = [
+                item for item in occurrences if item.status == validate_event_status(status)
+            ]
+        if task_id is not None:
+            occurrences = [item for item in occurrences if item.task_id == task_id]
+        return list(occurrences[offset : offset + limit])
+
     stmt = select(Event).options(selectinload(Event.area), selectinload(Event.task))
     if not include_deleted:
         stmt = stmt.where(Event.deleted_at.is_(None))
@@ -168,51 +501,43 @@ async def list_events(
             (tag_associations.c.entity_id == Event.id)
             & (tag_associations.c.entity_type == "event"),
         ).where(tag_associations.c.tag_id == tag_id)
-    if window_start is not None and window_end is not None:
-        stmt = stmt.where(Event.start_time <= window_end).where(
-            or_(Event.end_time.is_(None), Event.end_time >= window_start)
-        )
-    elif window_start is not None:
-        stmt = stmt.where(or_(Event.end_time.is_(None), Event.end_time >= window_start))
-    elif window_end is not None:
-        stmt = stmt.where(Event.start_time <= window_end)
     stmt = stmt.order_by(Event.start_time.desc(), Event.id.desc()).offset(offset).limit(limit)
     events = list((await session.execute(stmt)).scalars())
-    return await _attach_event_links_for_many(session, events)
+    return list(await _attach_event_links_for_many(session, events))
 
 
-async def update_event(
+async def _update_event_record(
     session: AsyncSession,
     *,
-    event_id: UUID,
-    title: str | None = None,
-    description: str | None = None,
-    clear_description: bool = False,
-    start_time: datetime | None = None,
-    end_time: datetime | None = None,
-    clear_end_time: bool = False,
-    priority: int | None = None,
-    status: str | None = None,
-    is_all_day: bool | None = None,
-    area_id: UUID | None = None,
-    clear_area: bool = False,
-    task_id: UUID | None = None,
-    clear_task: bool = False,
-    tag_ids: list[UUID] | None = None,
-    clear_tags: bool = False,
-    person_ids: list[UUID] | None = None,
-    clear_people: bool = False,
+    event: Event,
+    title: str | None,
+    description: str | None,
+    clear_description: bool,
+    start_time: datetime | None,
+    end_time: datetime | None,
+    clear_end_time: bool,
+    priority: int | None,
+    status: str | None,
+    is_all_day: bool | None,
+    area_id: UUID | None,
+    clear_area: bool,
+    task_id: UUID | None,
+    clear_task: bool,
+    tag_ids: list[UUID] | None,
+    clear_tags: bool,
+    person_ids: list[UUID] | None,
+    clear_people: bool,
+    recurrence_frequency: str | None,
+    recurrence_interval: int | None,
+    recurrence_count: int | None,
+    recurrence_until: datetime | None,
+    clear_recurrence: bool,
 ) -> Event:
-    """Update one event."""
-    event = await get_event(session, event_id=event_id, include_deleted=False)
-    if event is None:
-        raise EventNotFoundError(f"Event {event_id} was not found")
-
-    normalized_start_time = (
-        normalize_event_datetime(start_time, field_name="start_time") if start_time else None
-    )
-    normalized_end_time = (
-        normalize_event_datetime(end_time, field_name="end_time") if end_time else None
+    normalized_start_time = normalize_optional_event_datetime(start_time, field_name="start_time")
+    normalized_end_time = normalize_optional_event_datetime(end_time, field_name="end_time")
+    normalized_recurrence_until = normalize_optional_event_datetime(
+        recurrence_until,
+        field_name="recurrence_until",
     )
     next_start_time = (
         normalized_start_time if normalized_start_time is not None else event.start_time
@@ -225,6 +550,47 @@ async def update_event(
         else event.end_time
     )
     validate_event_time_range(start_time=next_start_time, end_time=next_end_time)
+
+    next_recurrence_frequency = (
+        None
+        if clear_recurrence
+        else recurrence_frequency
+        if recurrence_frequency is not None
+        else getattr(event, "recurrence_frequency", None)
+    )
+    next_recurrence_interval = (
+        None
+        if clear_recurrence
+        else recurrence_interval
+        if recurrence_interval is not None
+        else getattr(event, "recurrence_interval", None)
+    )
+    next_recurrence_count = (
+        None
+        if clear_recurrence
+        else recurrence_count
+        if recurrence_count is not None
+        else getattr(event, "recurrence_count", None)
+    )
+    next_recurrence_until = (
+        None
+        if clear_recurrence
+        else normalized_recurrence_until
+        if normalized_recurrence_until is not None
+        else getattr(event, "recurrence_until", None)
+    )
+    (
+        validated_recurrence_frequency,
+        validated_recurrence_interval,
+        validated_recurrence_count,
+        validated_recurrence_until,
+    ) = validate_event_recurrence(
+        start_time=next_start_time,
+        recurrence_frequency=next_recurrence_frequency,
+        recurrence_interval=next_recurrence_interval,
+        recurrence_count=next_recurrence_count,
+        recurrence_until=next_recurrence_until,
+    )
 
     if title is not None:
         event.title = validate_event_title(title)
@@ -254,31 +620,452 @@ async def update_event(
     elif task_id is not None:
         await ensure_event_task_exists(session, task_id)
         event.task_id = task_id
+    event.recurrence_frequency = validated_recurrence_frequency
+    event.recurrence_interval = validated_recurrence_interval
+    event.recurrence_count = validated_recurrence_count
+    event.recurrence_until = validated_recurrence_until
     if clear_tags:
         await sync_entity_tags(session, entity_id=event.id, entity_type="event", desired_tag_ids=[])
     elif tag_ids is not None:
         await sync_entity_tags(
-            session, entity_id=event.id, entity_type="event", desired_tag_ids=tag_ids
+            session,
+            entity_id=event.id,
+            entity_type="event",
+            desired_tag_ids=tag_ids,
         )
     if clear_people:
         await sync_entity_people(
-            session, entity_id=event.id, entity_type="event", desired_person_ids=[]
+            session,
+            entity_id=event.id,
+            entity_type="event",
+            desired_person_ids=[],
         )
     elif person_ids is not None:
         await sync_entity_people(
-            session, entity_id=event.id, entity_type="event", desired_person_ids=person_ids
+            session,
+            entity_id=event.id,
+            entity_type="event",
+            desired_person_ids=person_ids,
         )
     await session.flush()
     await session.refresh(event)
     return await _attach_event_links(session, event)
 
 
-async def delete_event(session: AsyncSession, *, event_id: UUID) -> None:
-    """Soft-delete one event."""
+async def _update_single_occurrence(
+    session: AsyncSession,
+    *,
+    master_event: Event,
+    instance_start: datetime,
+    title: str | None,
+    description: str | None,
+    clear_description: bool,
+    start_time: datetime | None,
+    end_time: datetime | None,
+    clear_end_time: bool,
+    priority: int | None,
+    status: str | None,
+    is_all_day: bool | None,
+    area_id: UUID | None,
+    clear_area: bool,
+    task_id: UUID | None,
+    clear_task: bool,
+    tag_ids: list[UUID] | None,
+    clear_tags: bool,
+    person_ids: list[UUID] | None,
+    clear_people: bool,
+) -> Event:
+    override_event = await _get_override_event_for_instance(
+        session,
+        master_event_id=master_event.id,
+        instance_start=instance_start,
+    )
+    if override_event is None:
+        override_start_time = start_time if start_time is not None else instance_start
+        override_end_time = (
+            None
+            if clear_end_time
+            else end_time
+            if end_time is not None
+            else _event_occurrence_end(master_event, occurrence_start=instance_start)
+        )
+        resolved_tag_ids = _resolve_link_ids(
+            explicit_ids=tag_ids,
+            clear_flag=clear_tags,
+            existing_items=getattr(master_event, "tags", None),
+        )
+        resolved_person_ids = _resolve_link_ids(
+            explicit_ids=person_ids,
+            clear_flag=clear_people,
+            existing_items=getattr(master_event, "people", None),
+        )
+        override_event = await create_event(
+            session,
+            title=title or master_event.title,
+            description=None
+            if clear_description
+            else description
+            if description is not None
+            else master_event.description,
+            start_time=override_start_time,
+            end_time=override_end_time,
+            priority=priority if priority is not None else master_event.priority,
+            status=status or master_event.status,
+            is_all_day=is_all_day if is_all_day is not None else master_event.is_all_day,
+            area_id=(
+                None if clear_area else area_id if area_id is not None else master_event.area_id
+            ),
+            task_id=(
+                None if clear_task else task_id if task_id is not None else master_event.task_id
+            ),
+            tag_ids=resolved_tag_ids,
+            person_ids=resolved_person_ids,
+            recurrence_parent_event_id=master_event.id,
+            recurrence_instance_start=instance_start,
+        )
+    else:
+        override_event = await _attach_event_links(session, override_event)
+        override_event = await _update_event_record(
+            session,
+            event=override_event,
+            title=title,
+            description=description,
+            clear_description=clear_description,
+            start_time=start_time,
+            end_time=end_time,
+            clear_end_time=clear_end_time,
+            priority=priority,
+            status=status,
+            is_all_day=is_all_day,
+            area_id=area_id,
+            clear_area=clear_area,
+            task_id=task_id,
+            clear_task=clear_task,
+            tag_ids=tag_ids,
+            clear_tags=clear_tags,
+            person_ids=person_ids,
+            clear_people=clear_people,
+            recurrence_frequency=None,
+            recurrence_interval=None,
+            recurrence_count=None,
+            recurrence_until=None,
+            clear_recurrence=False,
+        )
+    await _record_skip_exception(
+        session,
+        master_event_id=master_event.id,
+        instance_start=instance_start,
+    )
+    return override_event
+
+
+async def _update_future_series(
+    session: AsyncSession,
+    *,
+    master_event: Event,
+    instance_start: datetime,
+    title: str | None,
+    description: str | None,
+    clear_description: bool,
+    start_time: datetime | None,
+    end_time: datetime | None,
+    clear_end_time: bool,
+    priority: int | None,
+    status: str | None,
+    is_all_day: bool | None,
+    area_id: UUID | None,
+    clear_area: bool,
+    task_id: UUID | None,
+    clear_task: bool,
+    tag_ids: list[UUID] | None,
+    clear_tags: bool,
+    person_ids: list[UUID] | None,
+    clear_people: bool,
+    recurrence_frequency: str | None,
+    recurrence_interval: int | None,
+    recurrence_count: int | None,
+    recurrence_until: datetime | None,
+    clear_recurrence: bool,
+) -> Event:
+    previous_start = get_previous_event_occurrence_start(
+        master_event,
+        instance_start=instance_start,
+    )
+    if previous_start is None:
+        return await _update_event_record(
+            session,
+            event=master_event,
+            title=title,
+            description=description,
+            clear_description=clear_description,
+            start_time=start_time,
+            end_time=end_time,
+            clear_end_time=clear_end_time,
+            priority=priority,
+            status=status,
+            is_all_day=is_all_day,
+            area_id=area_id,
+            clear_area=clear_area,
+            task_id=task_id,
+            clear_task=clear_task,
+            tag_ids=tag_ids,
+            clear_tags=clear_tags,
+            person_ids=person_ids,
+            clear_people=clear_people,
+            recurrence_frequency=recurrence_frequency,
+            recurrence_interval=recurrence_interval,
+            recurrence_count=recurrence_count,
+            recurrence_until=recurrence_until,
+            clear_recurrence=clear_recurrence,
+        )
+
+    master_event.recurrence_until = previous_start
+    await session.flush()
+
+    resolved_tag_ids = _resolve_link_ids(
+        explicit_ids=tag_ids,
+        clear_flag=clear_tags,
+        existing_items=getattr(master_event, "tags", None),
+    )
+    resolved_person_ids = _resolve_link_ids(
+        explicit_ids=person_ids,
+        clear_flag=clear_people,
+        existing_items=getattr(master_event, "people", None),
+    )
+    next_recurrence_frequency = (
+        None
+        if clear_recurrence
+        else recurrence_frequency
+        if recurrence_frequency is not None
+        else master_event.recurrence_frequency
+    )
+    next_recurrence_interval = (
+        None
+        if clear_recurrence
+        else recurrence_interval
+        if recurrence_interval is not None
+        else master_event.recurrence_interval
+    )
+    next_recurrence_count = recurrence_count
+    if (
+        next_recurrence_count is None
+        and not clear_recurrence
+        and master_event.recurrence_count is not None
+    ):
+        remaining = master_event.recurrence_count - get_event_occurrence_index(
+            master_event,
+            instance_start=instance_start,
+        )
+        next_recurrence_count = remaining
+    next_recurrence_until = (
+        None
+        if clear_recurrence
+        else recurrence_until
+        if recurrence_until is not None
+        else master_event.recurrence_until
+    )
+    return await create_event(
+        session,
+        title=title or master_event.title,
+        description=None
+        if clear_description
+        else description
+        if description is not None
+        else master_event.description,
+        start_time=start_time or instance_start,
+        end_time=None
+        if clear_end_time
+        else end_time
+        if end_time is not None
+        else _event_occurrence_end(master_event, occurrence_start=instance_start),
+        priority=priority if priority is not None else master_event.priority,
+        status=status or master_event.status,
+        is_all_day=is_all_day if is_all_day is not None else master_event.is_all_day,
+        area_id=None if clear_area else area_id if area_id is not None else master_event.area_id,
+        task_id=None if clear_task else task_id if task_id is not None else master_event.task_id,
+        tag_ids=resolved_tag_ids,
+        person_ids=resolved_person_ids,
+        recurrence_frequency=next_recurrence_frequency,
+        recurrence_interval=next_recurrence_interval,
+        recurrence_count=next_recurrence_count,
+        recurrence_until=next_recurrence_until,
+    )
+
+
+async def update_event(
+    session: AsyncSession,
+    *,
+    event_id: UUID,
+    title: str | None = None,
+    description: str | None = None,
+    clear_description: bool = False,
+    start_time: datetime | None = None,
+    end_time: datetime | None = None,
+    clear_end_time: bool = False,
+    priority: int | None = None,
+    status: str | None = None,
+    is_all_day: bool | None = None,
+    area_id: UUID | None = None,
+    clear_area: bool = False,
+    task_id: UUID | None = None,
+    clear_task: bool = False,
+    tag_ids: list[UUID] | None = None,
+    clear_tags: bool = False,
+    person_ids: list[UUID] | None = None,
+    clear_people: bool = False,
+    recurrence_frequency: str | None = None,
+    recurrence_interval: int | None = None,
+    recurrence_count: int | None = None,
+    recurrence_until: datetime | None = None,
+    clear_recurrence: bool = False,
+    scope: str = "all",
+    instance_start: datetime | None = None,
+) -> Event:
+    """Update one event."""
     event = await get_event(session, event_id=event_id, include_deleted=False)
     if event is None:
         raise EventNotFoundError(f"Event {event_id} was not found")
-    event.soft_delete()
+
+    normalized_scope = validate_event_scope(scope)
+    normalized_instance_start = normalize_optional_event_datetime(
+        instance_start,
+        field_name="instance_start",
+    )
+    if normalized_scope in {"single", "all_future"}:
+        if normalized_instance_start is None:
+            raise EventValidationError("Instance-level recurring updates require --instance-start.")
+        validate_event_instance_start(event, instance_start=normalized_instance_start)
+    if normalized_scope == "single":
+        assert normalized_instance_start is not None
+        return await _update_single_occurrence(
+            session,
+            master_event=event,
+            instance_start=normalized_instance_start,
+            title=title,
+            description=description,
+            clear_description=clear_description,
+            start_time=start_time,
+            end_time=end_time,
+            clear_end_time=clear_end_time,
+            priority=priority,
+            status=status,
+            is_all_day=is_all_day,
+            area_id=area_id,
+            clear_area=clear_area,
+            task_id=task_id,
+            clear_task=clear_task,
+            tag_ids=tag_ids,
+            clear_tags=clear_tags,
+            person_ids=person_ids,
+            clear_people=clear_people,
+        )
+    if normalized_scope == "all_future":
+        assert normalized_instance_start is not None
+        return await _update_future_series(
+            session,
+            master_event=event,
+            instance_start=normalized_instance_start,
+            title=title,
+            description=description,
+            clear_description=clear_description,
+            start_time=start_time,
+            end_time=end_time,
+            clear_end_time=clear_end_time,
+            priority=priority,
+            status=status,
+            is_all_day=is_all_day,
+            area_id=area_id,
+            clear_area=clear_area,
+            task_id=task_id,
+            clear_task=clear_task,
+            tag_ids=tag_ids,
+            clear_tags=clear_tags,
+            person_ids=person_ids,
+            clear_people=clear_people,
+            recurrence_frequency=recurrence_frequency,
+            recurrence_interval=recurrence_interval,
+            recurrence_count=recurrence_count,
+            recurrence_until=recurrence_until,
+            clear_recurrence=clear_recurrence,
+        )
+    return await _update_event_record(
+        session,
+        event=event,
+        title=title,
+        description=description,
+        clear_description=clear_description,
+        start_time=start_time,
+        end_time=end_time,
+        clear_end_time=clear_end_time,
+        priority=priority,
+        status=status,
+        is_all_day=is_all_day,
+        area_id=area_id,
+        clear_area=clear_area,
+        task_id=task_id,
+        clear_task=clear_task,
+        tag_ids=tag_ids,
+        clear_tags=clear_tags,
+        person_ids=person_ids,
+        clear_people=clear_people,
+        recurrence_frequency=recurrence_frequency,
+        recurrence_interval=recurrence_interval,
+        recurrence_count=recurrence_count,
+        recurrence_until=recurrence_until,
+        clear_recurrence=clear_recurrence,
+    )
+
+
+async def delete_event(
+    session: AsyncSession,
+    *,
+    event_id: UUID,
+    scope: str = "all",
+    instance_start: datetime | None = None,
+) -> None:
+    """Soft-delete one event or one recurring slice."""
+    event = await get_event(session, event_id=event_id, include_deleted=False)
+    if event is None:
+        raise EventNotFoundError(f"Event {event_id} was not found")
+
+    normalized_scope = validate_event_scope(scope)
+    normalized_instance_start = normalize_optional_event_datetime(
+        instance_start,
+        field_name="instance_start",
+    )
+    if normalized_scope == "all":
+        event.soft_delete()
+        await session.flush()
+        return
+
+    if normalized_instance_start is None:
+        raise EventValidationError("Instance-level recurring deletes require --instance-start.")
+    validate_event_instance_start(event, instance_start=normalized_instance_start)
+
+    if normalized_scope == "single":
+        override_event = await _get_override_event_for_instance(
+            session,
+            master_event_id=event.id,
+            instance_start=normalized_instance_start,
+        )
+        if override_event is not None:
+            override_event.soft_delete()
+        await _record_skip_exception(
+            session,
+            master_event_id=event.id,
+            instance_start=normalized_instance_start,
+        )
+        await session.flush()
+        return
+
+    previous_start = get_previous_event_occurrence_start(
+        event,
+        instance_start=normalized_instance_start,
+    )
+    if previous_start is None:
+        event.soft_delete()
+    else:
+        event.recurrence_until = previous_start
     await session.flush()
 
 
@@ -298,12 +1085,14 @@ async def batch_delete_events(
 __all__ = [
     "EventAreaReferenceNotFoundError",
     "EventNotFoundError",
+    "EventOccurrence",
     "EventTaskReferenceNotFoundError",
     "EventValidationError",
     "batch_delete_events",
     "create_event",
     "delete_event",
     "get_event",
+    "list_event_occurrences",
     "list_events",
     "update_event",
 ]

--- a/src/lifeos_cli/db/services/schedule_queries.py
+++ b/src/lifeos_cli/db/services/schedule_queries.py
@@ -1,0 +1,236 @@
+"""Read-side helpers for CLI schedule views."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from uuid import UUID
+
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from lifeos_cli.application.time_preferences import get_utc_window_for_local_date
+from lifeos_cli.db.models.habit_action import HabitAction
+from lifeos_cli.db.models.task import Task
+from lifeos_cli.db.services.events import EventOccurrence, list_event_occurrences
+
+
+@dataclass(frozen=True)
+class ScheduleTaskItem:
+    """Task item included in a schedule day."""
+
+    id: UUID
+    content: str
+    status: str
+    planning_cycle_type: str
+    planning_cycle_days: int
+    planning_cycle_start_date: date
+    planning_cycle_end_date: date
+
+
+@dataclass(frozen=True)
+class ScheduleHabitActionItem:
+    """Habit-action item included in a schedule day."""
+
+    id: UUID
+    habit_id: UUID
+    habit_title: str
+    action_date: date
+    status: str
+    notes: str | None
+
+
+@dataclass(frozen=True)
+class ScheduleEventItem:
+    """Event item included in a schedule day."""
+
+    id: UUID
+    title: str
+    status: str
+    start_time: datetime
+    end_time: datetime | None
+    task_id: UUID | None
+
+
+@dataclass(frozen=True)
+class ScheduleDay:
+    """Aggregated schedule view for one local date."""
+
+    local_date: date
+    tasks: tuple[ScheduleTaskItem, ...]
+    habit_actions: tuple[ScheduleHabitActionItem, ...]
+    events: tuple[ScheduleEventItem, ...]
+
+
+def _iter_date_range(start_date: date, end_date: date) -> list[date]:
+    day_count = (end_date - start_date).days + 1
+    return [start_date + timedelta(days=offset) for offset in range(day_count)]
+
+
+def _normalize_schedule_range(*, start_date: date, end_date: date) -> tuple[date, date]:
+    if end_date < start_date:
+        raise ValueError("end_date must be on or after start_date")
+    return start_date, end_date
+
+
+def _task_cycle_end_date(task: Task) -> date:
+    assert task.planning_cycle_start_date is not None
+    assert task.planning_cycle_days is not None
+    return task.planning_cycle_start_date + timedelta(days=task.planning_cycle_days - 1)
+
+
+async def _load_schedule_tasks(
+    session: AsyncSession,
+    *,
+    start_date: date,
+    end_date: date,
+) -> list[Task]:
+    stmt = (
+        select(Task)
+        .where(
+            Task.deleted_at.is_(None),
+            Task.planning_cycle_start_date.is_not(None),
+            Task.planning_cycle_days.is_not(None),
+            Task.planning_cycle_type.is_not(None),
+            Task.planning_cycle_start_date <= end_date,
+            Task.planning_cycle_start_date
+            + (Task.planning_cycle_days - 1) * text("INTERVAL '1 day'")
+            >= start_date,
+        )
+        .order_by(Task.planning_cycle_start_date.asc(), Task.display_order.asc(), Task.id.asc())
+    )
+    return list((await session.execute(stmt)).scalars())
+
+
+async def _load_schedule_habit_actions(
+    session: AsyncSession,
+    *,
+    start_date: date,
+    end_date: date,
+) -> list[HabitAction]:
+    stmt = (
+        select(HabitAction)
+        .options(selectinload(HabitAction.habit))
+        .where(
+            HabitAction.deleted_at.is_(None),
+            HabitAction.action_date >= start_date,
+            HabitAction.action_date <= end_date,
+        )
+        .order_by(HabitAction.action_date.asc(), HabitAction.id.asc())
+    )
+    return list((await session.execute(stmt)).scalars())
+
+
+async def _load_schedule_events(
+    session: AsyncSession,
+    *,
+    start_date: date,
+    end_date: date,
+) -> list[EventOccurrence]:
+    range_window_start, _ = get_utc_window_for_local_date(start_date)
+    _, range_window_end_exclusive = get_utc_window_for_local_date(end_date)
+    range_window_end = range_window_end_exclusive - timedelta(microseconds=1)
+    return await list_event_occurrences(
+        session,
+        window_start=range_window_start,
+        window_end=range_window_end,
+    )
+
+
+def _map_task_item(task: Task) -> ScheduleTaskItem:
+    assert task.planning_cycle_type is not None
+    assert task.planning_cycle_days is not None
+    assert task.planning_cycle_start_date is not None
+    return ScheduleTaskItem(
+        id=task.id,
+        content=task.content,
+        status=task.status,
+        planning_cycle_type=task.planning_cycle_type,
+        planning_cycle_days=task.planning_cycle_days,
+        planning_cycle_start_date=task.planning_cycle_start_date,
+        planning_cycle_end_date=_task_cycle_end_date(task),
+    )
+
+
+def _map_habit_action_item(action: HabitAction) -> ScheduleHabitActionItem:
+    assert action.habit is not None
+    return ScheduleHabitActionItem(
+        id=action.id,
+        habit_id=action.habit_id,
+        habit_title=action.habit.title,
+        action_date=action.action_date,
+        status=action.status,
+        notes=action.notes,
+    )
+
+
+def _map_event_item(event: EventOccurrence) -> ScheduleEventItem:
+    return ScheduleEventItem(
+        id=event.id,
+        title=event.title,
+        status=event.status,
+        start_time=event.start_time,
+        end_time=event.end_time,
+        task_id=event.task_id,
+    )
+
+
+async def list_schedule_in_range(
+    session: AsyncSession,
+    *,
+    start_date: date,
+    end_date: date,
+) -> list[ScheduleDay]:
+    """Return a grouped schedule view for one local-date range."""
+    start_date, end_date = _normalize_schedule_range(start_date=start_date, end_date=end_date)
+    dates = _iter_date_range(start_date, end_date)
+    tasks = await _load_schedule_tasks(session, start_date=start_date, end_date=end_date)
+    habit_actions = await _load_schedule_habit_actions(
+        session,
+        start_date=start_date,
+        end_date=end_date,
+    )
+    events = await _load_schedule_events(session, start_date=start_date, end_date=end_date)
+
+    task_items = [_map_task_item(task) for task in tasks]
+    action_items = [_map_habit_action_item(action) for action in habit_actions]
+    event_items = [_map_event_item(event) for event in events]
+
+    days: list[ScheduleDay] = []
+    for current_date in dates:
+        current_tasks = tuple(
+            item
+            for item in task_items
+            if item.planning_cycle_start_date <= current_date <= item.planning_cycle_end_date
+        )
+        current_actions = tuple(item for item in action_items if item.action_date == current_date)
+        (
+            current_window_start,
+            current_window_end_exclusive,
+        ) = get_utc_window_for_local_date(current_date)
+        current_window_end = current_window_end_exclusive - timedelta(microseconds=1)
+        current_events = tuple(
+            item
+            for item in event_items
+            if item.start_time <= current_window_end
+            and (item.end_time is None or item.end_time >= current_window_start)
+        )
+        days.append(
+            ScheduleDay(
+                local_date=current_date,
+                tasks=current_tasks,
+                habit_actions=current_actions,
+                events=current_events,
+            )
+        )
+    return days
+
+
+async def get_schedule_for_date(
+    session: AsyncSession,
+    *,
+    target_date: date,
+) -> ScheduleDay:
+    """Return a grouped schedule view for one local date."""
+    return (await list_schedule_in_range(session, start_date=target_date, end_date=target_date))[0]

--- a/src/lifeos_cli/db/services/schedules.py
+++ b/src/lifeos_cli/db/services/schedules.py
@@ -1,0 +1,21 @@
+"""Schedule service facade."""
+
+from __future__ import annotations
+
+from lifeos_cli.db.services.schedule_queries import (
+    ScheduleDay,
+    ScheduleEventItem,
+    ScheduleHabitActionItem,
+    ScheduleTaskItem,
+    get_schedule_for_date,
+    list_schedule_in_range,
+)
+
+__all__ = [
+    "ScheduleDay",
+    "ScheduleEventItem",
+    "ScheduleHabitActionItem",
+    "ScheduleTaskItem",
+    "get_schedule_for_date",
+    "list_schedule_in_range",
+]

--- a/tests/test_cli_domains.py
+++ b/tests/test_cli_domains.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime
+from typing import cast
 from uuid import UUID
 
 import pytest
@@ -86,6 +87,40 @@ def test_main_event_add_creates_event(
 
     assert exit_code == 0
     assert "Created event 12121212-1212-1212-1212-121212121212" in captured.out
+
+
+def test_main_event_add_passes_recurrence_fields(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    async def fake_create_event(session: object, **kwargs: object) -> object:
+        assert kwargs["recurrence_frequency"] == "daily"
+        assert kwargs["recurrence_interval"] == 2
+        assert kwargs["recurrence_count"] == 5
+        return make_record(id=UUID("34343434-3434-3434-3434-343434343434"))
+
+    monkeypatch.setattr(db_session, "session_scope", make_session_scope())
+    monkeypatch.setattr(events, "create_event", fake_create_event)
+
+    exit_code = cli.main(
+        [
+            "event",
+            "add",
+            "Daily review",
+            "--start-time",
+            "2026-04-10T09:00:00-04:00",
+            "--recurrence-frequency",
+            "daily",
+            "--recurrence-interval",
+            "2",
+            "--recurrence-count",
+            "5",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "Created event 34343434-3434-3434-3434-343434343434" in captured.out
 
 
 def test_main_tag_add_creates_tag(
@@ -370,6 +405,69 @@ def test_main_event_update_rejects_conflicting_clear_area_flags(
 
     assert exit_code == 1
     assert "Use either --area-id or --clear-area, not both." in captured.err
+
+
+def test_main_event_update_passes_scope_fields(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    async def fake_update_event(session: object, **kwargs: object) -> object:
+        assert kwargs["scope"] == "single"
+        instance_start = cast(datetime, kwargs["instance_start"])
+        assert instance_start is not None
+        assert str(instance_start.isoformat()) == "2026-04-10T09:00:00-04:00"
+        return make_record(id=UUID("56565656-5656-5656-5656-565656565656"))
+
+    monkeypatch.setattr(db_session, "session_scope", make_session_scope())
+    monkeypatch.setattr(events, "update_event", fake_update_event)
+
+    exit_code = cli.main(
+        [
+            "event",
+            "update",
+            "56565656-5656-5656-5656-565656565656",
+            "--scope",
+            "single",
+            "--instance-start",
+            "2026-04-10T09:00:00-04:00",
+            "--title",
+            "Updated review",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "Updated event 56565656-5656-5656-5656-565656565656" in captured.out
+
+
+def test_main_event_delete_passes_scope_fields(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    async def fake_delete_event(session: object, **kwargs: object) -> None:
+        assert kwargs["scope"] == "all_future"
+        instance_start = cast(datetime, kwargs["instance_start"])
+        assert instance_start is not None
+        assert str(instance_start.isoformat()) == "2026-04-10T09:00:00-04:00"
+
+    monkeypatch.setattr(db_session, "session_scope", make_session_scope())
+    monkeypatch.setattr(events, "delete_event", fake_delete_event)
+
+    exit_code = cli.main(
+        [
+            "event",
+            "delete",
+            "56565656-5656-5656-5656-565656565656",
+            "--scope",
+            "all_future",
+            "--instance-start",
+            "2026-04-10T09:00:00-04:00",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "Soft-deleted event 56565656-5656-5656-5656-565656565656" in captured.out
 
 
 def test_main_people_update_can_clear_location(

--- a/tests/test_cli_integration_schedule.py
+++ b/tests/test_cli_integration_schedule.py
@@ -63,6 +63,22 @@ def test_real_cli_schedule_workflow(integration_context: IntegrationContext) -> 
     assert_ok(event_result)
     event_id = extract_created_id(event_result.stdout)
 
+    recurring_event_result = run_lifeos(
+        integration_context,
+        "event",
+        "add",
+        "Daily review",
+        "--start-time",
+        "2026-04-10T12:00:00-04:00",
+        "--end-time",
+        "2026-04-10T12:30:00-04:00",
+        "--recurrence-frequency",
+        "daily",
+        "--recurrence-count",
+        "2",
+    )
+    assert_ok(recurring_event_result)
+
     schedule_show_result = run_lifeos(
         integration_context,
         "schedule",
@@ -79,6 +95,7 @@ def test_real_cli_schedule_workflow(integration_context: IntegrationContext) -> 
     assert "Daily Review" in schedule_show_result.stdout
     assert event_id in schedule_show_result.stdout
     assert "Release planning block" in schedule_show_result.stdout
+    assert "Daily review" in schedule_show_result.stdout
 
     schedule_list_result = run_lifeos(
         integration_context,
@@ -93,3 +110,4 @@ def test_real_cli_schedule_workflow(integration_context: IntegrationContext) -> 
     assert "date: 2026-04-10" in schedule_list_result.stdout
     assert "date: 2026-04-11" in schedule_list_result.stdout
     assert task_id in schedule_list_result.stdout
+    assert schedule_list_result.stdout.count("Daily review") == 2

--- a/tests/test_cli_integration_schedule.py
+++ b/tests/test_cli_integration_schedule.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from tests.cli_integration_support import (
+    INTEGRATION_PYTESTMARK,
+    IntegrationContext,
+    assert_ok,
+    extract_created_id,
+    init_context,
+    run_lifeos,
+)
+
+pytestmark = INTEGRATION_PYTESTMARK
+
+
+def test_real_cli_schedule_workflow(integration_context: IntegrationContext) -> None:
+    init_context(integration_context)
+
+    vision_result = run_lifeos(integration_context, "vision", "add", "Launch lifeos-cli")
+    assert_ok(vision_result)
+    vision_id = extract_created_id(vision_result.stdout)
+
+    task_result = run_lifeos(
+        integration_context,
+        "task",
+        "add",
+        "Draft release checklist",
+        "--vision-id",
+        vision_id,
+        "--planning-cycle-type",
+        "week",
+        "--planning-cycle-days",
+        "7",
+        "--planning-cycle-start-date",
+        "2026-04-10",
+    )
+    assert_ok(task_result)
+    task_id = extract_created_id(task_result.stdout)
+
+    habit_result = run_lifeos(
+        integration_context,
+        "habit",
+        "add",
+        "Daily Review",
+        "--start-date",
+        "2026-04-10",
+        "--duration-days",
+        "7",
+    )
+    assert_ok(habit_result)
+
+    event_result = run_lifeos(
+        integration_context,
+        "event",
+        "add",
+        "Release planning block",
+        "--start-time",
+        "2026-04-10T09:00:00-04:00",
+        "--end-time",
+        "2026-04-10T10:00:00-04:00",
+        "--task-id",
+        task_id,
+    )
+    assert_ok(event_result)
+    event_id = extract_created_id(event_result.stdout)
+
+    schedule_show_result = run_lifeos(
+        integration_context,
+        "schedule",
+        "show",
+        "--date",
+        "2026-04-10",
+    )
+    assert_ok(schedule_show_result)
+    assert "date: 2026-04-10" in schedule_show_result.stdout
+    assert "tasks:" in schedule_show_result.stdout
+    assert "habit_actions:" in schedule_show_result.stdout
+    assert "events:" in schedule_show_result.stdout
+    assert task_id in schedule_show_result.stdout
+    assert "Daily Review" in schedule_show_result.stdout
+    assert event_id in schedule_show_result.stdout
+    assert "Release planning block" in schedule_show_result.stdout
+
+    schedule_list_result = run_lifeos(
+        integration_context,
+        "schedule",
+        "list",
+        "--start-date",
+        "2026-04-10",
+        "--end-date",
+        "2026-04-11",
+    )
+    assert_ok(schedule_list_result)
+    assert "date: 2026-04-10" in schedule_list_result.stdout
+    assert "date: 2026-04-11" in schedule_list_result.stdout
+    assert task_id in schedule_list_result.stdout

--- a/tests/test_cli_notes.py
+++ b/tests/test_cli_notes.py
@@ -201,7 +201,7 @@ def test_main_note_search_prints_matching_notes(
 
     assert exit_code == 0
     assert (
-        "44444444-4444-4444-4444-444444444444\tactive\t2026-04-09T04:05:06+00:00\t"
+        "44444444-4444-4444-4444-444444444444\tactive\t2026-04-09T00:05:06-04:00\t"
         "meeting notes for april planning" in captured.out
     )
 
@@ -329,7 +329,7 @@ def test_main_note_list_prints_formatted_notes(
 
     assert exit_code == 0
     assert (
-        "22222222-2222-2222-2222-222222222222\tactive\t2026-04-09T01:02:03+00:00\tfirst note"
+        "22222222-2222-2222-2222-222222222222\tactive\t2026-04-08T21:02:03-04:00\tfirst note"
         in captured.out
     )
 

--- a/tests/test_cli_notes.py
+++ b/tests/test_cli_notes.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+from collections.abc import Iterator
 from pathlib import Path
 from uuid import UUID
 
@@ -18,6 +19,14 @@ from lifeos_cli.db.services.notes import (
     NoteNotFoundError,
 )
 from tests.support import make_record, make_session_scope, utc_datetime
+
+
+@pytest.fixture(autouse=True)
+def _use_stable_note_timezone(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    clear_config_cache()
+    monkeypatch.setenv("LIFEOS_TIMEZONE", "UTC")
+    yield
+    clear_config_cache()
 
 
 def test_main_note_add_creates_note(
@@ -201,7 +210,7 @@ def test_main_note_search_prints_matching_notes(
 
     assert exit_code == 0
     assert (
-        "44444444-4444-4444-4444-444444444444\tactive\t2026-04-09T00:05:06-04:00\t"
+        "44444444-4444-4444-4444-444444444444\tactive\t2026-04-09T04:05:06+00:00\t"
         "meeting notes for april planning" in captured.out
     )
 
@@ -329,7 +338,7 @@ def test_main_note_list_prints_formatted_notes(
 
     assert exit_code == 0
     assert (
-        "22222222-2222-2222-2222-222222222222\tactive\t2026-04-08T21:02:03-04:00\tfirst note"
+        "22222222-2222-2222-2222-222222222222\tactive\t2026-04-09T01:02:03+00:00\tfirst note"
         in captured.out
     )
 

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -127,6 +127,7 @@ def test_cli_top_level_help_describes_command_grammar(capsys) -> None:
     assert "Manage dated habit actions" in captured.out
     assert "timelog" in captured.out
     assert "Manage actual time records" in captured.out
+    assert "primary command reference" in captured.out
     assert 'lifeos note add "Capture an idea"' in captured.out
 
 

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -119,6 +119,8 @@ def test_cli_top_level_help_describes_command_grammar(capsys) -> None:
     assert "Initialize local configuration" in captured.out
     assert "event" in captured.out
     assert "Manage planned schedule events" in captured.out
+    assert "schedule" in captured.out
+    assert "Inspect aggregated schedule views" in captured.out
     assert "people" in captured.out
     assert "Manage people and relationships" in captured.out
     assert "habit-action" in captured.out
@@ -191,6 +193,51 @@ def test_cli_parser_supports_event_list_by_local_date() -> None:
     assert str(args.local_date) == "2026-04-10"
 
 
+def test_cli_parser_supports_event_recurrence_add_flags() -> None:
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "event",
+            "add",
+            "Daily review",
+            "--start-time",
+            "2026-04-10T09:00:00-04:00",
+            "--recurrence-frequency",
+            "daily",
+            "--recurrence-interval",
+            "2",
+            "--recurrence-count",
+            "5",
+        ]
+    )
+
+    assert args.resource == "event"
+    assert args.event_command == "add"
+    assert args.recurrence_frequency == "daily"
+    assert args.recurrence_interval == 2
+    assert args.recurrence_count == 5
+
+
+def test_cli_parser_supports_event_update_scope_flags() -> None:
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "event",
+            "update",
+            "11111111-1111-1111-1111-111111111111",
+            "--scope",
+            "single",
+            "--instance-start",
+            "2026-04-10T09:00:00-04:00",
+        ]
+    )
+
+    assert args.resource == "event"
+    assert args.event_command == "update"
+    assert args.scope == "single"
+    assert args.instance_start.isoformat() == "2026-04-10T09:00:00-04:00"
+
+
 def test_cli_parser_supports_people_add_command() -> None:
     parser = build_parser()
     args = parser.parse_args(["people", "add", "Alice", "--nickname", "ally"])
@@ -199,6 +246,27 @@ def test_cli_parser_supports_people_add_command() -> None:
     assert args.people_command == "add"
     assert args.name == "Alice"
     assert args.nickname == ["ally"]
+
+
+def test_cli_parser_supports_schedule_show_command() -> None:
+    parser = build_parser()
+    args = parser.parse_args(["schedule", "show", "--date", "2026-04-10"])
+
+    assert args.resource == "schedule"
+    assert args.schedule_command == "show"
+    assert str(args.target_date) == "2026-04-10"
+
+
+def test_cli_parser_supports_schedule_list_command() -> None:
+    parser = build_parser()
+    args = parser.parse_args(
+        ["schedule", "list", "--start-date", "2026-04-10", "--end-date", "2026-04-16"]
+    )
+
+    assert args.resource == "schedule"
+    assert args.schedule_command == "list"
+    assert str(args.start_date) == "2026-04-10"
+    assert str(args.end_date) == "2026-04-16"
 
 
 def test_cli_parser_supports_people_update_clear_location_command() -> None:

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -130,6 +130,34 @@ def test_cli_top_level_help_describes_command_grammar(capsys) -> None:
     assert 'lifeos note add "Capture an idea"' in captured.out
 
 
+def test_cli_schedule_help_describes_read_model_and_occurrences(capsys) -> None:
+    parser = build_parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["schedule", "--help"])
+
+    captured = capsys.readouterr()
+
+    assert (
+        "Schedule is a CLI read model built from tasks, habit actions, and events" in captured.out
+    )
+    assert "expanded recurring event occurrences" in captured.out
+    assert "Dates use the configured timezone and `day_starts_at` preference." in captured.out
+
+
+def test_cli_event_delete_help_describes_recurring_scope_requirements(capsys) -> None:
+    parser = build_parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["event", "delete", "--help"])
+
+    captured = capsys.readouterr()
+
+    assert "Use `--scope single|all_future|all` for recurring series deletes." in captured.out
+    assert "`--scope single` and `--scope all_future` require `--instance-start`." in captured.out
+    assert "--scope all_future --instance-start 2026-04-10T09:00:00-04:00" in captured.out
+
+
 def test_cli_parser_supports_area_add_command() -> None:
     parser = build_parser()
     args = parser.parse_args(

--- a/tests/test_cli_schedule.py
+++ b/tests/test_cli_schedule.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from datetime import date
+from uuid import UUID
+
+import pytest
+
+from lifeos_cli import cli
+from lifeos_cli.db import session as db_session
+from lifeos_cli.db.services import schedules
+from tests.support import make_session_scope, utc_datetime
+
+
+def test_main_schedule_show_prints_grouped_sections(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    async def fake_get_schedule_for_date(session: object, *, target_date: date) -> object:
+        assert str(target_date) == "2026-04-10"
+        return schedules.ScheduleDay(
+            local_date=target_date,
+            tasks=(
+                schedules.ScheduleTaskItem(
+                    id=UUID("11111111-1111-1111-1111-111111111111"),
+                    content="Draft release checklist",
+                    status="todo",
+                    planning_cycle_type="week",
+                    planning_cycle_days=7,
+                    planning_cycle_start_date=target_date,
+                    planning_cycle_end_date=target_date,
+                ),
+            ),
+            habit_actions=(
+                schedules.ScheduleHabitActionItem(
+                    id=UUID("22222222-2222-2222-2222-222222222222"),
+                    habit_id=UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+                    habit_title="Daily Review",
+                    action_date=target_date,
+                    status="todo",
+                    notes=None,
+                ),
+            ),
+            events=(
+                schedules.ScheduleEventItem(
+                    id=UUID("33333333-3333-3333-3333-333333333333"),
+                    title="Doctor appointment",
+                    status="planned",
+                    start_time=utc_datetime(2026, 4, 10, 13, 0),
+                    end_time=utc_datetime(2026, 4, 10, 14, 0),
+                    task_id=None,
+                ),
+            ),
+        )
+
+    monkeypatch.setattr(db_session, "session_scope", make_session_scope())
+    monkeypatch.setattr(schedules, "get_schedule_for_date", fake_get_schedule_for_date)
+
+    exit_code = cli.main(["schedule", "show", "--date", "2026-04-10"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "date: 2026-04-10" in captured.out
+    assert "tasks:" in captured.out
+    assert "habit_actions:" in captured.out
+    assert "events:" in captured.out
+    assert "Draft release checklist" in captured.out
+    assert "Daily Review" in captured.out
+    assert "Doctor appointment" in captured.out
+
+
+def test_main_schedule_list_rejects_inverted_date_range(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = cli.main(
+        [
+            "schedule",
+            "list",
+            "--start-date",
+            "2026-04-11",
+            "--end-date",
+            "2026-04-10",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "--end-date must be on or after --start-date." in captured.err

--- a/tests/test_domain_services_time.py
+++ b/tests/test_domain_services_time.py
@@ -126,6 +126,42 @@ def test_create_event_normalizes_offset_datetimes_to_utc(monkeypatch: pytest.Mon
     assert created.end_time == utc_datetime(2026, 4, 10, 14, 0)
 
 
+def test_create_event_accepts_recurrence_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = SimpleNamespace(add=None, flush=AsyncMock(), refresh=AsyncMock())
+
+    def fake_add(_: object) -> None:
+        pass
+
+    async def fake_ensure_area_exists(_: object, __: UUID | None) -> None:
+        return None
+
+    async def fake_ensure_task_exists(_: object, __: UUID | None) -> None:
+        return None
+
+    async def fake_attach_event_links(_: object, event: object) -> object:
+        return event
+
+    session.add = fake_add
+    monkeypatch.setattr(events, "ensure_event_area_exists", fake_ensure_area_exists)
+    monkeypatch.setattr(events, "ensure_event_task_exists", fake_ensure_task_exists)
+    monkeypatch.setattr(events, "_attach_event_links", fake_attach_event_links)
+
+    created = asyncio.run(
+        events.create_event(
+            cast(Any, session),
+            title="Daily review",
+            start_time=utc_datetime(2026, 4, 10, 13, 0),
+            recurrence_frequency="daily",
+            recurrence_interval=2,
+            recurrence_count=5,
+        )
+    )
+
+    assert created.recurrence_frequency == "daily"
+    assert created.recurrence_interval == 2
+    assert created.recurrence_count == 5
+
+
 def test_create_timelog_rejects_naive_datetimes() -> None:
     session = SimpleNamespace()
 
@@ -164,6 +200,10 @@ def test_update_event_can_clear_optional_fields(monkeypatch: pytest.MonkeyPatch)
         priority=3,
         status="planned",
         is_all_day=False,
+        recurrence_frequency=None,
+        recurrence_interval=None,
+        recurrence_count=None,
+        recurrence_until=None,
         area_id=UUID("11111111-1111-1111-1111-111111111111"),
         task_id=UUID("22222222-2222-2222-2222-222222222222"),
     )
@@ -207,6 +247,109 @@ def test_update_event_can_clear_optional_fields(monkeypatch: pytest.MonkeyPatch)
     assert updated_event.task_id is None
     session.flush.assert_awaited_once()
     session.commit.assert_not_called()
+
+
+def test_delete_event_single_records_skip_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    event = SimpleNamespace(
+        id=UUID("abababab-abab-abab-abab-abababababab"),
+        start_time=utc_datetime(2026, 4, 10, 13, 0),
+        end_time=utc_datetime(2026, 4, 10, 14, 0),
+        recurrence_frequency="daily",
+        recurrence_interval=1,
+        recurrence_count=3,
+        recurrence_until=None,
+        recurrence_parent_event_id=None,
+    )
+    session = SimpleNamespace(flush=AsyncMock())
+    record_skip = AsyncMock()
+
+    async def fake_get_event(_: object, *, event_id: UUID, include_deleted: bool = False) -> object:
+        assert event_id == UUID("abababab-abab-abab-abab-abababababab")
+        assert include_deleted is False
+        return event
+
+    async def fake_get_override_event(
+        _: object,
+        *,
+        master_event_id: UUID,
+        instance_start: datetime,
+    ) -> object | None:
+        assert master_event_id == event.id
+        assert instance_start == utc_datetime(2026, 4, 11, 13, 0)
+        return None
+
+    monkeypatch.setattr(events, "get_event", fake_get_event)
+    monkeypatch.setattr(events, "_get_override_event_for_instance", fake_get_override_event)
+    monkeypatch.setattr(events, "_record_skip_exception", record_skip)
+
+    asyncio.run(
+        events.delete_event(
+            cast(Any, session),
+            event_id=UUID("abababab-abab-abab-abab-abababababab"),
+            scope="single",
+            instance_start=utc_datetime(2026, 4, 11, 13, 0),
+        )
+    )
+
+    record_skip.assert_awaited_once()
+    session.flush.assert_awaited_once()
+
+
+def test_list_event_occurrences_expands_recurring_series_and_skips_exceptions() -> None:
+    class _Result:
+        def __init__(self, values: list[object]) -> None:
+            self._values = values
+
+        def scalars(self) -> list[object]:
+            return self._values
+
+    class _Session:
+        def __init__(self) -> None:
+            self._results = [
+                _Result(
+                    [
+                        SimpleNamespace(
+                            id=UUID("abababab-abab-abab-abab-abababababab"),
+                            title="Daily review",
+                            status="planned",
+                            start_time=utc_datetime(2026, 4, 10, 13, 0),
+                            end_time=utc_datetime(2026, 4, 10, 14, 0),
+                            task_id=None,
+                            deleted_at=None,
+                            recurrence_frequency="daily",
+                            recurrence_interval=1,
+                            recurrence_count=3,
+                            recurrence_until=None,
+                            recurrence_parent_event_id=None,
+                        )
+                    ]
+                ),
+                _Result(
+                    [
+                        SimpleNamespace(
+                            master_event_id=UUID("abababab-abab-abab-abab-abababababab"),
+                            instance_start=utc_datetime(2026, 4, 11, 13, 0),
+                        )
+                    ]
+                ),
+                _Result([]),
+            ]
+
+        async def execute(self, statement: object) -> _Result:
+            return self._results.pop(0)
+
+    occurrences = asyncio.run(
+        events.list_event_occurrences(
+            cast(Any, _Session()),
+            window_start=utc_datetime(2026, 4, 10, 0, 0),
+            window_end=utc_datetime(2026, 4, 12, 23, 59),
+        )
+    )
+
+    assert [item.start_time for item in occurrences] == [
+        utc_datetime(2026, 4, 10, 13, 0),
+        utc_datetime(2026, 4, 12, 13, 0),
+    ]
 
 
 def test_update_timelog_can_clear_optional_fields(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_domain_services_time.py
+++ b/tests/test_domain_services_time.py
@@ -352,6 +352,98 @@ def test_list_event_occurrences_expands_recurring_series_and_skips_exceptions() 
     ]
 
 
+def test_list_event_occurrences_applies_all_supported_filters() -> None:
+    class _Result:
+        def __init__(self, values: list[object]) -> None:
+            self._values = values
+
+        def scalars(self) -> list[object]:
+            return self._values
+
+    class _Session:
+        def __init__(self) -> None:
+            self.statements: list[object] = []
+            self._results = [_Result([]), _Result([])]
+
+        async def execute(self, statement: object) -> _Result:
+            self.statements.append(statement)
+            return self._results.pop(0)
+
+    area_id = UUID("11111111-1111-1111-1111-111111111111")
+    task_id = UUID("22222222-2222-2222-2222-222222222222")
+    person_id = UUID("33333333-3333-3333-3333-333333333333")
+    tag_id = UUID("44444444-4444-4444-4444-444444444444")
+    session = _Session()
+
+    occurrences = asyncio.run(
+        events.list_event_occurrences(
+            cast(Any, session),
+            window_start=utc_datetime(2026, 4, 10, 0, 0),
+            window_end=utc_datetime(2026, 4, 12, 23, 59),
+            title_contains="review",
+            status="planned",
+            area_id=area_id,
+            task_id=task_id,
+            person_id=person_id,
+            tag_id=tag_id,
+        )
+    )
+
+    assert occurrences == []
+    assert len(session.statements) == 2
+    master_sql = str(session.statements[0])
+    override_sql = str(session.statements[1])
+
+    for statement_sql in (master_sql, override_sql):
+        assert "person_associations" in statement_sql
+        assert "tag_associations" in statement_sql
+        assert "events.area_id" in statement_sql
+        assert "events.task_id" in statement_sql
+        assert "events.status" in statement_sql
+        assert "title" in statement_sql
+
+
+def test_list_events_with_one_sided_window_uses_overlap_query(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Result:
+        def scalars(self) -> list[object]:
+            return []
+
+    class _Session:
+        def __init__(self) -> None:
+            self.statements: list[object] = []
+
+        async def execute(self, statement: object) -> _Result:
+            self.statements.append(statement)
+            return _Result()
+
+    list_occurrences = AsyncMock(return_value=[])
+
+    async def fake_attach_event_links_for_many(
+        _: object, event_records: list[object]
+    ) -> list[object]:
+        return event_records
+
+    monkeypatch.setattr(events, "list_event_occurrences", list_occurrences)
+    monkeypatch.setattr(events, "_attach_event_links_for_many", fake_attach_event_links_for_many)
+
+    session = _Session()
+    listed = asyncio.run(
+        events.list_events(
+            cast(Any, session),
+            window_start=utc_datetime(2026, 4, 10, 12, 0),
+        )
+    )
+
+    assert listed == []
+    list_occurrences.assert_not_awaited()
+    assert len(session.statements) == 1
+    statement_sql = str(session.statements[0])
+    assert "end_time IS NULL OR" in statement_sql
+    assert "end_time >=" in statement_sql
+
+
 def test_update_timelog_can_clear_optional_fields(monkeypatch: pytest.MonkeyPatch) -> None:
     timelog = SimpleNamespace(
         id=UUID("cdcdcdcd-cdcd-cdcd-cdcd-cdcdcdcdcdcd"),

--- a/tests/test_schedule_queries.py
+++ b/tests/test_schedule_queries.py
@@ -117,6 +117,80 @@ def test_list_schedule_in_range_groups_tasks_actions_and_events(monkeypatch) -> 
     assert [item.title for item in days[1].events] == ["Late call"]
 
 
+def test_list_schedule_in_range_uses_expanded_recurring_event_occurrences(monkeypatch) -> None:
+    async def fake_load_tasks(session: object, *, start_date: date, end_date: date) -> list[object]:
+        assert start_date == date(2026, 4, 10)
+        assert end_date == date(2026, 4, 11)
+        return []
+
+    async def fake_load_habit_actions(
+        session: object, *, start_date: date, end_date: date
+    ) -> list[object]:
+        assert start_date == date(2026, 4, 10)
+        assert end_date == date(2026, 4, 11)
+        return []
+
+    calls: list[tuple[object, object]] = []
+
+    async def fake_list_event_occurrences(
+        session: object,
+        *,
+        window_start: object,
+        window_end: object,
+        **_: object,
+    ) -> list[object]:
+        calls.append((window_start, window_end))
+        return [
+            make_record(
+                id=UUID("33333333-3333-3333-3333-333333333333"),
+                title="Daily review",
+                status="planned",
+                start_time=utc_datetime(2026, 4, 10, 13, 0),
+                end_time=utc_datetime(2026, 4, 10, 13, 30),
+                task_id=None,
+            ),
+            make_record(
+                id=UUID("33333333-3333-3333-3333-333333333333"),
+                title="Daily review",
+                status="planned",
+                start_time=utc_datetime(2026, 4, 11, 13, 0),
+                end_time=utc_datetime(2026, 4, 11, 13, 30),
+                task_id=None,
+            ),
+        ]
+
+    def fake_get_utc_window_for_local_date(target_date: date):
+        if target_date == date(2026, 4, 10):
+            return utc_datetime(2026, 4, 10, 0, 0), utc_datetime(2026, 4, 11, 0, 0)
+        return utc_datetime(2026, 4, 11, 0, 0), utc_datetime(2026, 4, 12, 0, 0)
+
+    monkeypatch.setattr(schedule_queries, "_load_schedule_tasks", fake_load_tasks)
+    monkeypatch.setattr(schedule_queries, "_load_schedule_habit_actions", fake_load_habit_actions)
+    monkeypatch.setattr(schedule_queries, "list_event_occurrences", fake_list_event_occurrences)
+    monkeypatch.setattr(
+        schedule_queries,
+        "get_utc_window_for_local_date",
+        fake_get_utc_window_for_local_date,
+    )
+
+    days = asyncio.run(
+        schedule_queries.list_schedule_in_range(
+            cast(Any, object()),
+            start_date=date(2026, 4, 10),
+            end_date=date(2026, 4, 11),
+        )
+    )
+
+    assert calls == [
+        (
+            utc_datetime(2026, 4, 10, 0, 0),
+            utc_datetime(2026, 4, 11, 23, 59, 59).replace(microsecond=999999),
+        )
+    ]
+    assert [item.title for item in days[0].events] == ["Daily review"]
+    assert [item.title for item in days[1].events] == ["Daily review"]
+
+
 def test_list_schedule_in_range_rejects_inverted_date_range() -> None:
     try:
         asyncio.run(

--- a/tests/test_schedule_queries.py
+++ b/tests/test_schedule_queries.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import date
+from typing import Any, cast
+from uuid import UUID
+
+from lifeos_cli.db.services import schedule_queries
+from tests.support import make_record, utc_datetime
+
+
+def test_load_schedule_tasks_builds_overlap_query() -> None:
+    class _Result:
+        def scalars(self) -> list[object]:
+            return []
+
+    class _Session:
+        statement = None
+
+        async def execute(self, statement: object) -> _Result:
+            self.statement = statement
+            return _Result()
+
+    session = _Session()
+    tasks = asyncio.run(
+        schedule_queries._load_schedule_tasks(
+            cast(Any, session),
+            start_date=date(2026, 4, 10),
+            end_date=date(2026, 4, 11),
+        )
+    )
+
+    assert tasks == []
+    assert session.statement is not None
+
+
+def test_list_schedule_in_range_groups_tasks_actions_and_events(monkeypatch) -> None:
+    async def fake_load_tasks(session: object, *, start_date: date, end_date: date) -> list[object]:
+        assert start_date == date(2026, 4, 10)
+        assert end_date == date(2026, 4, 11)
+        return [
+            make_record(
+                id=UUID("11111111-1111-1111-1111-111111111111"),
+                content="Draft release checklist",
+                status="todo",
+                planning_cycle_type="week",
+                planning_cycle_days=2,
+                planning_cycle_start_date=date(2026, 4, 10),
+            )
+        ]
+
+    async def fake_load_habit_actions(
+        session: object, *, start_date: date, end_date: date
+    ) -> list[object]:
+        assert start_date == date(2026, 4, 10)
+        assert end_date == date(2026, 4, 11)
+        return [
+            make_record(
+                id=UUID("22222222-2222-2222-2222-222222222222"),
+                habit_id=UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+                action_date=date(2026, 4, 10),
+                status="todo",
+                notes=None,
+                habit=make_record(title="Daily Review"),
+            )
+        ]
+
+    async def fake_load_events(
+        session: object,
+        *,
+        start_date: date,
+        end_date: date,
+    ) -> list[object]:
+        assert start_date == date(2026, 4, 10)
+        assert end_date == date(2026, 4, 11)
+        return [
+            make_record(
+                id=UUID("33333333-3333-3333-3333-333333333333"),
+                title="Late call",
+                status="planned",
+                start_time=utc_datetime(2026, 4, 10, 23, 30),
+                end_time=utc_datetime(2026, 4, 11, 1, 0),
+                task_id=None,
+            )
+        ]
+
+    def fake_get_utc_window_for_local_date(target_date: date):
+        if target_date == date(2026, 4, 10):
+            return utc_datetime(2026, 4, 10, 0, 0), utc_datetime(2026, 4, 11, 0, 0)
+        return utc_datetime(2026, 4, 11, 0, 0), utc_datetime(2026, 4, 12, 0, 0)
+
+    monkeypatch.setattr(schedule_queries, "_load_schedule_tasks", fake_load_tasks)
+    monkeypatch.setattr(schedule_queries, "_load_schedule_habit_actions", fake_load_habit_actions)
+    monkeypatch.setattr(schedule_queries, "_load_schedule_events", fake_load_events)
+    monkeypatch.setattr(
+        schedule_queries,
+        "get_utc_window_for_local_date",
+        fake_get_utc_window_for_local_date,
+    )
+
+    days = asyncio.run(
+        schedule_queries.list_schedule_in_range(
+            cast(Any, object()),
+            start_date=date(2026, 4, 10),
+            end_date=date(2026, 4, 11),
+        )
+    )
+
+    assert len(days) == 2
+    assert days[0].local_date == date(2026, 4, 10)
+    assert [item.content for item in days[0].tasks] == ["Draft release checklist"]
+    assert [item.habit_title for item in days[0].habit_actions] == ["Daily Review"]
+    assert [item.title for item in days[0].events] == ["Late call"]
+    assert days[1].local_date == date(2026, 4, 11)
+    assert [item.content for item in days[1].tasks] == ["Draft release checklist"]
+    assert days[1].habit_actions == ()
+    assert [item.title for item in days[1].events] == ["Late call"]
+
+
+def test_list_schedule_in_range_rejects_inverted_date_range() -> None:
+    try:
+        asyncio.run(
+            schedule_queries.list_schedule_in_range(
+                cast(Any, object()),
+                start_date=date(2026, 4, 11),
+                end_date=date(2026, 4, 10),
+            )
+        )
+    except ValueError as exc:
+        assert str(exc) == "end_date must be on or after start_date"
+    else:
+        raise AssertionError("Expected ValueError for inverted schedule range")


### PR DESCRIPTION
## 概述
本 PR 聚焦时间域的两条主线：

- 引入面向 CLI 用户的 `schedule` 统一日程读模型
- 为 `event` 补齐 recurring series 的首版能力

## 模块变更
### 1. schedule 读模型与 CLI
- 新增 `lifeos schedule show --date YYYY-MM-DD`
- 新增 `lifeos schedule list --start-date YYYY-MM-DD --end-date YYYY-MM-DD`
- 基于现有 `task`、`habit-action`、`event` 聚合输出统一日程视图
- 按本地日期分组输出 `tasks`、`habit_actions`、`events`
- `task` 采用 planning cycle overlap 规则纳入 schedule

### 2. recurring event 能力
- 为 `event` 模型新增 recurrence 字段
- 新增 `event_occurrence_exceptions` 模型与迁移
- `event add` 支持 recurrence 参数（当前支持 `daily` / `weekly`）
- `event update` 支持 `--scope single|all_future|all` 与 `--instance-start`
- `event delete` 支持 `--scope single|all_future|all` 与 `--instance-start`
- `schedule` 读模型接入 recurring event occurrence 展开

### 3. 查询语义与回归修正
- 修正 `event list` 在 bounded window recurring 查询下遗漏 `area`、`task`、`person`、`tag` 过滤的问题
- 修正单边 `--window-start` / `--window-end` 查询回退为普通 overlap 过滤，避免无界 recurring 展开

### 4. 文档与测试
- 更新 `docs/cli.md` 中 `schedule` 与 recurring `event` 的说明
- 新增 `schedule` 相关 parser / CLI / service 测试
- 新增 recurring `event` 的 service / parser / CLI 测试
- 补充 `schedule` 的 integration 测试
- 同步修正 note CLI 输出的本地时区断言，和当前输出行为保持一致
- 为 recurring 查询过滤与单边窗口语义补充回归测试

## 校验
- `bash ./scripts/doctor.sh`

## Issue 关联
- Closes #30
- Closes #31
- Closes #32
- Closes #33
