### PR TITLE
feat: add event types to events and schedule views

### DIFF
--- a/src/lifeos_cli/alembic/versions/20260411_1400_add_event_type_to_events.py
+++ b/src/lifeos_cli/alembic/versions/20260411_1400_add_event_type_to_events.py
@@ -1,0 +1,51 @@
+"""Add first-class event type support."""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260411_1400"
+down_revision = "20260411_0900"
+branch_labels = None
+depends_on = None
+
+
+def _schema_name() -> str:
+    context = op.get_context()
+    return context.version_table_schema or "lifeos"
+
+
+def upgrade() -> None:
+    schema_name = _schema_name()
+
+    op.add_column(
+        "events",
+        sa.Column(
+            "event_type",
+            sa.String(length=20),
+            nullable=False,
+            server_default="appointment",
+        ),
+        schema=schema_name,
+    )
+    op.create_index(
+        "ix_events_event_type",
+        "events",
+        ["event_type"],
+        unique=False,
+        schema=schema_name,
+    )
+    op.alter_column(
+        "events",
+        "event_type",
+        server_default=None,
+        schema=schema_name,
+    )
+
+
+def downgrade() -> None:
+    schema_name = _schema_name()
+
+    op.drop_index("ix_events_event_type", table_name="events", schema=schema_name)
+    op.drop_column("events", "event_type", schema=schema_name)

--- a/src/lifeos_cli/alembic/versions/20260411_1400_add_event_type_to_events.py
+++ b/src/lifeos_cli/alembic/versions/20260411_1400_add_event_type_to_events.py
@@ -36,6 +36,12 @@ def upgrade() -> None:
         unique=False,
         schema=schema_name,
     )
+    op.create_check_constraint(
+        "ck_events_event_type_valid",
+        "events",
+        "event_type IN ('appointment', 'timeblock', 'deadline')",
+        schema=schema_name,
+    )
     op.alter_column(
         "events",
         "event_type",
@@ -47,5 +53,11 @@ def upgrade() -> None:
 def downgrade() -> None:
     schema_name = _schema_name()
 
+    op.drop_constraint(
+        "ck_events_event_type_valid",
+        "events",
+        schema=schema_name,
+        type_="check",
+    )
     op.drop_index("ix_events_event_type", table_name="events", schema=schema_name)
     op.drop_column("events", "event_type", schema=schema_name)

--- a/src/lifeos_cli/cli_support/parser.py
+++ b/src/lifeos_cli/cli_support/parser.py
@@ -68,6 +68,8 @@ def build_parser() -> argparse.ArgumentParser:
                 'lifeos vision add "Launch lifeos-cli" --area-id <area-id>',
                 'lifeos task add "Draft release plan" --vision-id <vision-id>',
                 'lifeos event add "Doctor appointment" --start-time 2026-04-10T09:00:00-04:00',
+                'lifeos event add "Focus Work" --type timeblock '
+                "--start-time 2026-04-10T13:00:00-04:00",
                 "lifeos schedule show --date 2026-04-10",
                 'lifeos timelog add "Deep work" --start-time 2026-04-10T13:00:00-04:00 '
                 "--end-time 2026-04-10T14:30:00-04:00",

--- a/src/lifeos_cli/cli_support/resources/event/handlers.py
+++ b/src/lifeos_cli/cli_support/resources/event/handlers.py
@@ -14,8 +14,9 @@ from lifeos_cli.db.services import events as event_services
 
 def _format_event_summary(event: Any) -> str:
     status = "deleted" if getattr(event, "deleted_at", None) is not None else event.status
+    event_type = getattr(event, "event_type", "appointment")
     return (
-        f"{event.id}\t{status}\t{format_timestamp(event.start_time)}\t"
+        f"{event.id}\t{status}\t{event_type}\t{format_timestamp(event.start_time)}\t"
         f"{format_timestamp(event.end_time)}\t{event.task_id or '-'}\t{event.title}"
     )
 
@@ -31,6 +32,7 @@ def _format_event_detail(event: Any) -> str:
             f"title: {event.title}",
             f"description: {event.description or '-'}",
             f"status: {event.status}",
+            f"event_type: {getattr(event, 'event_type', 'appointment')}",
             f"priority: {event.priority}",
             f"is_all_day: {event.is_all_day}",
             f"start_time: {format_timestamp(event.start_time)}",
@@ -70,6 +72,7 @@ async def handle_event_add_async(args: argparse.Namespace) -> int:
                 end_time=args.end_time,
                 priority=args.priority,
                 status=args.status,
+                event_type=args.event_type,
                 is_all_day=args.all_day,
                 area_id=args.area_id,
                 task_id=args.task_id,
@@ -110,6 +113,7 @@ async def handle_event_list_async(args: argparse.Namespace) -> int:
                 session,
                 title_contains=args.title_contains,
                 status=args.status,
+                event_type=args.event_type,
                 area_id=args.area_id,
                 task_id=args.task_id,
                 person_id=args.person_id,
@@ -197,6 +201,7 @@ async def handle_event_update_async(args: argparse.Namespace) -> int:
                 clear_end_time=args.clear_end_time,
                 priority=args.priority,
                 status=args.status,
+                event_type=args.event_type,
                 is_all_day=args.all_day,
                 area_id=args.area_id,
                 clear_area=args.clear_area,

--- a/src/lifeos_cli/cli_support/resources/event/parser.py
+++ b/src/lifeos_cli/cli_support/resources/event/parser.py
@@ -40,6 +40,8 @@ def build_event_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentP
             ),
             examples=(
                 'lifeos event add "Doctor appointment" --start-time 2026-04-10T09:00:00-04:00',
+                'lifeos event add "Focus Work" --type timeblock '
+                "--start-time 2026-04-10T13:00:00-04:00",
                 "lifeos event list --window-start 2026-04-10T00:00:00-04:00 "
                 "--window-end 2026-04-10T23:59:59-04:00",
                 "lifeos event batch delete --ids <event-id-1> <event-id-2>",
@@ -47,6 +49,7 @@ def build_event_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentP
             notes=(
                 "Use `list` as the primary query entrypoint for events.",
                 "Events can optionally reference one area and one task.",
+                "Event types distinguish hard appointments, flexible timeblocks, and deadlines.",
                 "Delete operations in the public CLI always perform soft deletion.",
             ),
         ),
@@ -65,10 +68,12 @@ def build_event_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentP
             examples=(
                 'lifeos event add "Doctor appointment" --start-time 2026-04-10T09:00:00-04:00 '
                 "--end-time 2026-04-10T10:00:00-04:00",
-                'lifeos event add "Deep work block" --start-time 2026-04-10T13:00:00-04:00 '
+                'lifeos event add "Deep work block" --type timeblock '
+                "--start-time 2026-04-10T13:00:00-04:00 "
                 "--task-id <task-id> --area-id <area-id>",
             ),
             notes=(
+                "`appointment` is the default type. Use `--type` for timeblocks and deadlines.",
                 "Use repeated `--tag-id` and `--person-id` flags to attach tags and people.",
                 "If `--end-time` is omitted, the event is treated as open-ended.",
                 "Use recurrence flags to create a recurring series without renaming the resource.",
@@ -83,6 +88,12 @@ def build_event_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentP
     add_parser.add_argument("--end-time", type=_datetime_value, help="Optional end time")
     add_parser.add_argument("--priority", type=int, default=0, help="Priority from 0 to 5")
     add_parser.add_argument("--status", default="planned", help="Event status")
+    add_parser.add_argument(
+        "--type",
+        dest="event_type",
+        default="appointment",
+        help="Event type: appointment, timeblock, or deadline",
+    )
     add_parser.add_argument(
         "--all-day",
         action=argparse.BooleanOptionalAction,
@@ -142,6 +153,7 @@ def build_event_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentP
                 "lifeos event list --status planned --window-start 2026-04-10T00:00:00-04:00 "
                 "--window-end 2026-04-10T23:59:59-04:00",
                 "lifeos event list --date 2026-04-10",
+                "lifeos event list --type deadline --date 2026-04-10",
                 "lifeos event list --task-id <task-id> --person-id <person-id>",
             ),
             notes=(
@@ -149,6 +161,7 @@ def build_event_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentP
                 "Use `--date` to query one configured local day using your timezone and "
                 "`day_starts_at` preference.",
                 "Recurring series are expanded for bounded window queries and schedule views.",
+                "Use `--type` to narrow results to one event topology.",
                 "Use `--title-contains` for lightweight text filtering instead of a "
                 "separate search command.",
             ),
@@ -156,6 +169,11 @@ def build_event_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentP
     )
     list_parser.add_argument("--title-contains", help="Filter by title substring")
     list_parser.add_argument("--status", help="Filter by event status")
