### PR TITLE
feat: add lifeos config set command

### DIFF
--- a/src/lifeos_cli/application/configuration.py
+++ b/src/lifeos_cli/application/configuration.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 from lifeos_cli.cli_support.runtime_utils import refresh_runtime_configuration
@@ -17,6 +17,7 @@ from lifeos_cli.config import (
     PreferencesSettings,
     detect_default_language,
     detect_default_timezone,
+    parse_boolean_value,
     resolve_config_path,
     validate_database_schema_name,
     validate_database_url,
@@ -55,11 +56,33 @@ class InitializationRequest:
     prompts: InitializationPrompts | None = None
 
 
+SUPPORTED_CONFIG_KEYS = (
+    "database.url",
+    "database.schema",
+    "database.echo",
+    "preferences.timezone",
+    "preferences.language",
+    "preferences.day_starts_at",
+    "preferences.week_starts_on",
+    "preferences.vision_experience_rate_per_hour",
+)
+
+
+@dataclass(frozen=True)
+class ConfigSetResult:
+    """Result of one config set write operation."""
+
+    key: str
+    config_path: Path
+    database_settings: DatabaseSettings
+    preferences_settings: PreferencesSettings
+
+
 def build_database_settings(request: InitializationRequest) -> DatabaseSettings:
     """Build database settings from explicit input, current config, and prompts."""
     config_path = resolve_config_path()
     try:
-        current = DatabaseSettings.from_env()
+        current = DatabaseSettings.from_env(include_overrides=False)
     except (ConfigurationError, ValueError):
         current = DatabaseSettings(
             database_url=None,
@@ -100,7 +123,7 @@ def build_preferences_settings(request: InitializationRequest) -> PreferencesSet
     """Build preference settings from explicit input and current config."""
     config_path = resolve_config_path()
     try:
-        current = PreferencesSettings.from_env()
+        current = PreferencesSettings.from_env(include_overrides=False)
     except (ConfigurationError, ValueError):
         current = PreferencesSettings(
             timezone=detect_default_timezone(),
@@ -144,3 +167,69 @@ def persist_runtime_settings(
     )
     refresh_runtime_configuration()
     return config_path
+
+
+def set_runtime_config_value(*, key: str, value: str) -> ConfigSetResult:
+    """Persist one supported runtime config key and refresh caches."""
+    normalized_key = key.strip()
+    if normalized_key not in SUPPORTED_CONFIG_KEYS:
+        supported_keys = ", ".join(SUPPORTED_CONFIG_KEYS)
+        raise ConfigurationError(
+            f"Unsupported config key {normalized_key!r}. Supported keys: {supported_keys}"
+        )
+
+    database_settings = DatabaseSettings.from_env(include_overrides=False)
+    preferences_settings = PreferencesSettings.from_env(include_overrides=False)
+
+    if normalized_key == "database.url":
+        database_settings = replace(
+            database_settings,
+            database_url=validate_database_url(value),
+        )
+    elif normalized_key == "database.schema":
+        database_settings = replace(
+            database_settings,
+            database_schema=validate_database_schema_name(value),
+        )
+    elif normalized_key == "database.echo":
+        database_settings = replace(
+            database_settings,
+            database_echo=parse_boolean_value(value, field_name="Config key `database.echo`"),
+        )
+    elif normalized_key == "preferences.timezone":
+        preferences_settings = replace(
+            preferences_settings,
+            timezone=validate_timezone_name(value),
+        )
+    elif normalized_key == "preferences.language":
+        preferences_settings = replace(
+            preferences_settings,
+            language=validate_language(value),
+        )
+    elif normalized_key == "preferences.day_starts_at":
+        preferences_settings = replace(
+            preferences_settings,
+            day_starts_at=validate_day_starts_at(value),
+        )
+    elif normalized_key == "preferences.week_starts_on":
+        preferences_settings = replace(
+            preferences_settings,
+            week_starts_on=validate_week_starts_on(value),
+        )
+    elif normalized_key == "preferences.vision_experience_rate_per_hour":
+        preferences_settings = replace(
+            preferences_settings,
+            vision_experience_rate_per_hour=validate_vision_experience_rate_per_hour(value),
+        )
+
+    written_path = write_database_settings(
+        database_settings,
+        preferences=preferences_settings,
+    )
+    refresh_runtime_configuration()
+    return ConfigSetResult(
+        key=normalized_key,
+        config_path=written_path,
+        database_settings=database_settings,
+        preferences_settings=preferences_settings,
+    )

--- a/src/lifeos_cli/cli_support/parser.py
+++ b/src/lifeos_cli/cli_support/parser.py
@@ -60,6 +60,7 @@ def build_parser() -> argparse.ArgumentParser:
             examples=(
                 "lifeos init",
                 "lifeos config show",
+                "lifeos config set preferences.timezone America/Toronto",
                 "lifeos db ping",
                 "lifeos data export all --output lifeos-bundle.zip",
                 'lifeos area add "Health"',

--- a/src/lifeos_cli/cli_support/system/config_commands.py
+++ b/src/lifeos_cli/cli_support/system/config_commands.py
@@ -6,11 +6,13 @@ import argparse
 import sys
 
 from lifeos_cli.application.configuration import (
+    SUPPORTED_CONFIG_KEYS,
     InitializationPrompts,
     InitializationRequest,
     build_database_settings,
     build_preferences_settings,
     persist_runtime_settings,
+    set_runtime_config_value,
 )
 from lifeos_cli.application.database import (
     ping_configured_database,
@@ -98,6 +100,21 @@ def _handle_config_show(args: argparse.Namespace) -> int:
         format_config_summary(
             get_database_settings(),
             get_preferences_settings(),
+            show_secrets=args.show_secrets,
+        )
+    )
+    return 0
+
+
+def _handle_config_set(args: argparse.Namespace) -> int:
+    """Persist one supported config key to the local config file."""
+    result = set_runtime_config_value(key=args.key, value=args.value)
+    print(f"Updated config file: {result.config_path}")
+    print(f"Updated key: {result.key}")
+    print(
+        format_config_summary(
+            result.database_settings,
+            result.preferences_settings,
             show_secrets=args.show_secrets,
         )
     )
@@ -206,6 +223,11 @@ def build_config_parser(subparsers: argparse._SubParsersAction[argparse.Argument
             examples=(
                 "lifeos config show",
                 "lifeos config show --show-secrets",
+                "lifeos config set preferences.timezone America/Toronto",
+            ),
+            notes=(
+                "Use `set` to persist supported keys into the local config file.",
+                "Environment variables still override config-file values at runtime.",
             ),
         ),
     )
@@ -236,3 +258,30 @@ def build_config_parser(subparsers: argparse._SubParsersAction[argparse.Argument
         help="Print sensitive values such as database passwords in full",
     )
     show_parser.set_defaults(handler=_handle_config_show)
+
+    set_parser = add_documented_parser(
+        config_subparsers,
+        "set",
+        help_content=HelpContent(
+            summary="Persist one config value",
+            description="Write one supported config key to the local config file.",
+            examples=(
+                "lifeos config set preferences.timezone America/Toronto",
+                "lifeos config set database.echo true",
+                "lifeos config set preferences.vision_experience_rate_per_hour 120",
+            ),
+            notes=(
+                "This command writes the config file, not environment variables.",
+                "Supported keys: " + ", ".join(SUPPORTED_CONFIG_KEYS),
+                "Use `config show` to inspect the effective values after environment overrides.",
+            ),
+        ),
+    )
+    set_parser.add_argument("key", help="Supported config key to update")
+    set_parser.add_argument("value", help="New value to persist for the selected key")
+    set_parser.add_argument(
+        "--show-secrets",
+        action="store_true",
+        help="Print sensitive values such as database passwords in full after writing",
+    )
+    set_parser.set_defaults(handler=_handle_config_set)

--- a/src/lifeos_cli/config.py
+++ b/src/lifeos_cli/config.py
@@ -176,6 +176,16 @@ def _parse_bool(value: str) -> bool:
     return normalized in {"1", "true", "yes", "on"}
 
 
+def parse_boolean_value(value: str, *, field_name: str) -> bool:
+    """Parse a strict boolean string used by explicit CLI write commands."""
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise ConfigurationError(f"{field_name} must be one of: true, false, yes, no, on, off, 1, 0.")
+
+
 def _serialize_toml_string(value: str) -> str:
     escaped = value.replace("\\", "\\\\").replace('"', '\\"')
     return f'"{escaped}"'
@@ -183,14 +193,16 @@ def _serialize_toml_string(value: str) -> str:
 
 def _render_database_table(settings: DatabaseSettings) -> str:
     """Render the `[database]` TOML table for persisted settings."""
-    return "\n".join(
+    lines = ["[database]"]
+    if settings.database_url is not None:
+        lines.append(f"url = {_serialize_toml_string(settings.database_url)}")
+    lines.extend(
         (
-            "[database]",
-            f"url = {_serialize_toml_string(settings.require_database_url())}",
             f"schema = {_serialize_toml_string(settings.database_schema)}",
             f"echo = {'true' if settings.database_echo else 'false'}",
         )
     )
+    return "\n".join(lines)
 
 
 def _render_preferences_table(settings: PreferencesSettings) -> str:
@@ -258,6 +270,20 @@ def load_config_file(config_path: Path) -> dict[str, Any]:
     return loaded
 
 
+def _get_config_table(
+    file_values: Mapping[str, Any],
+    *,
+    config_path: Path,
+    table_name: str,
+) -> dict[str, Any]:
+    table_values = file_values.get(table_name, {})
+    if table_values and not isinstance(table_values, dict):
+        raise ConfigurationError(
+            f"Config file {config_path} must define [{table_name}] as a TOML table"
+        )
+    return table_values if isinstance(table_values, dict) else {}
+
+
 @dataclass(frozen=True)
 class DatabaseSettings:
     """Database settings loaded from config files and environment variables."""
@@ -268,34 +294,38 @@ class DatabaseSettings:
     config_file: Path
 
     @classmethod
-    def from_env(cls, env: Mapping[str, str] | None = None) -> DatabaseSettings:
+    def from_env(
+        cls,
+        env: Mapping[str, str] | None = None,
+        *,
+        include_overrides: bool = True,
+    ) -> DatabaseSettings:
         """Build database settings from config files and environment variables."""
-        source = env or os.environ
+        source = os.environ if env is None else env
         config_path = resolve_config_path(source)
         file_values = load_config_file(config_path)
-        database_values = file_values.get("database", {})
-        if database_values and not isinstance(database_values, dict):
-            raise ConfigurationError(
-                f"Config file {config_path} must define [database] as a TOML table"
-            )
-        database_values = database_values if isinstance(database_values, dict) else {}
+        database_values = _get_config_table(
+            file_values,
+            config_path=config_path,
+            table_name="database",
+        )
 
         file_url = database_values.get("url")
         file_schema = database_values.get("schema")
         file_echo = database_values.get("echo")
 
-        database_url = source.get("LIFEOS_DATABASE_URL")
+        database_url = source.get("LIFEOS_DATABASE_URL") if include_overrides else None
         if database_url is None and isinstance(file_url, str):
             database_url = file_url
         if database_url is not None:
             database_url = validate_database_url(database_url)
 
-        database_schema = source.get("LIFEOS_DATABASE_SCHEMA")
+        database_schema = source.get("LIFEOS_DATABASE_SCHEMA") if include_overrides else None
         if database_schema is None and isinstance(file_schema, str):
             database_schema = file_schema
         database_schema = database_schema or DEFAULT_DATABASE_SCHEMA
 
-        database_echo_value = source.get("LIFEOS_DATABASE_ECHO")
+        database_echo_value = source.get("LIFEOS_DATABASE_ECHO") if include_overrides else None
         if database_echo_value is not None:
             database_echo = _parse_bool(database_echo_value)
         elif isinstance(file_echo, bool):
@@ -345,17 +375,21 @@ class PreferencesSettings:
     config_file: Path
 
     @classmethod
-    def from_env(cls, env: Mapping[str, str] | None = None) -> PreferencesSettings:
+    def from_env(
+        cls,
+        env: Mapping[str, str] | None = None,
+        *,
+        include_overrides: bool = True,
+    ) -> PreferencesSettings:
         """Build preferences from config files and optional environment overrides."""
-        source = env or os.environ
+        source = os.environ if env is None else env
         config_path = resolve_config_path(source)
         file_values = load_config_file(config_path)
-        preference_values = file_values.get("preferences", {})
-        if preference_values and not isinstance(preference_values, dict):
-            raise ConfigurationError(
-                f"Config file {config_path} must define [preferences] as a TOML table"
-            )
-        preference_values = preference_values if isinstance(preference_values, dict) else {}
+        preference_values = _get_config_table(
+            file_values,
+            config_path=config_path,
+            table_name="preferences",
+        )
 
         file_timezone = preference_values.get("timezone")
         file_language = preference_values.get("language")
@@ -363,30 +397,30 @@ class PreferencesSettings:
         file_week_starts_on = preference_values.get("week_starts_on")
         file_vision_experience_rate = preference_values.get("vision_experience_rate_per_hour")
 
-        timezone_value = source.get("LIFEOS_TIMEZONE")
+        timezone_value = source.get("LIFEOS_TIMEZONE") if include_overrides else None
         if timezone_value is None and isinstance(file_timezone, str):
             timezone_value = file_timezone
         timezone_value = validate_timezone_name(timezone_value or detect_default_timezone(source))
 
-        language_value = source.get("LIFEOS_LANGUAGE")
+        language_value = source.get("LIFEOS_LANGUAGE") if include_overrides else None
         if language_value is None and isinstance(file_language, str):
             language_value = file_language
         language_value = validate_language(language_value or detect_default_language(source))
 
-        day_starts_at_value = source.get("LIFEOS_DAY_STARTS_AT")
+        day_starts_at_value = source.get("LIFEOS_DAY_STARTS_AT") if include_overrides else None
         if day_starts_at_value is None and isinstance(file_day_starts_at, str):
             day_starts_at_value = file_day_starts_at
         day_starts_at_value = validate_day_starts_at(day_starts_at_value or DEFAULT_DAY_STARTS_AT)
 
-        week_starts_on_value = source.get("LIFEOS_WEEK_STARTS_ON")
+        week_starts_on_value = source.get("LIFEOS_WEEK_STARTS_ON") if include_overrides else None
         if week_starts_on_value is None and isinstance(file_week_starts_on, str):
             week_starts_on_value = file_week_starts_on
         week_starts_on_value = validate_week_starts_on(
             week_starts_on_value or DEFAULT_WEEK_STARTS_ON
         )
 
-        vision_experience_rate_value: int | str | None = source.get(
-            "LIFEOS_VISION_EXPERIENCE_RATE_PER_HOUR"
+        vision_experience_rate_value: int | str | None = (
+            source.get("LIFEOS_VISION_EXPERIENCE_RATE_PER_HOUR") if include_overrides else None
         )
         if vision_experience_rate_value is None and file_vision_experience_rate is not None:
             vision_experience_rate_value = file_vision_experience_rate

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -203,6 +203,144 @@ def test_main_config_show_masks_database_password(
     clear_config_cache()
 
 
+def test_main_config_set_updates_preference_value(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        "\n".join(
+            (
+                "[database]",
+                'schema = "lifeos"',
+                "echo = false",
+                "",
+                "[preferences]",
+                'timezone = "UTC"',
+                'language = "en"',
+                'day_starts_at = "00:00"',
+                'week_starts_on = "monday"',
+                "vision_experience_rate_per_hour = 60",
+                "",
+                "[notes]",
+                'default_editor = "nvim"',
+                "",
+            )
+        ),
+        encoding="utf-8",
+    )
+    clear_config_cache()
+    monkeypatch.setenv("LIFEOS_CONFIG_FILE", str(config_path))
+
+    exit_code = cli.main(["config", "set", "preferences.timezone", "America/Toronto"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "Updated key: preferences.timezone" in captured.out
+    assert "Preference timezone: America/Toronto" in captured.out
+    content = config_path.read_text(encoding="utf-8")
+    assert 'timezone = "America/Toronto"' in content
+    assert "[notes]" in content
+    assert 'default_editor = "nvim"' in content
+    clear_config_cache()
+
+
+def test_main_config_set_updates_database_echo_strictly(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        "\n".join(
+            (
+                "[database]",
+                'url = "postgresql+psycopg://db-user:<db-password>@localhost:5432/lifeos"',
+                'schema = "lifeos"',
+                "echo = false",
+                "",
+                "[preferences]",
+                'timezone = "UTC"',
+                'language = "en"',
+                'day_starts_at = "00:00"',
+                'week_starts_on = "monday"',
+                "vision_experience_rate_per_hour = 60",
+                "",
+            )
+        ),
+        encoding="utf-8",
+    )
+    clear_config_cache()
+    monkeypatch.setenv("LIFEOS_CONFIG_FILE", str(config_path))
+
+    exit_code = cli.main(["config", "set", "database.echo", "true"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "Database echo: true" in captured.out
+    assert "db-user:***" in captured.out
+    assert "echo = true" in config_path.read_text(encoding="utf-8")
+    clear_config_cache()
+
+
+def test_main_config_set_rejects_unknown_key(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    config_path = tmp_path / "config.toml"
+    clear_config_cache()
+    monkeypatch.setenv("LIFEOS_CONFIG_FILE", str(config_path))
+
+    exit_code = cli.main(["config", "set", "preferences.unknown", "value"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "Unsupported config key" in captured.err
+    assert not config_path.exists()
+    clear_config_cache()
+
+
+def test_main_config_set_ignores_runtime_env_overrides_when_persisting(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        "\n".join(
+            (
+                "[database]",
+                'schema = "lifeos"',
+                "echo = false",
+                "",
+                "[preferences]",
+                'timezone = "America/Toronto"',
+                'language = "zh-Hans"',
+                'day_starts_at = "04:00"',
+                'week_starts_on = "sunday"',
+                "vision_experience_rate_per_hour = 90",
+                "",
+            )
+        ),
+        encoding="utf-8",
+    )
+    clear_config_cache()
+    monkeypatch.setenv("LIFEOS_CONFIG_FILE", str(config_path))
+    monkeypatch.setenv("LIFEOS_TIMEZONE", "UTC")
+
+    exit_code = cli.main(["config", "set", "preferences.language", "en-CA"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "Updated key: preferences.language" in captured.out
+    content = config_path.read_text(encoding="utf-8")
+    assert 'timezone = "America/Toronto"' in content
+    assert 'language = "en-CA"' in content
+    clear_config_cache()
+
+
 def test_main_init_can_repair_invalid_existing_config(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -71,6 +71,16 @@ def test_cli_parser_supports_init_preference_flags() -> None:
     assert args.vision_experience_rate_per_hour == 120
 
 
+def test_cli_parser_supports_config_set_command() -> None:
+    parser = build_parser()
+    args = parser.parse_args(["config", "set", "preferences.timezone", "America/Toronto"])
+
+    assert args.resource == "config"
+    assert args.config_command == "set"
+    assert args.key == "preferences.timezone"
+    assert args.value == "America/Toronto"
+
+
 def test_cli_parser_supports_note_search_command() -> None:
     parser = build_parser()
     args = parser.parse_args(["note", "search", "meeting notes", "--limit", "20"])
@@ -118,6 +128,7 @@ def test_cli_top_level_help_describes_command_grammar(capsys) -> None:
     assert "resources:" in captured.out
     assert "init" in captured.out
     assert "Initialize local configuration" in captured.out
+    assert "lifeos config set preferences.timezone America/Toronto" in captured.out
     assert "data" in captured.out
     assert "Run unified data import/export and batch commands" in captured.out
     assert "event" in captured.out
@@ -149,6 +160,19 @@ def test_cli_schedule_help_describes_read_model_and_occurrences(capsys) -> None:
     )
     assert "expanded recurring event occurrences" in captured.out
     assert "Dates use the configured timezone and `day_starts_at` preference." in captured.out
+
+
+def test_cli_config_help_describes_set_command(capsys) -> None:
+    parser = build_parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["config", "--help"])
+
+    captured = capsys.readouterr()
+
+    assert "show" in captured.out
+    assert "set" in captured.out
+    assert "Environment variables still override config-file values at runtime." in captured.out
 
 
 def test_cli_data_help_describes_snapshot_and_bundle_model(capsys) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,6 +13,7 @@ from lifeos_cli.config import (
     DatabaseSettings,
     PreferencesSettings,
     detect_default_language,
+    parse_boolean_value,
     validate_database_schema_name,
     validate_database_url,
     validate_day_starts_at,
@@ -48,6 +49,36 @@ def test_database_settings_honors_env_values(tmp_path: Path) -> None:
     assert settings.database_url == "postgresql+psycopg://localhost/custom"
     assert settings.database_schema == "lifeos_dev"
     assert settings.database_echo is True
+
+
+def test_database_settings_can_ignore_env_overrides(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        "\n".join(
+            (
+                "[database]",
+                'url = "postgresql+psycopg://localhost/from_file"',
+                'schema = "lifeos_notes"',
+                "echo = false",
+                "",
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    settings = DatabaseSettings.from_env(
+        {
+            "LIFEOS_CONFIG_FILE": str(config_path),
+            "LIFEOS_DATABASE_URL": "postgresql+psycopg://localhost/from_env",
+            "LIFEOS_DATABASE_SCHEMA": "lifeos_dev",
+            "LIFEOS_DATABASE_ECHO": "true",
+        },
+        include_overrides=False,
+    )
+
+    assert settings.database_url == "postgresql+psycopg://localhost/from_file"
+    assert settings.database_schema == "lifeos_notes"
+    assert settings.database_echo is False
 
 
 def test_database_settings_reads_config_file(tmp_path: Path) -> None:
@@ -129,6 +160,42 @@ def test_preferences_settings_read_config_file(tmp_path: Path) -> None:
     )
 
     settings = PreferencesSettings.from_env({"LIFEOS_CONFIG_FILE": str(config_path)})
+
+    assert settings.timezone == "America/Toronto"
+    assert settings.language == "zh-Hans"
+    assert settings.day_starts_at == "04:00"
+    assert settings.week_starts_on == "sunday"
+    assert settings.vision_experience_rate_per_hour == 90
+
+
+def test_preferences_settings_can_ignore_env_overrides(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        "\n".join(
+            (
+                "[preferences]",
+                'timezone = "America/Toronto"',
+                'language = "zh-Hans"',
+                'day_starts_at = "04:00"',
+                'week_starts_on = "sunday"',
+                "vision_experience_rate_per_hour = 90",
+                "",
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    settings = PreferencesSettings.from_env(
+        {
+            "LIFEOS_CONFIG_FILE": str(config_path),
+            "LIFEOS_TIMEZONE": "UTC",
+            "LIFEOS_LANGUAGE": "en",
+            "LIFEOS_DAY_STARTS_AT": "00:00",
+            "LIFEOS_WEEK_STARTS_ON": "monday",
+            "LIFEOS_VISION_EXPERIENCE_RATE_PER_HOUR": "120",
+        },
+        include_overrides=False,
+    )
 
     assert settings.timezone == "America/Toronto"
     assert settings.language == "zh-Hans"
@@ -228,6 +295,45 @@ def test_validate_vision_experience_rate_per_hour_rejects_invalid_values() -> No
         assert "between 1 and 3600" in str(exc)
     else:
         raise AssertionError("invalid vision experience rate should fail")
+
+
+def test_parse_boolean_value_rejects_invalid_values() -> None:
+    assert parse_boolean_value("true", field_name="Config key `database.echo`") is True
+    assert parse_boolean_value("0", field_name="Config key `database.echo`") is False
+
+    try:
+        parse_boolean_value("maybe", field_name="Config key `database.echo`")
+    except ConfigurationError as exc:
+        assert "true, false" in str(exc)
+    else:
+        raise AssertionError("invalid boolean string should fail")
+
+
+def test_write_database_settings_can_write_preferences_without_database_url(tmp_path: Path) -> None:
+    config_path = tmp_path / "lifeos" / "config.toml"
+    database_settings = DatabaseSettings(
+        database_url=None,
+        database_schema="lifeos",
+        database_echo=False,
+        config_file=config_path,
+    )
+    preferences_settings = PreferencesSettings(
+        timezone="America/Toronto",
+        language="zh-Hans",
+        day_starts_at="04:00",
+        week_starts_on="sunday",
+        vision_experience_rate_per_hour=90,
+        config_file=config_path,
+    )
+
+    written_path = write_database_settings(database_settings, preferences=preferences_settings)
+
+    assert written_path == config_path
+    content = config_path.read_text(encoding="utf-8")
+    assert "[database]" in content
+    assert "url =" not in content
+    assert 'schema = "lifeos"' in content
+    assert 'timezone = "America/Toronto"' in content
 
 
 def test_write_database_settings_persists_toml(tmp_path: Path) -> None:


### PR DESCRIPTION
## 概述
- 为 `lifeos config` 新增 `set` 子命令，支持从 CLI 直接写入受支持的配置键。
- 复用现有配置校验与持久化逻辑，避免实现一个通用但不可控的 TOML 编辑器。
- 补充帮助文本与测试覆盖，确保 CLI 帮助、参数解析和文件写入行为一致。

## 模块变更
### 配置应用层
- 在 `application/configuration.py` 中新增受支持键白名单与 `set_runtime_config_value(...)`。
- 写配置时基于配置文件当前值工作，不把当前进程中的 `LIFEOS_*` 环境覆盖值错误落盘。
- 写入后刷新运行时缓存，保持当前进程后续读取一致。

### 配置读写层
- 在 `config.py` 中补充严格布尔值解析。
- 调整数据库配置表渲染逻辑，允许仅更新偏好设置时不强制要求数据库 URL 已存在。
- 为 `DatabaseSettings.from_env(...)` 与 `PreferencesSettings.from_env(...)` 增加可选的 override 忽略模式，用于持久化场景。

### CLI 与帮助文本
- 新增 `lifeos config set <key> <value>`。
- 更新 `lifeos --help`、`lifeos config --help` 与 `lifeos config set --help` 示例和说明。
- `config set` 支持 `--show-secrets`，便于写入后校验敏感配置展示。

### 测试
- 新增 parser、config、CLI 层测试。
- 覆盖受支持键写入、未知键报错、严格布尔解析、保留其它 TOML 顶层 section、忽略运行时环境覆盖值等场景。

## 相关提交
- `a1d16a5` `feat: add config set command`

## 验证
- `bash ./scripts/doctor.sh`

## Issue 关联
- Closes #42
