### PR TITLE
fix: shorten occurrence exception constraint identifier to comply with postgres limit

### DIFF
--- a/src/lifeos_cli/alembic/versions/20260410_1200_add_event_recurrence_support.py
+++ b/src/lifeos_cli/alembic/versions/20260410_1200_add_event_recurrence_support.py
@@ -121,7 +121,7 @@ def upgrade() -> None:
         schema=schema_name,
     )
     op.create_index(
-        "uq_event_occurrence_exceptions_master_event_id_instance_start_active",
+        "uq_evt_occur_exc_master_id_start_active",
         "event_occurrence_exceptions",
         ["master_event_id", "instance_start"],
         unique=True,
@@ -134,7 +134,7 @@ def downgrade() -> None:
     schema_name = _schema_name()
 
     op.drop_index(
-        "uq_event_occurrence_exceptions_master_event_id_instance_start_active",
+        "uq_evt_occur_exc_master_id_start_active",
         table_name="event_occurrence_exceptions",
         schema=schema_name,
     )

--- a/src/lifeos_cli/db/models/event_occurrence_exception.py
+++ b/src/lifeos_cli/db/models/event_occurrence_exception.py
@@ -19,7 +19,7 @@ class EventOccurrenceException(UUIDPrimaryKeyMixin, TimestampedMixin, SoftDelete
         Index("ix_event_occurrence_exceptions_master_event_id", "master_event_id"),
         Index("ix_event_occurrence_exceptions_instance_start", "instance_start"),
         Index(
-            "uq_event_occurrence_exceptions_master_event_id_instance_start_active",
+            "uq_evt_occur_exc_master_id_start_active",
             "master_event_id",
             "instance_start",
             unique=True,


### PR DESCRIPTION
Resolves #40.

**Description:**
The previous migration `20260410_1200_add_event_recurrence_support.py` used a unique constraint identifier `uq_event_occurrence_exceptions_master_event_id_instance_start_active` which exceeded the PostgreSQL limit of 63 characters (it was 68 characters long). This caused the migration to implicitly rollback the transaction due to schema modifications failing.

**Fix:**
Shortened the constraint name to `uq_evt_occur_exc_master_id_start_active` (39 chars) across Alembic version and SQLAlchemy models.