+    list_parser.add_argument(
+        "--type",
+        dest="event_type",
+        help="Filter by event type: appointment, timeblock, or deadline",
+    )
     list_parser.add_argument("--area-id", type=UUID, help="Filter by linked area")
     list_parser.add_argument("--task-id", type=UUID, help="Filter by linked task")
     list_parser.add_argument("--person-id", type=UUID, help="Filter by linked person")
@@ -196,12 +214,14 @@ def build_event_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentP
             description="Update mutable event fields.",
             examples=(
                 "lifeos event update 11111111-1111-1111-1111-111111111111 --status completed",
+                "lifeos event update 11111111-1111-1111-1111-111111111111 --type deadline",
                 "lifeos event update 11111111-1111-1111-1111-111111111111 "
                 "--clear-task --clear-area",
                 "lifeos event update 11111111-1111-1111-1111-111111111111 "
                 "--clear-people --clear-tags",
             ),
             notes=(
+                "Use `--type` to retag an event as appointment, timeblock, or deadline.",
                 "Use `--clear-*` flags to explicitly remove optional values.",
                 "Do not mix a value flag with the matching clear flag in the same command.",
                 "Use `--scope single|all_future|all` for recurring series updates.",
@@ -220,6 +240,11 @@ def build_event_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentP
     update_parser.add_argument("--clear-end-time", action="store_true", help="Clear end time")
     update_parser.add_argument("--priority", type=int, help="Updated priority from 0 to 5")
     update_parser.add_argument("--status", help="Updated event status")
+    update_parser.add_argument(
+        "--type",
+        dest="event_type",
+        help="Updated event type: appointment, timeblock, or deadline",
+    )
     update_parser.add_argument(
         "--all-day",
         action=argparse.BooleanOptionalAction,

--- a/src/lifeos_cli/cli_support/resources/schedule/handlers.py
+++ b/src/lifeos_cli/cli_support/resources/schedule/handlers.py
@@ -57,18 +57,18 @@ def _format_schedule_day(day: schedule_services.ScheduleDay) -> str:
 
     _append_schedule_event_section(
         lines,
-        heading="events_appointments:",
-        events=day.appointment_events,
+        heading="appointments:",
+        events=day.appointments,
     )
     _append_schedule_event_section(
         lines,
-        heading="events_timeblocks:",
-        events=day.timeblock_events,
+        heading="timeblocks:",
+        events=day.timeblocks,
     )
     _append_schedule_event_section(
         lines,
-        heading="events_deadlines:",
-        events=day.deadline_events,
+        heading="deadlines:",
+        events=day.deadlines,
     )
     return "\n".join(lines)
 

--- a/src/lifeos_cli/cli_support/resources/schedule/handlers.py
+++ b/src/lifeos_cli/cli_support/resources/schedule/handlers.py
@@ -29,6 +29,19 @@ def _format_schedule_event(item: schedule_services.ScheduleEventItem) -> str:
     )
 
 
+def _append_schedule_event_section(
+    lines: list[str],
+    *,
+    heading: str,
+    events: tuple[schedule_services.ScheduleEventItem, ...],
+) -> None:
+    lines.append(heading)
+    if events:
+        lines.extend(_format_schedule_event(item) for item in events)
+    else:
+        lines.append("  -")
+
+
 def _format_schedule_day(day: schedule_services.ScheduleDay) -> str:
     lines = [f"date: {day.local_date}", "tasks:"]
     if day.tasks:
@@ -42,11 +55,21 @@ def _format_schedule_day(day: schedule_services.ScheduleDay) -> str:
     else:
         lines.append("  -")
 
-    lines.append("events:")
-    if day.events:
-        lines.extend(_format_schedule_event(item) for item in day.events)
-    else:
-        lines.append("  -")
+    _append_schedule_event_section(
+        lines,
+        heading="events_appointments:",
+        events=day.appointment_events,
+    )
+    _append_schedule_event_section(
+        lines,
+        heading="events_timeblocks:",
+        events=day.timeblock_events,
+    )
+    _append_schedule_event_section(
+        lines,
+        heading="events_deadlines:",
+        events=day.deadline_events,
+    )
     return "\n".join(lines)
 
 

--- a/src/lifeos_cli/cli_support/resources/schedule/parser.py
+++ b/src/lifeos_cli/cli_support/resources/schedule/parser.py
@@ -34,6 +34,7 @@ def build_schedule_parser(
                 "Use `show` for one exact local day.",
                 "Use `list` for multi-day ranges.",
                 "Dates use the configured timezone and `day_starts_at` preference.",
+                "Event output is segmented into appointment, timeblock, and deadline sections.",
                 "Schedule reads from existing domains and does not create a new stored entity.",
             ),
         ),
@@ -50,7 +51,10 @@ def build_schedule_parser(
             summary="Show one schedule day",
             description="Show the aggregated schedule for one local day.",
             examples=("lifeos schedule show --date 2026-04-10",),
-            notes=("The output groups tasks, habit actions, and event occurrences for the day.",),
+            notes=(
+                "The output groups tasks, habit actions, and event occurrences for the day.",
+                "Event occurrences are split into appointment, timeblock, and deadline sections.",
+            ),
         ),
     )
     show_parser.add_argument(
@@ -72,6 +76,7 @@ def build_schedule_parser(
             notes=(
                 "The range is inclusive on both start and end dates.",
                 "Recurring event occurrences are expanded inside the requested range.",
+                "Event occurrences remain segmented by type inside each day block.",
             ),
         ),
     )

--- a/src/lifeos_cli/db/models/event.py
+++ b/src/lifeos_cli/db/models/event.py
@@ -22,6 +22,7 @@ class Event(UUIDPrimaryKeyMixin, TimestampedMixin, SoftDeleteMixin, Base):
     __tablename__ = "events"
     __table_args__ = (
         Index("ix_events_status_start_time", "status", "start_time"),
+        Index("ix_events_event_type", "event_type"),
         Index("ix_events_area_id", "area_id"),
         Index("ix_events_task_id", "task_id"),
         Index("ix_events_recurrence_parent_event_id", "recurrence_parent_event_id"),
@@ -38,6 +39,7 @@ class Event(UUIDPrimaryKeyMixin, TimestampedMixin, SoftDeleteMixin, Base):
     )
     priority: Mapped[int] = mapped_column(Integer, nullable=False, default=0, index=True)
     status: Mapped[str] = mapped_column(String(20), nullable=False, default="planned", index=True)
+    event_type: Mapped[str] = mapped_column(String(20), nullable=False, default="appointment")
     is_all_day: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     recurrence_frequency: Mapped[str | None] = mapped_column(String(16), nullable=True, index=True)
     recurrence_interval: Mapped[int | None] = mapped_column(Integer, nullable=True)
@@ -73,4 +75,8 @@ class Event(UUIDPrimaryKeyMixin, TimestampedMixin, SoftDeleteMixin, Base):
         people: list[Person]
 
     def __repr__(self) -> str:
-        return f"Event(id={self.id!s}, title={self.title!r}, status={self.status!r})"
+        return (
+            "Event("
+            f"id={self.id!s}, title={self.title!r}, status={self.status!r}, "
+            f"event_type={self.event_type!r})"
+        )

--- a/src/lifeos_cli/db/models/event.py
+++ b/src/lifeos_cli/db/models/event.py
@@ -6,7 +6,17 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, Index, Integer, String, Text, Uuid
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    Uuid,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from lifeos_cli.db.base import Base, SoftDeleteMixin, TimestampedMixin, UUIDPrimaryKeyMixin
@@ -21,6 +31,10 @@ class Event(UUIDPrimaryKeyMixin, TimestampedMixin, SoftDeleteMixin, Base):
 
     __tablename__ = "events"
     __table_args__ = (
+        CheckConstraint(
+            "event_type IN ('appointment', 'timeblock', 'deadline')",
+            name="ck_events_event_type_valid",
+        ),
         Index("ix_events_status_start_time", "status", "start_time"),
         Index("ix_events_event_type", "event_type"),
         Index("ix_events_area_id", "area_id"),

--- a/src/lifeos_cli/db/services/event_support.py
+++ b/src/lifeos_cli/db/services/event_support.py
@@ -14,6 +14,7 @@ from lifeos_cli.db.models.event import Event
 from lifeos_cli.db.models.task import Task
 
 VALID_EVENT_STATUSES = {"planned", "cancelled", "completed"}
+VALID_EVENT_TYPES = {"appointment", "timeblock", "deadline"}
 VALID_EVENT_RECURRENCE_FREQUENCIES = {"daily", "weekly"}
 VALID_EVENT_OPERATION_SCOPES = {"single", "all_future", "all"}
 
@@ -53,6 +54,15 @@ def validate_event_status(status: str) -> str:
         raise EventValidationError(
             f"Invalid event status {normalized!r}. Expected one of: {allowed}"
         )
+    return normalized
+
+
+def validate_event_type(event_type: str) -> str:
+    """Validate an event type value."""
+    normalized = event_type.strip().lower()
+    if normalized not in VALID_EVENT_TYPES:
+        allowed = ", ".join(sorted(VALID_EVENT_TYPES))
+        raise EventValidationError(f"Invalid event type {normalized!r}. Expected one of: {allowed}")
     return normalized
 
 

--- a/src/lifeos_cli/db/services/events.py
+++ b/src/lifeos_cli/db/services/events.py
@@ -40,6 +40,7 @@ from lifeos_cli.db.services.event_support import (
     validate_event_status,
     validate_event_time_range,
     validate_event_title,
+    validate_event_type,
 )
 
 
@@ -50,6 +51,7 @@ class EventOccurrence:
     id: UUID
     title: str
     status: str
+    event_type: str
     start_time: datetime
     end_time: datetime | None
     task_id: UUID | None
@@ -209,6 +211,7 @@ def _build_event_values(
     description: str | None,
     priority: int,
     status: str,
+    event_type: str,
     is_all_day: bool,
     area_id: UUID | None,
     task_id: UUID | None,
@@ -226,6 +229,7 @@ def _build_event_values(
         "description": description,
         "priority": priority,
         "status": status,
+        "event_type": event_type,
         "is_all_day": is_all_day,
         "area_id": area_id,
         "task_id": task_id,
@@ -247,6 +251,7 @@ async def create_event(
     description: str | None = None,
     priority: int = 0,
     status: str = "planned",
+    event_type: str = "appointment",
     is_all_day: bool = False,
     area_id: UUID | None = None,
     task_id: UUID | None = None,
@@ -274,6 +279,7 @@ async def create_event(
     validate_event_time_range(start_time=normalized_start_time, end_time=normalized_end_time)
     normalized_priority = validate_event_priority(priority)
     normalized_status = validate_event_status(status)
+    normalized_event_type = validate_event_type(event_type)
     (
         normalized_recurrence_frequency,
         normalized_recurrence_interval,
@@ -296,6 +302,7 @@ async def create_event(
             description=description,
             priority=normalized_priority,
             status=normalized_status,
+            event_type=normalized_event_type,
             is_all_day=is_all_day,
             area_id=area_id,
             task_id=task_id,
@@ -342,6 +349,7 @@ async def list_event_occurrences(
     window_end: datetime,
     title_contains: str | None = None,
     status: str | None = None,
+    event_type: str | None = None,
     area_id: UUID | None = None,
     task_id: UUID | None = None,
     person_id: UUID | None = None,
@@ -364,6 +372,8 @@ async def list_event_occurrences(
         master_stmt = master_stmt.where(Event.title.ilike(f"%{title_contains.strip()}%"))
     if status is not None:
         master_stmt = master_stmt.where(Event.status == validate_event_status(status))
+    if event_type is not None:
+        master_stmt = master_stmt.where(Event.event_type == validate_event_type(event_type))
     if area_id is not None:
         master_stmt = master_stmt.where(Event.area_id == area_id)
     if task_id is not None:
@@ -395,6 +405,8 @@ async def list_event_occurrences(
         override_stmt = override_stmt.where(Event.title.ilike(f"%{title_contains.strip()}%"))
     if status is not None:
         override_stmt = override_stmt.where(Event.status == validate_event_status(status))
+    if event_type is not None:
+        override_stmt = override_stmt.where(Event.event_type == validate_event_type(event_type))
     if area_id is not None:
         override_stmt = override_stmt.where(Event.area_id == area_id)
     if task_id is not None:
@@ -428,6 +440,7 @@ async def list_event_occurrences(
                         id=master.id,
                         title=master.title,
                         status=master.status,
+                        event_type=getattr(master, "event_type", "appointment"),
                         start_time=master.start_time,
                         end_time=master.end_time,
                         task_id=master.task_id,
@@ -453,6 +466,7 @@ async def list_event_occurrences(
                     id=master.id,
                     title=master.title,
                     status=master.status,
+                    event_type=getattr(master, "event_type", "appointment"),
                     start_time=occurrence_start,
                     end_time=_event_occurrence_end(master, occurrence_start=occurrence_start),
                     task_id=master.task_id,
@@ -469,6 +483,7 @@ async def list_event_occurrences(
                 id=override.id,
                 title=override.title,
                 status=override.status,
+                event_type=getattr(override, "event_type", "appointment"),
                 start_time=override.start_time,
                 end_time=override.end_time,
                 task_id=override.task_id,
@@ -487,6 +502,7 @@ async def list_events(
     *,
     title_contains: str | None = None,
     status: str | None = None,
+    event_type: str | None = None,
     area_id: UUID | None = None,
     task_id: UUID | None = None,
     person_id: UUID | None = None,
@@ -511,6 +527,7 @@ async def list_events(
             window_end=window_end,
             title_contains=title_contains,
             status=status,
+            event_type=event_type,
             area_id=area_id,
             task_id=task_id,
             person_id=person_id,
@@ -526,6 +543,8 @@ async def list_events(
         stmt = stmt.where(Event.title.ilike(f"%{title_contains.strip()}%"))
     if status is not None:
         stmt = stmt.where(Event.status == validate_event_status(status))
+    if event_type is not None:
+        stmt = stmt.where(Event.event_type == validate_event_type(event_type))
     if area_id is not None:
         stmt = stmt.where(Event.area_id == area_id)
     if task_id is not None:
@@ -563,6 +582,7 @@ async def _update_event_record(
     clear_end_time: bool,
     priority: int | None,
     status: str | None,
+    event_type: str | None,
     is_all_day: bool | None,
     area_id: UUID | None,
     clear_area: bool,
@@ -653,6 +673,8 @@ async def _update_event_record(
         event.priority = validate_event_priority(priority)
     if status is not None:
         event.status = validate_event_status(status)
+    if event_type is not None:
+        event.event_type = validate_event_type(event_type)
     if is_all_day is not None:
         event.is_all_day = is_all_day
     if clear_area:
@@ -710,6 +732,7 @@ async def _update_single_occurrence(
     clear_end_time: bool,
     priority: int | None,
     status: str | None,
+    event_type: str | None,
     is_all_day: bool | None,
     area_id: UUID | None,
     clear_area: bool,
@@ -756,6 +779,7 @@ async def _update_single_occurrence(
             end_time=override_end_time,
             priority=priority if priority is not None else master_event.priority,
             status=status or master_event.status,
+            event_type=event_type or master_event.event_type,
             is_all_day=is_all_day if is_all_day is not None else master_event.is_all_day,
             area_id=(
                 None if clear_area else area_id if area_id is not None else master_event.area_id
@@ -781,6 +805,7 @@ async def _update_single_occurrence(
             clear_end_time=clear_end_time,
             priority=priority,
             status=status,
+            event_type=event_type,
             is_all_day=is_all_day,
             area_id=area_id,
             clear_area=clear_area,
@@ -817,6 +842,7 @@ async def _update_future_series(
     clear_end_time: bool,
     priority: int | None,
     status: str | None,
+    event_type: str | None,
     is_all_day: bool | None,
     area_id: UUID | None,
     clear_area: bool,
@@ -848,6 +874,7 @@ async def _update_future_series(
             clear_end_time=clear_end_time,
             priority=priority,
             status=status,
+            event_type=event_type,
             is_all_day=is_all_day,
             area_id=area_id,
             clear_area=clear_area,
@@ -925,6 +952,7 @@ async def _update_future_series(
         else _event_occurrence_end(master_event, occurrence_start=instance_start),
         priority=priority if priority is not None else master_event.priority,
         status=status or master_event.status,
+        event_type=event_type or master_event.event_type,
         is_all_day=is_all_day if is_all_day is not None else master_event.is_all_day,
         area_id=None if clear_area else area_id if area_id is not None else master_event.area_id,
         task_id=None if clear_task else task_id if task_id is not None else master_event.task_id,
@@ -949,6 +977,7 @@ async def update_event(
     clear_end_time: bool = False,
     priority: int | None = None,
     status: str | None = None,
+    event_type: str | None = None,
     is_all_day: bool | None = None,
     area_id: UUID | None = None,
     clear_area: bool = False,
@@ -994,6 +1023,7 @@ async def update_event(
             clear_end_time=clear_end_time,
             priority=priority,
             status=status,
+            event_type=event_type,
             is_all_day=is_all_day,
             area_id=area_id,
             clear_area=clear_area,
@@ -1018,6 +1048,7 @@ async def update_event(
             clear_end_time=clear_end_time,
             priority=priority,
             status=status,
+            event_type=event_type,
             is_all_day=is_all_day,
             area_id=area_id,
             clear_area=clear_area,
@@ -1044,6 +1075,7 @@ async def update_event(
         clear_end_time=clear_end_time,
         priority=priority,
         status=status,
+        event_type=event_type,
         is_all_day=is_all_day,
         area_id=area_id,
         clear_area=clear_area,

--- a/src/lifeos_cli/db/services/events.py
+++ b/src/lifeos_cli/db/services/events.py
@@ -203,6 +203,42 @@ async def _apply_event_links(
         )
 
 
+def _apply_event_query_filters(
+    stmt: Any,
+    *,
+    title_contains: str | None,
+    normalized_status: str | None,
+    normalized_event_type: str | None,
+    area_id: UUID | None,
+    task_id: UUID | None,
+    person_id: UUID | None,
+    tag_id: UUID | None,
+) -> Any:
+    if title_contains:
+        stmt = stmt.where(Event.title.ilike(f"%{title_contains.strip()}%"))
+    if normalized_status is not None:
+        stmt = stmt.where(Event.status == normalized_status)
+    if normalized_event_type is not None:
+        stmt = stmt.where(Event.event_type == normalized_event_type)
+    if area_id is not None:
+        stmt = stmt.where(Event.area_id == area_id)
+    if task_id is not None:
+        stmt = stmt.where(Event.task_id == task_id)
+    if person_id is not None:
+        stmt = stmt.join(
+            person_associations,
+            (person_associations.c.entity_id == Event.id)
+            & (person_associations.c.entity_type == "event"),
+        ).where(person_associations.c.person_id == person_id)
+    if tag_id is not None:
+        stmt = stmt.join(
+            tag_associations,
+            (tag_associations.c.entity_id == Event.id)
+            & (tag_associations.c.entity_type == "event"),
+        ).where(tag_associations.c.tag_id == tag_id)
+    return stmt
+
+
 def _build_event_values(
     *,
     title: str,
@@ -357,6 +393,9 @@ async def list_event_occurrences(
     include_deleted: bool = False,
 ) -> list[EventOccurrence]:
     """List expanded event occurrences that overlap one time window."""
+    normalized_status = validate_event_status(status) if status is not None else None
+    normalized_event_type = validate_event_type(event_type) if event_type is not None else None
+
     master_stmt = select(Event).where(
         Event.recurrence_parent_event_id.is_(None),
         Event.start_time <= window_end,
@@ -368,28 +407,16 @@ async def list_event_occurrences(
     )
     if not include_deleted:
         master_stmt = master_stmt.where(Event.deleted_at.is_(None))
-    if title_contains:
-        master_stmt = master_stmt.where(Event.title.ilike(f"%{title_contains.strip()}%"))
-    if status is not None:
-        master_stmt = master_stmt.where(Event.status == validate_event_status(status))
-    if event_type is not None:
-        master_stmt = master_stmt.where(Event.event_type == validate_event_type(event_type))
-    if area_id is not None:
-        master_stmt = master_stmt.where(Event.area_id == area_id)
-    if task_id is not None:
-        master_stmt = master_stmt.where(Event.task_id == task_id)
-    if person_id is not None:
-        master_stmt = master_stmt.join(
-            person_associations,
-            (person_associations.c.entity_id == Event.id)
-            & (person_associations.c.entity_type == "event"),
-        ).where(person_associations.c.person_id == person_id)
-    if tag_id is not None:
-        master_stmt = master_stmt.join(
-            tag_associations,
-            (tag_associations.c.entity_id == Event.id)
-            & (tag_associations.c.entity_type == "event"),
-        ).where(tag_associations.c.tag_id == tag_id)
+    master_stmt = _apply_event_query_filters(
+        master_stmt,
+        title_contains=title_contains,
+        normalized_status=normalized_status,
+        normalized_event_type=normalized_event_type,
+        area_id=area_id,
+        task_id=task_id,
+        person_id=person_id,
+        tag_id=tag_id,
+    )
     masters = list((await session.execute(master_stmt)).scalars())
     master_ids = [event.id for event in masters if event_is_recurring(event)]
     skip_map = await _load_skip_exceptions(session, master_event_ids=master_ids)
@@ -401,28 +428,16 @@ async def list_event_occurrences(
     )
     if not include_deleted:
         override_stmt = override_stmt.where(Event.deleted_at.is_(None))
-    if title_contains:
-        override_stmt = override_stmt.where(Event.title.ilike(f"%{title_contains.strip()}%"))
-    if status is not None:
-        override_stmt = override_stmt.where(Event.status == validate_event_status(status))
-    if event_type is not None:
-        override_stmt = override_stmt.where(Event.event_type == validate_event_type(event_type))
-    if area_id is not None:
-        override_stmt = override_stmt.where(Event.area_id == area_id)
-    if task_id is not None:
-        override_stmt = override_stmt.where(Event.task_id == task_id)
-    if person_id is not None:
-        override_stmt = override_stmt.join(
-            person_associations,
-            (person_associations.c.entity_id == Event.id)
-            & (person_associations.c.entity_type == "event"),
-        ).where(person_associations.c.person_id == person_id)
-    if tag_id is not None:
-        override_stmt = override_stmt.join(
-            tag_associations,
-            (tag_associations.c.entity_id == Event.id)
-            & (tag_associations.c.entity_type == "event"),
-        ).where(tag_associations.c.tag_id == tag_id)
+    override_stmt = _apply_event_query_filters(
+        override_stmt,
+        title_contains=title_contains,
+        normalized_status=normalized_status,
+        normalized_event_type=normalized_event_type,
+        area_id=area_id,
+        task_id=task_id,
+        person_id=person_id,
+        tag_id=tag_id,
+    )
     overrides = list((await session.execute(override_stmt)).scalars())
     override_keys = {
         (override.recurrence_parent_event_id, override.recurrence_instance_start): override
@@ -515,6 +530,9 @@ async def list_events(
     offset: int = 0,
 ) -> list[object]:
     """List events with optional filters."""
+    normalized_status = validate_event_status(status) if status is not None else None
+    normalized_event_type = validate_event_type(event_type) if event_type is not None else None
+
     if local_date is not None:
         local_window_start, local_window_end_exclusive = get_utc_window_for_local_date(local_date)
         window_start = local_window_start
@@ -526,8 +544,8 @@ async def list_events(
             window_start=window_start,
             window_end=window_end,
             title_contains=title_contains,
-            status=status,
-            event_type=event_type,
+            status=normalized_status,
+            event_type=normalized_event_type,
             area_id=area_id,
             task_id=task_id,
             person_id=person_id,
@@ -539,32 +557,20 @@ async def list_events(
     stmt = select(Event).options(selectinload(Event.area), selectinload(Event.task))
     if not include_deleted:
         stmt = stmt.where(Event.deleted_at.is_(None))
-    if title_contains:
-        stmt = stmt.where(Event.title.ilike(f"%{title_contains.strip()}%"))
-    if status is not None:
-        stmt = stmt.where(Event.status == validate_event_status(status))
-    if event_type is not None:
-        stmt = stmt.where(Event.event_type == validate_event_type(event_type))
-    if area_id is not None:
-        stmt = stmt.where(Event.area_id == area_id)
-    if task_id is not None:
-        stmt = stmt.where(Event.task_id == task_id)
+    stmt = _apply_event_query_filters(
+        stmt,
+        title_contains=title_contains,
+        normalized_status=normalized_status,
+        normalized_event_type=normalized_event_type,
+        area_id=area_id,
+        task_id=task_id,
+        person_id=person_id,
+        tag_id=tag_id,
+    )
     if window_start is not None:
         stmt = stmt.where(or_(Event.end_time.is_(None), Event.end_time >= window_start))
     if window_end is not None:
         stmt = stmt.where(Event.start_time <= window_end)
-    if person_id is not None:
-        stmt = stmt.join(
-            person_associations,
-            (person_associations.c.entity_id == Event.id)
-            & (person_associations.c.entity_type == "event"),
-        ).where(person_associations.c.person_id == person_id)
-    if tag_id is not None:
-        stmt = stmt.join(
-            tag_associations,
-            (tag_associations.c.entity_id == Event.id)
-            & (tag_associations.c.entity_type == "event"),
-        ).where(tag_associations.c.tag_id == tag_id)
     stmt = stmt.order_by(Event.start_time.desc(), Event.id.desc()).offset(offset).limit(limit)
     events = list((await session.execute(stmt)).scalars())
     return list(await _attach_event_links_for_many(session, events))

--- a/src/lifeos_cli/db/services/schedule_queries.py
+++ b/src/lifeos_cli/db/services/schedule_queries.py
@@ -61,9 +61,9 @@ class ScheduleDay:
     local_date: date
     tasks: tuple[ScheduleTaskItem, ...]
     habit_actions: tuple[ScheduleHabitActionItem, ...]
-    appointment_events: tuple[ScheduleEventItem, ...]
-    timeblock_events: tuple[ScheduleEventItem, ...]
-    deadline_events: tuple[ScheduleEventItem, ...]
+    appointments: tuple[ScheduleEventItem, ...]
+    timeblocks: tuple[ScheduleEventItem, ...]
+    deadlines: tuple[ScheduleEventItem, ...]
 
 
 def _iter_date_range(start_date: date, end_date: date) -> list[date]:
@@ -220,19 +220,17 @@ async def list_schedule_in_range(
             if item.start_time <= current_window_end
             and (item.end_time is None or item.end_time >= current_window_start)
         )
-        appointment_events = tuple(
-            item for item in current_events if item.event_type == "appointment"
-        )
-        timeblock_events = tuple(item for item in current_events if item.event_type == "timeblock")
-        deadline_events = tuple(item for item in current_events if item.event_type == "deadline")
+        appointments = tuple(item for item in current_events if item.event_type == "appointment")
+        timeblocks = tuple(item for item in current_events if item.event_type == "timeblock")
+        deadlines = tuple(item for item in current_events if item.event_type == "deadline")
         days.append(
             ScheduleDay(
                 local_date=current_date,
                 tasks=current_tasks,
                 habit_actions=current_actions,
-                appointment_events=appointment_events,
-                timeblock_events=timeblock_events,
-                deadline_events=deadline_events,
+                appointments=appointments,
+                timeblocks=timeblocks,
+                deadlines=deadlines,
             )
         )
     return days

--- a/src/lifeos_cli/db/services/schedule_queries.py
+++ b/src/lifeos_cli/db/services/schedule_queries.py
@@ -48,6 +48,7 @@ class ScheduleEventItem:
     id: UUID
     title: str
     status: str
+    event_type: str
     start_time: datetime
     end_time: datetime | None
     task_id: UUID | None
@@ -60,7 +61,9 @@ class ScheduleDay:
     local_date: date
     tasks: tuple[ScheduleTaskItem, ...]
     habit_actions: tuple[ScheduleHabitActionItem, ...]
-    events: tuple[ScheduleEventItem, ...]
+    appointment_events: tuple[ScheduleEventItem, ...]
+    timeblock_events: tuple[ScheduleEventItem, ...]
+    deadline_events: tuple[ScheduleEventItem, ...]
 
 
 def _iter_date_range(start_date: date, end_date: date) -> list[date]:
@@ -170,6 +173,7 @@ def _map_event_item(event: EventOccurrence) -> ScheduleEventItem:
         id=event.id,
         title=event.title,
         status=event.status,
+        event_type=getattr(event, "event_type", "appointment"),
         start_time=event.start_time,
         end_time=event.end_time,
         task_id=event.task_id,
@@ -216,12 +220,19 @@ async def list_schedule_in_range(
             if item.start_time <= current_window_end
             and (item.end_time is None or item.end_time >= current_window_start)
         )
+        appointment_events = tuple(
+            item for item in current_events if item.event_type == "appointment"
+        )
+        timeblock_events = tuple(item for item in current_events if item.event_type == "timeblock")
+        deadline_events = tuple(item for item in current_events if item.event_type == "deadline")
         days.append(
             ScheduleDay(
                 local_date=current_date,
                 tasks=current_tasks,
                 habit_actions=current_actions,
-                events=current_events,
+                appointment_events=appointment_events,
+                timeblock_events=timeblock_events,
+                deadline_events=deadline_events,
             )
         )
     return days

--- a/tests/test_cli_domains.py
+++ b/tests/test_cli_domains.py
@@ -66,6 +66,7 @@ def test_main_event_add_creates_event(
 ) -> None:
     async def fake_create_event(session: object, **kwargs: object) -> object:
         assert kwargs["title"] == "Doctor appointment"
+        assert kwargs["event_type"] == "appointment"
         assert kwargs["person_ids"] == [UUID("11111111-1111-1111-1111-111111111111")]
         return make_record(id=UUID("12121212-1212-1212-1212-121212121212"))
 
@@ -121,6 +122,34 @@ def test_main_event_add_passes_recurrence_fields(
 
     assert exit_code == 0
     assert "Created event 34343434-3434-3434-3434-343434343434" in captured.out
+
+
+def test_main_event_add_passes_event_type(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    async def fake_create_event(session: object, **kwargs: object) -> object:
+        assert kwargs["event_type"] == "timeblock"
+        return make_record(id=UUID("45454545-4545-4545-4545-454545454545"))
+
+    monkeypatch.setattr(db_session, "session_scope", make_session_scope())
+    monkeypatch.setattr(events, "create_event", fake_create_event)
+
+    exit_code = cli.main(
+        [
+            "event",
+            "add",
+            "Focus Work",
+            "--type",
+            "timeblock",
+            "--start-time",
+            "2026-04-10T09:00:00-04:00",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "Created event 45454545-4545-4545-4545-454545454545" in captured.out
 
 
 def test_main_tag_add_creates_tag(
@@ -413,6 +442,7 @@ def test_main_event_update_passes_scope_fields(
 ) -> None:
     async def fake_update_event(session: object, **kwargs: object) -> object:
         assert kwargs["scope"] == "single"
+        assert kwargs["event_type"] == "deadline"
         instance_start = cast(datetime, kwargs["instance_start"])
         assert instance_start is not None
         assert str(instance_start.isoformat()) == "2026-04-10T09:00:00-04:00"
@@ -430,6 +460,8 @@ def test_main_event_update_passes_scope_fields(
             "single",
             "--instance-start",
             "2026-04-10T09:00:00-04:00",
+            "--type",
+            "deadline",
             "--title",
             "Updated review",
         ]

--- a/tests/test_cli_integration_schedule.py
+++ b/tests/test_cli_integration_schedule.py
@@ -53,6 +53,8 @@ def test_real_cli_schedule_workflow(integration_context: IntegrationContext) -> 
         "event",
         "add",
         "Release planning block",
+        "--type",
+        "timeblock",
         "--start-time",
         "2026-04-10T09:00:00-04:00",
         "--end-time",
@@ -68,6 +70,8 @@ def test_real_cli_schedule_workflow(integration_context: IntegrationContext) -> 
         "event",
         "add",
         "Daily review",
+        "--type",
+        "deadline",
         "--start-time",
         "2026-04-10T12:00:00-04:00",
         "--end-time",
@@ -90,7 +94,9 @@ def test_real_cli_schedule_workflow(integration_context: IntegrationContext) -> 
     assert "date: 2026-04-10" in schedule_show_result.stdout
     assert "tasks:" in schedule_show_result.stdout
     assert "habit_actions:" in schedule_show_result.stdout
-    assert "events:" in schedule_show_result.stdout
+    assert "events_appointments:" in schedule_show_result.stdout
+    assert "events_timeblocks:" in schedule_show_result.stdout
+    assert "events_deadlines:" in schedule_show_result.stdout
     assert task_id in schedule_show_result.stdout
     assert "Daily Review" in schedule_show_result.stdout
     assert event_id in schedule_show_result.stdout

--- a/tests/test_cli_integration_schedule.py
+++ b/tests/test_cli_integration_schedule.py
@@ -94,9 +94,9 @@ def test_real_cli_schedule_workflow(integration_context: IntegrationContext) -> 
     assert "date: 2026-04-10" in schedule_show_result.stdout
     assert "tasks:" in schedule_show_result.stdout
     assert "habit_actions:" in schedule_show_result.stdout
-    assert "events_appointments:" in schedule_show_result.stdout
-    assert "events_timeblocks:" in schedule_show_result.stdout
-    assert "events_deadlines:" in schedule_show_result.stdout
+    assert "appointments:" in schedule_show_result.stdout
+    assert "timeblocks:" in schedule_show_result.stdout
+    assert "deadlines:" in schedule_show_result.stdout
     assert task_id in schedule_show_result.stdout
     assert "Daily Review" in schedule_show_result.stdout
     assert event_id in schedule_show_result.stdout

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -160,6 +160,10 @@ def test_cli_schedule_help_describes_read_model_and_occurrences(capsys) -> None:
     )
     assert "expanded recurring event occurrences" in captured.out
     assert "Dates use the configured timezone and `day_starts_at` preference." in captured.out
+    assert (
+        "Event output is segmented into appointment, timeblock, and deadline sections."
+        in captured.out
+    )
 
 
 def test_cli_config_help_describes_set_command(capsys) -> None:
@@ -366,6 +370,7 @@ def test_cli_parser_supports_event_add_command() -> None:
     assert args.event_command == "add"
     assert args.title == "Doctor appointment"
     assert len(args.person_ids) == 1
+    assert args.event_type == "appointment"
 
 
 def test_cli_parser_supports_event_list_by_local_date() -> None:
@@ -400,6 +405,24 @@ def test_cli_parser_supports_event_recurrence_add_flags() -> None:
     assert args.recurrence_frequency == "daily"
     assert args.recurrence_interval == 2
     assert args.recurrence_count == 5
+
+
+def test_cli_parser_supports_event_type_flags() -> None:
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "event",
+            "list",
+            "--type",
+            "deadline",
+            "--date",
+            "2026-04-10",
+        ]
+    )
+
+    assert args.resource == "event"
+    assert args.event_command == "list"
+    assert args.event_type == "deadline"
 
 
 def test_cli_parser_supports_event_update_scope_flags() -> None:

--- a/tests/test_cli_schedule.py
+++ b/tests/test_cli_schedule.py
@@ -40,16 +40,19 @@ def test_main_schedule_show_prints_grouped_sections(
                     notes=None,
                 ),
             ),
-            events=(
+            appointment_events=(
                 schedules.ScheduleEventItem(
                     id=UUID("33333333-3333-3333-3333-333333333333"),
                     title="Doctor appointment",
                     status="planned",
+                    event_type="appointment",
                     start_time=utc_datetime(2026, 4, 10, 13, 0),
                     end_time=utc_datetime(2026, 4, 10, 14, 0),
                     task_id=None,
                 ),
             ),
+            timeblock_events=(),
+            deadline_events=(),
         )
 
     monkeypatch.setattr(db_session, "session_scope", make_session_scope())
@@ -62,7 +65,9 @@ def test_main_schedule_show_prints_grouped_sections(
     assert "date: 2026-04-10" in captured.out
     assert "tasks:" in captured.out
     assert "habit_actions:" in captured.out
-    assert "events:" in captured.out
+    assert "events_appointments:" in captured.out
+    assert "events_timeblocks:" in captured.out
+    assert "events_deadlines:" in captured.out
     assert "Draft release checklist" in captured.out
     assert "Daily Review" in captured.out
     assert "Doctor appointment" in captured.out

--- a/tests/test_cli_schedule.py
+++ b/tests/test_cli_schedule.py
@@ -40,7 +40,7 @@ def test_main_schedule_show_prints_grouped_sections(
                     notes=None,
                 ),
             ),
-            appointment_events=(
+            appointments=(
                 schedules.ScheduleEventItem(
                     id=UUID("33333333-3333-3333-3333-333333333333"),
                     title="Doctor appointment",
@@ -51,8 +51,8 @@ def test_main_schedule_show_prints_grouped_sections(
                     task_id=None,
                 ),
             ),
-            timeblock_events=(),
-            deadline_events=(),
+            timeblocks=(),
+            deadlines=(),
         )
 
     monkeypatch.setattr(db_session, "session_scope", make_session_scope())
@@ -65,9 +65,9 @@ def test_main_schedule_show_prints_grouped_sections(
     assert "date: 2026-04-10" in captured.out
     assert "tasks:" in captured.out
     assert "habit_actions:" in captured.out
-    assert "events_appointments:" in captured.out
-    assert "events_timeblocks:" in captured.out
-    assert "events_deadlines:" in captured.out
+    assert "appointments:" in captured.out
+    assert "timeblocks:" in captured.out
+    assert "deadlines:" in captured.out
     assert "Draft release checklist" in captured.out
     assert "Daily Review" in captured.out
     assert "Doctor appointment" in captured.out

--- a/tests/test_domain_services_time.py
+++ b/tests/test_domain_services_time.py
@@ -47,6 +47,7 @@ def test_create_event_flushes_without_committing(monkeypatch: pytest.MonkeyPatch
     )
 
     assert event.title == "Doctor appointment"
+    assert event.event_type == "appointment"
     assert event.start_time == utc_datetime(2026, 4, 10, 13, 0)
     session.flush.assert_awaited_once()
     session.commit.assert_not_called()
@@ -162,6 +163,38 @@ def test_create_event_accepts_recurrence_fields(monkeypatch: pytest.MonkeyPatch)
     assert created.recurrence_count == 5
 
 
+def test_create_event_accepts_event_type(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = SimpleNamespace(add=None, flush=AsyncMock(), refresh=AsyncMock())
+
+    def fake_add(_: object) -> None:
+        pass
+
+    async def fake_ensure_area_exists(_: object, __: UUID | None) -> None:
+        return None
+
+    async def fake_ensure_task_exists(_: object, __: UUID | None) -> None:
+        return None
+
+    async def fake_attach_event_links(_: object, event: object) -> object:
+        return event
+
+    session.add = fake_add
+    monkeypatch.setattr(events, "ensure_event_area_exists", fake_ensure_area_exists)
+    monkeypatch.setattr(events, "ensure_event_task_exists", fake_ensure_task_exists)
+    monkeypatch.setattr(events, "_attach_event_links", fake_attach_event_links)
+
+    created = asyncio.run(
+        events.create_event(
+            cast(Any, session),
+            title="Focus block",
+            start_time=utc_datetime(2026, 4, 10, 13, 0),
+            event_type="timeblock",
+        )
+    )
+
+    assert created.event_type == "timeblock"
+
+
 def test_create_timelog_rejects_naive_datetimes() -> None:
     session = SimpleNamespace()
 
@@ -199,6 +232,7 @@ def test_update_event_can_clear_optional_fields(monkeypatch: pytest.MonkeyPatch)
         end_time=utc_datetime(2026, 4, 10, 10, 0),
         priority=3,
         status="planned",
+        event_type="appointment",
         is_all_day=False,
         recurrence_frequency=None,
         recurrence_interval=None,
@@ -382,6 +416,7 @@ def test_list_event_occurrences_applies_all_supported_filters() -> None:
             window_end=utc_datetime(2026, 4, 12, 23, 59),
             title_contains="review",
             status="planned",
+            event_type="deadline",
             area_id=area_id,
             task_id=task_id,
             person_id=person_id,
@@ -400,6 +435,7 @@ def test_list_event_occurrences_applies_all_supported_filters() -> None:
         assert "events.area_id" in statement_sql
         assert "events.task_id" in statement_sql
         assert "events.status" in statement_sql
+        assert "events.event_type" in statement_sql
         assert "title" in statement_sql
 
 

--- a/tests/test_schedule_queries.py
+++ b/tests/test_schedule_queries.py
@@ -78,6 +78,7 @@ def test_list_schedule_in_range_groups_tasks_actions_and_events(monkeypatch) -> 
                 id=UUID("33333333-3333-3333-3333-333333333333"),
                 title="Late call",
                 status="planned",
+                event_type="appointment",
                 start_time=utc_datetime(2026, 4, 10, 23, 30),
                 end_time=utc_datetime(2026, 4, 11, 1, 0),
                 task_id=None,
@@ -110,11 +111,13 @@ def test_list_schedule_in_range_groups_tasks_actions_and_events(monkeypatch) -> 
     assert days[0].local_date == date(2026, 4, 10)
     assert [item.content for item in days[0].tasks] == ["Draft release checklist"]
     assert [item.habit_title for item in days[0].habit_actions] == ["Daily Review"]
-    assert [item.title for item in days[0].events] == ["Late call"]
+    assert [item.title for item in days[0].appointment_events] == ["Late call"]
+    assert days[0].timeblock_events == ()
+    assert days[0].deadline_events == ()
     assert days[1].local_date == date(2026, 4, 11)
     assert [item.content for item in days[1].tasks] == ["Draft release checklist"]
     assert days[1].habit_actions == ()
-    assert [item.title for item in days[1].events] == ["Late call"]
+    assert [item.title for item in days[1].appointment_events] == ["Late call"]
 
 
 def test_list_schedule_in_range_uses_expanded_recurring_event_occurrences(monkeypatch) -> None:
@@ -145,6 +148,7 @@ def test_list_schedule_in_range_uses_expanded_recurring_event_occurrences(monkey
                 id=UUID("33333333-3333-3333-3333-333333333333"),
                 title="Daily review",
                 status="planned",
+                event_type="timeblock",
                 start_time=utc_datetime(2026, 4, 10, 13, 0),
                 end_time=utc_datetime(2026, 4, 10, 13, 30),
                 task_id=None,
@@ -153,6 +157,7 @@ def test_list_schedule_in_range_uses_expanded_recurring_event_occurrences(monkey
                 id=UUID("33333333-3333-3333-3333-333333333333"),
                 title="Daily review",
                 status="planned",
+                event_type="timeblock",
                 start_time=utc_datetime(2026, 4, 11, 13, 0),
                 end_time=utc_datetime(2026, 4, 11, 13, 30),
                 task_id=None,
@@ -187,8 +192,78 @@ def test_list_schedule_in_range_uses_expanded_recurring_event_occurrences(monkey
             utc_datetime(2026, 4, 11, 23, 59, 59).replace(microsecond=999999),
         )
     ]
-    assert [item.title for item in days[0].events] == ["Daily review"]
-    assert [item.title for item in days[1].events] == ["Daily review"]
+    assert [item.title for item in days[0].timeblock_events] == ["Daily review"]
+    assert [item.title for item in days[1].timeblock_events] == ["Daily review"]
+
+
+def test_list_schedule_in_range_groups_events_by_type(monkeypatch) -> None:
+    async def fake_load_tasks(session: object, *, start_date: date, end_date: date) -> list[object]:
+        return []
+
+    async def fake_load_habit_actions(
+        session: object, *, start_date: date, end_date: date
+    ) -> list[object]:
+        return []
+
+    async def fake_load_events(
+        session: object,
+        *,
+        start_date: date,
+        end_date: date,
+    ) -> list[object]:
+        return [
+            make_record(
+                id=UUID("11111111-1111-1111-1111-111111111111"),
+                title="Doctor appointment",
+                status="planned",
+                event_type="appointment",
+                start_time=utc_datetime(2026, 4, 10, 13, 0),
+                end_time=utc_datetime(2026, 4, 10, 14, 0),
+                task_id=None,
+            ),
+            make_record(
+                id=UUID("22222222-2222-2222-2222-222222222222"),
+                title="Focus block",
+                status="planned",
+                event_type="timeblock",
+                start_time=utc_datetime(2026, 4, 10, 15, 0),
+                end_time=utc_datetime(2026, 4, 10, 16, 0),
+                task_id=None,
+            ),
+            make_record(
+                id=UUID("33333333-3333-3333-3333-333333333333"),
+                title="Tax deadline",
+                status="planned",
+                event_type="deadline",
+                start_time=utc_datetime(2026, 4, 10, 17, 0),
+                end_time=None,
+                task_id=None,
+            ),
+        ]
+
+    def fake_get_utc_window_for_local_date(target_date: date):
+        return utc_datetime(2026, 4, 10, 0, 0), utc_datetime(2026, 4, 11, 0, 0)
+
+    monkeypatch.setattr(schedule_queries, "_load_schedule_tasks", fake_load_tasks)
+    monkeypatch.setattr(schedule_queries, "_load_schedule_habit_actions", fake_load_habit_actions)
+    monkeypatch.setattr(schedule_queries, "_load_schedule_events", fake_load_events)
+    monkeypatch.setattr(
+        schedule_queries,
+        "get_utc_window_for_local_date",
+        fake_get_utc_window_for_local_date,
+    )
+
+    days = asyncio.run(
+        schedule_queries.list_schedule_in_range(
+            cast(Any, object()),
+            start_date=date(2026, 4, 10),
+            end_date=date(2026, 4, 10),
+        )
+    )
+
+    assert [item.title for item in days[0].appointment_events] == ["Doctor appointment"]
+    assert [item.title for item in days[0].timeblock_events] == ["Focus block"]
+    assert [item.title for item in days[0].deadline_events] == ["Tax deadline"]
 
 
 def test_list_schedule_in_range_rejects_inverted_date_range() -> None:

--- a/tests/test_schedule_queries.py
+++ b/tests/test_schedule_queries.py
@@ -111,13 +111,13 @@ def test_list_schedule_in_range_groups_tasks_actions_and_events(monkeypatch) -> 
     assert days[0].local_date == date(2026, 4, 10)
     assert [item.content for item in days[0].tasks] == ["Draft release checklist"]
     assert [item.habit_title for item in days[0].habit_actions] == ["Daily Review"]
-    assert [item.title for item in days[0].appointment_events] == ["Late call"]
-    assert days[0].timeblock_events == ()
-    assert days[0].deadline_events == ()
+    assert [item.title for item in days[0].appointments] == ["Late call"]
+    assert days[0].timeblocks == ()
+    assert days[0].deadlines == ()
     assert days[1].local_date == date(2026, 4, 11)
     assert [item.content for item in days[1].tasks] == ["Draft release checklist"]
     assert days[1].habit_actions == ()
-    assert [item.title for item in days[1].appointment_events] == ["Late call"]
+    assert [item.title for item in days[1].appointments] == ["Late call"]
 
 
 def test_list_schedule_in_range_uses_expanded_recurring_event_occurrences(monkeypatch) -> None:
@@ -192,8 +192,8 @@ def test_list_schedule_in_range_uses_expanded_recurring_event_occurrences(monkey
             utc_datetime(2026, 4, 11, 23, 59, 59).replace(microsecond=999999),
         )
     ]
-    assert [item.title for item in days[0].timeblock_events] == ["Daily review"]
-    assert [item.title for item in days[1].timeblock_events] == ["Daily review"]
+    assert [item.title for item in days[0].timeblocks] == ["Daily review"]
+    assert [item.title for item in days[1].timeblocks] == ["Daily review"]
 
 
 def test_list_schedule_in_range_groups_events_by_type(monkeypatch) -> None:
@@ -261,9 +261,9 @@ def test_list_schedule_in_range_groups_events_by_type(monkeypatch) -> None:
         )
     )
 
-    assert [item.title for item in days[0].appointment_events] == ["Doctor appointment"]
-    assert [item.title for item in days[0].timeblock_events] == ["Focus block"]
-    assert [item.title for item in days[0].deadline_events] == ["Tax deadline"]
+    assert [item.title for item in days[0].appointments] == ["Doctor appointment"]
+    assert [item.title for item in days[0].timeblocks] == ["Focus block"]
+    assert [item.title for item in days[0].deadlines] == ["Tax deadline"]
 
 
 def test_list_schedule_in_range_rejects_inverted_date_range() -> None:

--- a/tests/test_timelog_stats.py
+++ b/tests/test_timelog_stats.py
@@ -31,9 +31,8 @@ def configured_time_preferences(monkeypatch: pytest.MonkeyPatch, tmp_path) -> It
     clear_config_cache()
 
 
-def test_iter_local_dates_for_timelog_window_respects_day_boundary(
-    configured_time_preferences: None,
-) -> None:
+@pytest.mark.usefixtures("configured_time_preferences")
+def test_iter_local_dates_for_timelog_window_respects_day_boundary() -> None:
     local_dates = timelog_stats.iter_local_dates_for_timelog_window(
         start_time=datetime(2026, 4, 10, 7, 30, tzinfo=timezone.utc),
         end_time=datetime(2026, 4, 10, 9, 30, tzinfo=timezone.utc),
@@ -53,9 +52,8 @@ def test_overlap_minutes_for_window_returns_whole_minutes() -> None:
     assert minutes == 30
 
 
-def test_resolve_stats_period_uses_configured_week_boundary(
-    configured_time_preferences: None,
-) -> None:
+@pytest.mark.usefixtures("configured_time_preferences")
+def test_resolve_stats_period_uses_configured_week_boundary() -> None:
     start_date, end_date = timelog_stats.resolve_stats_period(
         granularity="week",
         target_date=date(2026, 4, 9),


### PR DESCRIPTION
## 概述
- 为 `events` 增加一等字段 `event_type`，支持 `appointment`、`timeblock`、`deadline`。
- 让 `event` 资源的新增、查询、更新与详情输出能够感知事件类型。
- 让 `schedule` 视图在保留任务、习惯动作、事件三类聚合语义的前提下，将事件按类型细分展示。
- 在后续收敛中补充数据库约束、去重查询过滤逻辑，并统一 `schedule` 读模型与输出命名。

## 模块变更
### 数据模型与迁移
- 在 `events` 表中新增 `event_type` 字段，默认值为 `appointment`。
- 新增对应 Alembic 迁移，并补充索引以支持按类型查询。
- 为 `event_type` 增加数据库层 `CHECK` 约束，避免旁路写入产生非法值。

### 事件服务层
- 为事件类型增加集中校验逻辑。
- 在 `create_event`、`list_events`、`list_event_occurrences`、`update_event` 中打通 `event_type`。
- 抽取共享过滤逻辑，减少 `list_events` 与 `list_event_occurrences` 后续演进时的漂移风险。
- 对 recurring occurrence 展开增加默认回退，兼容旧测试桩和缺省值场景。

### CLI 与帮助文本
- `lifeos event add` 支持 `--type`。
- `lifeos event list` 支持按 `--type` 过滤。
- `lifeos event update` 支持更新事件类型。
- `event show/list` 输出中增加 `event_type` 展示。
- 更新相关帮助文本、示例和说明。

### Schedule 读模型与输出
- `schedule` 仍然保持 `tasks`、`habit_actions`、`events` 三类聚合语义。
- 在事件维度下按类型细分为 `appointments`、`timeblocks`、`deadlines` 三个区块。
- 统一 `schedule` 读模型字段与 CLI 输出命名，避免内部字段名与外部展示顺序不一致。
- `schedule show/list` 的帮助文本同步说明按类型分段展示的结构。

### 测试与清理
- 更新并补充 parser、CLI、domain service、schedule query 相关测试。
- 覆盖默认类型、按类型过滤、按类型分组输出、schedule 读模型分段展示等场景。
- 基于当前分支执行全仓死代码扫描，并清理高置信未使用测试形参。

## 相关提交
- `43e4278` `feat: add event types to schedule workflows`
- `7eef155` `refactor: tighten event type validation and remove dead code`
- `6b2bba8` `refactor: align schedule event section naming`

## 验证
- `uvx vulture src tests --min-confidence 80`
- `bash ./scripts/doctor.sh`

## Issue 关联
- Closes #43
