### PR TITLE
feat: add generic note associations

### DIFF
--- a/src/lifeos_cli/alembic/versions/20260411_1500_add_generic_associations.py
+++ b/src/lifeos_cli/alembic/versions/20260411_1500_add_generic_associations.py
@@ -1,0 +1,124 @@
+"""Add generic weak association support."""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260411_1500"
+down_revision = "20260411_1400"
+branch_labels = None
+depends_on = None
+
+
+def _schema_name() -> str:
+    context = op.get_context()
+    return context.version_table_schema or "lifeos"
+
+
+def upgrade() -> None:
+    schema_name = _schema_name()
+
+    op.create_table(
+        "associations",
+        sa.Column("source_model", sa.String(length=50), nullable=False),
+        sa.Column("source_id", sa.Uuid(), nullable=False),
+        sa.Column("target_model", sa.String(length=50), nullable=False),
+        sa.Column("target_id", sa.Uuid(), nullable=False),
+        sa.Column("link_type", sa.String(length=50), nullable=False),
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "source_model IN ('note', 'person', 'task', 'timelog')",
+            name="ck_associations_source_model_valid",
+        ),
+        sa.CheckConstraint(
+            "target_model IN ('note', 'person', 'task', 'timelog')",
+            name="ck_associations_target_model_valid",
+        ),
+        sa.CheckConstraint(
+            "link_type IN ('captured_from', 'is_about', 'relates_to')",
+            name="ck_associations_link_type_valid",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "source_model",
+            "source_id",
+            "target_model",
+            "target_id",
+            "link_type",
+            name="uq_associations_source_target_type",
+        ),
+        schema=schema_name,
+    )
+    op.create_index(
+        "ix_associations_link_type",
+        "associations",
+        ["link_type"],
+        unique=False,
+        schema=schema_name,
+    )
+    op.create_index(
+        "ix_associations_source_id",
+        "associations",
+        ["source_id"],
+        unique=False,
+        schema=schema_name,
+    )
+    op.create_index(
+        "ix_associations_source_model",
+        "associations",
+        ["source_model"],
+        unique=False,
+        schema=schema_name,
+    )
+    op.create_index(
+        "ix_associations_source_model_id_type",
+        "associations",
+        ["source_model", "source_id", "link_type"],
+        unique=False,
+        schema=schema_name,
+    )
+    op.create_index(
+        "ix_associations_target_id",
+        "associations",
+        ["target_id"],
+        unique=False,
+        schema=schema_name,
+    )
+    op.create_index(
+        "ix_associations_target_model",
+        "associations",
+        ["target_model"],
+        unique=False,
+        schema=schema_name,
+    )
+    op.create_index(
+        "ix_associations_target_model_id_type",
+        "associations",
+        ["target_model", "target_id", "link_type"],
+        unique=False,
+        schema=schema_name,
+    )
+
+
+def downgrade() -> None:
+    schema_name = _schema_name()
+
+    op.drop_index(
+        "ix_associations_target_model_id_type",
+        table_name="associations",
+        schema=schema_name,
+    )
+    op.drop_index("ix_associations_target_model", table_name="associations", schema=schema_name)
+    op.drop_index("ix_associations_target_id", table_name="associations", schema=schema_name)
+    op.drop_index(
+        "ix_associations_source_model_id_type",
+        table_name="associations",
+        schema=schema_name,
+    )
+    op.drop_index("ix_associations_source_model", table_name="associations", schema=schema_name)
+    op.drop_index("ix_associations_source_id", table_name="associations", schema=schema_name)
+    op.drop_index("ix_associations_link_type", table_name="associations", schema=schema_name)
+    op.drop_table("associations", schema=schema_name)

--- a/src/lifeos_cli/cli_support/output_utils.py
+++ b/src/lifeos_cli/cli_support/output_utils.py
@@ -11,41 +11,6 @@ from uuid import UUID
 from lifeos_cli.application.time_preferences import to_preferred_timezone
 
 
-class NoteSummary(Protocol):
-    """Protocol for CLI note summary rendering."""
-
-    @property
-    def id(self) -> UUID: ...
-
-    @property
-    def content(self) -> str: ...
-
-    @property
-    def created_at(self) -> object | None: ...
-
-    @property
-    def deleted_at(self) -> object | None: ...
-
-
-class NoteDetail(Protocol):
-    """Protocol for detailed note rendering."""
-
-    @property
-    def id(self) -> UUID: ...
-
-    @property
-    def content(self) -> str: ...
-
-    @property
-    def created_at(self) -> object | None: ...
-
-    @property
-    def updated_at(self) -> object | None: ...
-
-    @property
-    def deleted_at(self) -> object | None: ...
-
-
 class BatchResult(Protocol):
     """Protocol for batch command result rendering."""
 
@@ -91,31 +56,56 @@ def print_batch_result(
     return 1 if result.failed_ids else 0
 
 
-def format_note_summary(note: NoteSummary) -> str:
+def format_note_summary(note: object) -> str:
     """Render a note as a single-line summary for CLI output."""
     created_at = getattr(note, "created_at", None)
     deleted_at = getattr(note, "deleted_at", None)
     content = getattr(note, "content", "")
+    task = getattr(note, "task", None)
+    people = getattr(note, "people", []) or []
+    timelogs = getattr(note, "timelogs", []) or []
     normalized_content = " ".join(str(content).split())
     if len(normalized_content) > 80:
         normalized_content = f"{normalized_content[:77]}..."
     created_label = format_timestamp(created_at)
     status = "deleted" if deleted_at is not None else "active"
-    return f"{note.id}\t{status}\t{created_label}\t{normalized_content}"
+    task_id = getattr(task, "id", "-") if task is not None else "-"
+    note_id = getattr(note, "id", "-")
+    return (
+        f"{note_id}\t{status}\t{created_label}\t{task_id}\t"
+        f"{len(people)}\t{len(timelogs)}\t{normalized_content}"
+    )
 
 
-def format_note_detail(note: NoteDetail) -> str:
+def format_note_detail(note: object) -> str:
     """Render a note with full metadata and multi-line content."""
     created_at = getattr(note, "created_at", None)
     updated_at = getattr(note, "updated_at", None)
     deleted_at = getattr(note, "deleted_at", None)
+    task = getattr(note, "task", None)
+    people = getattr(note, "people", []) or []
+    timelogs = getattr(note, "timelogs", []) or []
     status = "deleted" if deleted_at is not None else "active"
+    people_names = ", ".join(
+        getattr(person, "name", str(getattr(person, "id", person))) for person in people
+    )
+    task_label = "-"
+    if task is not None:
+        task_id = getattr(task, "id", "-")
+        task_content = getattr(task, "content", "-")
+        task_label = f"{task_id} | {task_content}"
+    timelog_labels = ", ".join(
+        f"{getattr(timelog, 'id', '-')} | {getattr(timelog, 'title', '-')}" for timelog in timelogs
+    )
     lines = [
-        f"id: {note.id}",
+        f"id: {getattr(note, 'id', '-')}",
         f"status: {status}",
         f"created_at: {format_timestamp(created_at)}",
         f"updated_at: {format_timestamp(updated_at)}",
         f"deleted_at: {format_timestamp(deleted_at)}",
+        f"task: {task_label}",
+        f"people: {people_names or '-'}",
+        f"timelogs: {timelog_labels or '-'}",
         "content:",
         str(getattr(note, "content", "")),
     ]

--- a/src/lifeos_cli/cli_support/resources/note/handlers.py
+++ b/src/lifeos_cli/cli_support/resources/note/handlers.py
@@ -50,8 +50,21 @@ def resolve_note_content(args: argparse.Namespace) -> str:
 async def handle_note_add_async(args: argparse.Namespace) -> int:
     """Create a new note."""
     content = resolve_note_content(args)
-    async with db_session.session_scope() as session:
-        note = await note_services.create_note(session, content=content)
+    try:
+        async with db_session.session_scope() as session:
+            if args.person_ids is None and args.task_id is None and args.timelog_ids is None:
+                note = await note_services.create_note(session, content=content)
+            else:
+                note = await note_services.create_note(
+                    session,
+                    content=content,
+                    person_ids=args.person_ids,
+                    task_id=args.task_id,
+                    timelog_ids=args.timelog_ids,
+                )
+    except (LookupError, note_services.NoteValidationError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
     print(f"Created note {note.id}")
     return 0
 
@@ -64,12 +77,23 @@ def handle_note_add(args: argparse.Namespace) -> int:
 async def handle_note_list_async(args: argparse.Namespace) -> int:
     """List notes."""
     async with db_session.session_scope() as session:
-        notes = await note_services.list_notes(
-            session,
-            include_deleted=args.include_deleted,
-            limit=args.limit,
-            offset=args.offset,
-        )
+        if args.person_id is None and args.task_id is None and args.timelog_id is None:
+            notes = await note_services.list_notes(
+                session,
+                include_deleted=args.include_deleted,
+                limit=args.limit,
+                offset=args.offset,
+            )
+        else:
+            notes = await note_services.list_notes(
+                session,
+                include_deleted=args.include_deleted,
+                person_id=args.person_id,
+                task_id=args.task_id,
+                timelog_id=args.timelog_id,
+                limit=args.limit,
+                offset=args.offset,
+            )
     if not notes:
         print("No notes found.")
         return 0
@@ -90,13 +114,25 @@ async def handle_note_search_async(args: argparse.Namespace) -> int:
         raise ConfigurationError("Search query must not be empty.")
 
     async with db_session.session_scope() as session:
-        notes = await note_services.search_notes(
-            session,
-            query=normalized_query,
-            include_deleted=args.include_deleted,
-            limit=args.limit,
-            offset=args.offset,
-        )
+        if args.person_id is None and args.task_id is None and args.timelog_id is None:
+            notes = await note_services.search_notes(
+                session,
+                query=normalized_query,
+                include_deleted=args.include_deleted,
+                limit=args.limit,
+                offset=args.offset,
+            )
+        else:
+            notes = await note_services.search_notes(
+                session,
+                query=normalized_query,
+                include_deleted=args.include_deleted,
+                person_id=args.person_id,
+                task_id=args.task_id,
+                timelog_id=args.timelog_id,
+                limit=args.limit,
+                offset=args.offset,
+            )
     if not notes:
         print("No matching notes found.")
         return 0
@@ -132,12 +168,44 @@ def handle_note_show(args: argparse.Namespace) -> int:
 
 async def handle_note_update_async(args: argparse.Namespace) -> int:
     """Update note content."""
+    conflicts = (
+        (args.clear_people and args.person_ids is not None, "--person-id", "--clear-people"),
+        (args.clear_task and args.task_id is not None, "--task-id", "--clear-task"),
+        (args.clear_timelogs and args.timelog_ids is not None, "--timelog-id", "--clear-timelogs"),
+    )
+    for is_conflict, value_flag, clear_flag in conflicts:
+        if is_conflict:
+            print(f"Use either {value_flag} or {clear_flag}, not both.", file=sys.stderr)
+            return 1
+
     try:
         async with db_session.session_scope() as session:
-            note = await note_services.update_note(
-                session, note_id=args.note_id, content=args.content
-            )
-    except note_services.NoteNotFoundError as exc:
+            if (
+                args.person_ids is None
+                and not args.clear_people
+                and args.task_id is None
+                and not args.clear_task
+                and args.timelog_ids is None
+                and not args.clear_timelogs
+            ):
+                note = await note_services.update_note(
+                    session,
+                    note_id=args.note_id,
+                    content=args.content,
+                )
+            else:
+                note = await note_services.update_note(
+                    session,
+                    note_id=args.note_id,
+                    content=args.content,
+                    person_ids=args.person_ids,
+                    clear_people=args.clear_people,
+                    task_id=args.task_id,
+                    clear_task=args.clear_task,
+                    timelog_ids=args.timelog_ids,
+                    clear_timelogs=args.clear_timelogs,
+                )
+    except (note_services.NoteNotFoundError, note_services.NoteValidationError, LookupError) as exc:
         print(str(exc), file=sys.stderr)
         return 1
     print(f"Updated note {note.id}")

--- a/src/lifeos_cli/cli_support/resources/note/parser.py
+++ b/src/lifeos_cli/cli_support/resources/note/parser.py
@@ -47,7 +47,8 @@ def build_note_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentPa
                 "Prefer short, stable resource names, such as note, task, or people.",
                 "Action names stay short verbs, such as add, list, update, and delete.",
                 "Use the `batch` namespace when one command operates on multiple note records.",
-                "The list command prints tab-separated columns: id, status, created_at, content.",
+                "The list command prints tab-separated columns: id, status, created_at, "
+                "task_id, people_count, timelog_count, content.",
                 "Use `show` to inspect the full note body with preserved line breaks.",
                 "Delete operations in the CLI always perform soft deletion.",
             ),

--- a/src/lifeos_cli/cli_support/resources/note/parser_actions.py
+++ b/src/lifeos_cli/cli_support/resources/note/parser_actions.py
@@ -33,18 +33,19 @@ def build_note_add_parser(
             description=(
                 "Create a new note from inline text, stdin, or a file.\n\n"
                 "Use this action to capture short thoughts, prompts, or raw text before\n"
-                "they are linked to other domains such as tasks or people."
+                "they are linked to other domains such as tasks, people, or timelogs."
             ),
             examples=(
                 "lifeos init",
                 'lifeos note add "Capture the sprint retrospective idea"',
                 "printf 'line one\\nline two\\n' | lifeos note add --stdin",
                 "lifeos note add --file ./note.md",
-                'lifeos note add "Review the monthly budget assumptions"',
+                'lifeos note add "Review the monthly budget assumptions" --task-id <task-id>',
             ),
             notes=(
                 "Wrap inline content in quotes when it contains spaces.",
                 "Use `--stdin` or `--file` for multi-line note content.",
+                "Repeat `--person-id` and `--timelog-id` to link multiple records.",
             ),
         ),
     )
@@ -55,6 +56,23 @@ def build_note_add_parser(
         help="Read note content from standard input",
     )
     add_parser.add_argument("--file", help="Read note content from a UTF-8 text file")
+    add_parser.add_argument(
+        "--person-id",
+        dest="person_ids",
+        type=UUID,
+        action="append",
+        default=None,
+        help="Repeat to associate one or more people",
+    )
+    add_parser.add_argument("--task-id", type=UUID, help="Associate one task")
+    add_parser.add_argument(
+        "--timelog-id",
+        dest="timelog_ids",
+        type=UUID,
+        action="append",
+        default=None,
+        help="Repeat to associate one or more timelogs",
+    )
     add_parser.set_defaults(handler=handle_note_add)
 
 
@@ -69,10 +87,13 @@ def build_note_list_parser(
             description=(
                 "List notes in reverse creation order.\n\n"
                 "The output is tab-separated and currently includes: id, status,\n"
-                "created_at, and a normalized content preview."
+                "created_at, task_id, people_count, timelog_count, and a normalized "
+                "content preview."
             ),
             examples=(
                 "lifeos note list",
+                "lifeos note list --person-id <person-id>",
+                "lifeos note list --timelog-id <timelog-id>",
                 "lifeos note list --limit 20 --offset 20",
                 "lifeos note list --include-deleted",
             ),
@@ -82,6 +103,9 @@ def build_note_list_parser(
             ),
         ),
     )
+    list_parser.add_argument("--person-id", type=UUID, help="Filter by linked person")
+    list_parser.add_argument("--task-id", type=UUID, help="Filter by linked task")
+    list_parser.add_argument("--timelog-id", type=UUID, help="Filter by linked timelog")
     add_include_deleted_argument(list_parser, noun="notes")
     add_limit_offset_arguments(list_parser, row_noun="notes")
     list_parser.set_defaults(handler=handle_note_list)
@@ -103,6 +127,7 @@ def build_note_search_parser(
             ),
             examples=(
                 'lifeos note search "meeting notes"',
+                'lifeos note search "review" --task-id <task-id>',
                 'lifeos note search "budget q2" --limit 20',
                 'lifeos note search "archived idea" --include-deleted',
             ),
@@ -113,6 +138,9 @@ def build_note_search_parser(
         ),
     )
     search_parser.add_argument("query", help="Search query string")
+    search_parser.add_argument("--person-id", type=UUID, help="Filter by linked person")
+    search_parser.add_argument("--task-id", type=UUID, help="Filter by linked task")
+    search_parser.add_argument("--timelog-id", type=UUID, help="Filter by linked timelog")
     add_include_deleted_argument(search_parser, noun="notes in the search scope")
     add_limit_offset_arguments(search_parser, row_noun="matching notes")
     search_parser.set_defaults(handler=handle_note_search)
@@ -150,19 +178,48 @@ def build_note_update_parser(
         note_subparsers,
         "update",
         help_content=HelpContent(
-            summary="Replace note content",
+            summary="Update a note",
             description=(
-                "Replace the full content of an existing note.\n\n"
-                "This action updates the current note body in place. It does not apply\n"
-                "partial patches or keep revision history yet."
+                "Update note content and weak associations in place.\n\n"
+                "Omitted fields remain unchanged. Use `--clear-*` flags to remove links."
             ),
             examples=(
                 'lifeos note update 11111111-1111-1111-1111-111111111111 "Rewrite the note"',
+                "lifeos note update 11111111-1111-1111-1111-111111111111 --task-id <task-id>",
+                "lifeos note update 11111111-1111-1111-1111-111111111111 --clear-timelogs",
+            ),
+            notes=(
+                "Repeat `--person-id` and `--timelog-id` to replace linked records.",
+                "Use relation flags without `content` when only links need to change.",
             ),
         ),
     )
     update_parser.add_argument("note_id", type=UUID, help="Note identifier")
-    update_parser.add_argument("content", help="Replacement note content")
+    update_parser.add_argument("content", nargs="?", help="Replacement note content")
+    update_parser.add_argument(
+        "--person-id",
+        dest="person_ids",
+        type=UUID,
+        action="append",
+        default=None,
+        help="Repeat to replace people with one or more identifiers",
+    )
+    update_parser.add_argument("--clear-people", action="store_true", help="Remove all people")
+    update_parser.add_argument("--task-id", type=UUID, help="Replace the linked task")
+    update_parser.add_argument("--clear-task", action="store_true", help="Remove the linked task")
+    update_parser.add_argument(
+        "--timelog-id",
+        dest="timelog_ids",
+        type=UUID,
+        action="append",
+        default=None,
+        help="Repeat to replace timelogs with one or more identifiers",
+    )
+    update_parser.add_argument(
+        "--clear-timelogs",
+        action="store_true",
+        help="Remove all linked timelogs",
+    )
     update_parser.set_defaults(handler=handle_note_update)
 
 

--- a/src/lifeos_cli/cli_support/resources/timelog/handlers.py
+++ b/src/lifeos_cli/cli_support/resources/timelog/handlers.py
@@ -22,7 +22,8 @@ def _format_timelog_summary(timelog: Timelog) -> str:
     status = "deleted" if timelog.deleted_at is not None else timelog.tracking_method
     return (
         f"{timelog.id}\t{status}\t{format_timestamp(timelog.start_time)}\t"
-        f"{format_timestamp(timelog.end_time)}\t{timelog.task_id or '-'}\t{timelog.title}"
+        f"{format_timestamp(timelog.end_time)}\t{timelog.task_id or '-'}\t"
+        f"{getattr(timelog, 'linked_notes_count', 0)}\t{timelog.title}"
     )
 
 
@@ -47,6 +48,7 @@ def _format_timelog_detail(timelog: Timelog) -> str:
             f"notes: {timelog.notes or '-'}",
             f"area_id: {timelog.area_id or '-'}",
             f"task_id: {timelog.task_id or '-'}",
+            f"linked_notes_count: {getattr(timelog, 'linked_notes_count', 0)}",
             f"tags: {tag_names}",
             f"people: {people_names}",
             f"created_at: {format_timestamp(timelog.created_at)}",

--- a/src/lifeos_cli/cli_support/resources/timelog/parser.py
+++ b/src/lifeos_cli/cli_support/resources/timelog/parser.py
@@ -66,6 +66,8 @@ def build_timelog_parser(subparsers: argparse._SubParsersAction[argparse.Argumen
             notes=(
                 "Use `list` as the primary query entrypoint for timelogs.",
                 "Timelogs can optionally reference one area and one task.",
+                "Timelog list and show include `linked_notes_count` derived from "
+                "note associations.",
                 "Use `stats` for timelog stats grouped by area.",
                 "Delete operations in the public CLI always perform soft deletion.",
                 "Use `restore` to recover a soft-deleted timelog.",
@@ -146,6 +148,7 @@ def build_timelog_parser(subparsers: argparse._SubParsersAction[argparse.Argumen
                 "Use `--date` to query one configured local day using your timezone and "
                 "`day_starts_at` preference.",
                 "Use `--query` for lightweight text filtering across titles and notes.",
+                "List output includes one `linked_notes_count` column after `task_id`.",
             ),
         ),
     )
@@ -186,7 +189,7 @@ def build_timelog_parser(subparsers: argparse._SubParsersAction[argparse.Argumen
         "show",
         help_content=HelpContent(
             summary="Show a timelog",
-            description="Show one timelog with full metadata.",
+            description="Show one timelog with full metadata and derived note link counts.",
             examples=(
                 "lifeos timelog show 11111111-1111-1111-1111-111111111111",
                 "lifeos timelog show 11111111-1111-1111-1111-111111111111 --include-deleted",

--- a/src/lifeos_cli/db/maintenance.py
+++ b/src/lifeos_cli/db/maintenance.py
@@ -16,6 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from lifeos_cli.config import get_database_settings
 from lifeos_cli.db.models import (
     Area,
+    Association,
     Event,
     Habit,
     HabitAction,
@@ -65,6 +66,13 @@ RESOURCE_PERSON_ENTITY_TYPES: dict[str, str] = {
     "timelog": "timelog",
     "vision": "vision",
     "task": "task",
+}
+
+RESOURCE_ASSOCIATION_MODEL_TYPES: dict[str, str] = {
+    "note": "note",
+    "people": "person",
+    "task": "task",
+    "timelog": "timelog",
 }
 
 
@@ -124,6 +132,20 @@ async def purge_soft_deleted_record(
             delete(person_associations).where(
                 person_associations.c.entity_type == person_entity_type,
                 person_associations.c.entity_id == record_id,
+            )
+        )
+    association_model_type = RESOURCE_ASSOCIATION_MODEL_TYPES.get(resource)
+    if association_model_type is not None:
+        await session.execute(
+            delete(Association).where(
+                (Association.source_model == association_model_type)
+                & (Association.source_id == record_id)
+            )
+        )
+        await session.execute(
+            delete(Association).where(
+                (Association.target_model == association_model_type)
+                & (Association.target_id == record_id)
             )
         )
     await session.delete(record)

--- a/src/lifeos_cli/db/models/__init__.py
+++ b/src/lifeos_cli/db/models/__init__.py
@@ -2,6 +2,7 @@
 
 from .aggregated_timelog_stats_groupby_area import AggregatedTimelogStatsGroupByArea
 from .area import Area
+from .association import Association
 from .daily_timelog_stats_groupby_area import DailyTimelogStatsGroupByArea
 from .event import Event
 from .event_occurrence_exception import EventOccurrenceException
@@ -16,6 +17,7 @@ from .vision import Vision
 
 __all__ = [
     "AggregatedTimelogStatsGroupByArea",
+    "Association",
     "Area",
     "DailyTimelogStatsGroupByArea",
     "Event",

--- a/src/lifeos_cli/db/models/association.py
+++ b/src/lifeos_cli/db/models/association.py
@@ -1,0 +1,68 @@
+"""Generic weak association model for cross-entity links."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import CheckConstraint, Index, String, UniqueConstraint, Uuid
+from sqlalchemy.orm import Mapped, mapped_column
+
+from lifeos_cli.db.base import Base, TimestampedMixin, UUIDPrimaryKeyMixin
+
+VALID_ASSOCIATION_MODELS = ("note", "person", "task", "timelog")
+VALID_ASSOCIATION_LINK_TYPES = ("captured_from", "is_about", "relates_to")
+
+
+class Association(UUIDPrimaryKeyMixin, TimestampedMixin, Base):
+    """Directional weak link between two domain entities."""
+
+    __tablename__ = "associations"
+    __table_args__ = (
+        CheckConstraint(
+            "source_model IN ('note', 'person', 'task', 'timelog')",
+            name="ck_associations_source_model_valid",
+        ),
+        CheckConstraint(
+            "target_model IN ('note', 'person', 'task', 'timelog')",
+            name="ck_associations_target_model_valid",
+        ),
+        CheckConstraint(
+            "link_type IN ('captured_from', 'is_about', 'relates_to')",
+            name="ck_associations_link_type_valid",
+        ),
+        UniqueConstraint(
+            "source_model",
+            "source_id",
+            "target_model",
+            "target_id",
+            "link_type",
+            name="uq_associations_source_target_type",
+        ),
+        Index(
+            "ix_associations_source_model_id_type",
+            "source_model",
+            "source_id",
+            "link_type",
+        ),
+        Index(
+            "ix_associations_target_model_id_type",
+            "target_model",
+            "target_id",
+            "link_type",
+        ),
+    )
+
+    source_model: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    source_id: Mapped[UUID] = mapped_column(Uuid, nullable=False, index=True)
+    target_model: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    target_id: Mapped[UUID] = mapped_column(Uuid, nullable=False, index=True)
+    link_type: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+
+    def __repr__(self) -> str:
+        return (
+            "Association("
+            f"id={self.id!s}, "
+            f"{self.source_model}:{self.source_id!s} -> "
+            f"{self.target_model}:{self.target_id!s}, "
+            f"link_type={self.link_type!r})"
+        )

--- a/src/lifeos_cli/db/models/note.py
+++ b/src/lifeos_cli/db/models/note.py
@@ -2,10 +2,17 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from sqlalchemy import Index, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from lifeos_cli.db.base import Base, SoftDeleteMixin, TimestampedMixin, UUIDPrimaryKeyMixin
+
+if TYPE_CHECKING:
+    from lifeos_cli.db.models.person import Person
+    from lifeos_cli.db.models.task import Task
+    from lifeos_cli.db.models.timelog import Timelog
 
 
 class Note(UUIDPrimaryKeyMixin, TimestampedMixin, SoftDeleteMixin, Base):
@@ -18,6 +25,11 @@ class Note(UUIDPrimaryKeyMixin, TimestampedMixin, SoftDeleteMixin, Base):
     )
 
     content: Mapped[str] = mapped_column(Text, nullable=False)
+
+    if TYPE_CHECKING:
+        people: list[Person]
+        task: Task | None
+        timelogs: list[Timelog]
 
     def __repr__(self) -> str:
         preview = self.content[:40]

--- a/src/lifeos_cli/db/models/timelog.py
+++ b/src/lifeos_cli/db/models/timelog.py
@@ -50,6 +50,7 @@ class Timelog(UUIDPrimaryKeyMixin, TimestampedMixin, SoftDeleteMixin, Base):
     task = relationship("Task", foreign_keys=[task_id])
 
     if TYPE_CHECKING:
+        linked_notes_count: int
         tags: list[Tag]
         people: list[Person]
 

--- a/src/lifeos_cli/db/services/data_ops.py
+++ b/src/lifeos_cli/db/services/data_ops.py
@@ -45,6 +45,10 @@ from lifeos_cli.db.services import (
     timelogs,
     visions,
 )
+from lifeos_cli.db.services.entity_associations import (
+    get_target_ids_for_sources,
+    set_association_links,
+)
 from lifeos_cli.db.services.entity_people import sync_entity_people
 from lifeos_cli.db.services.entity_tags import sync_entity_tags
 
@@ -328,6 +332,9 @@ class PreparedSnapshotRow:
     direct_values: dict[str, Any]
     tag_ids: list[UUID] | None = None
     person_ids: list[UUID] | None = None
+    note_task_supplied: bool = False
+    note_task_id: UUID | None = None
+    note_timelog_ids: list[UUID] | None = None
     occurrence_exceptions: list[dict[str, Any]] | None = None
 
 
@@ -354,7 +361,18 @@ def prepare_snapshot_row(resource: str, index: int, payload: dict[str, Any]) -> 
     )
     person_ids = (
         _parse_person_ids(payload["person_ids"])
-        if spec.person_entity_type and "person_ids" in payload
+        if (spec.person_entity_type and "person_ids" in payload)
+        or (resource == "note" and "person_ids" in payload)
+        else None
+    )
+    note_task_id = (
+        None
+        if "task_id" not in payload
+        else (None if payload["task_id"] is None else UUID(str(payload["task_id"])))
+    )
+    note_timelog_ids = (
+        _parse_person_ids(payload["timelog_ids"])
+        if resource == "note" and "timelog_ids" in payload
         else None
     )
     occurrence_exceptions = (
@@ -369,6 +387,9 @@ def prepare_snapshot_row(resource: str, index: int, payload: dict[str, Any]) -> 
         direct_values=direct_values,
         tag_ids=tag_ids,
         person_ids=person_ids,
+        note_task_supplied=("task_id" in payload if resource == "note" else False),
+        note_task_id=note_task_id,
+        note_timelog_ids=note_timelog_ids,
         occurrence_exceptions=occurrence_exceptions,
     )
 
@@ -439,6 +460,52 @@ async def _load_event_occurrence_exceptions(
     return mapping
 
 
+async def _load_note_task_ids(
+    session: AsyncSession,
+    *,
+    note_ids: list[UUID],
+) -> dict[UUID, UUID | None]:
+    mapping = await get_target_ids_for_sources(
+        session,
+        source_model="note",
+        source_ids=note_ids,
+        target_model="task",
+        link_type="relates_to",
+    )
+    return {
+        note_id: (linked_task_ids[0] if linked_task_ids else None)
+        for note_id, linked_task_ids in mapping.items()
+    }
+
+
+async def _load_note_person_ids(
+    session: AsyncSession,
+    *,
+    note_ids: list[UUID],
+) -> dict[UUID, list[UUID]]:
+    return await get_target_ids_for_sources(
+        session,
+        source_model="note",
+        source_ids=note_ids,
+        target_model="person",
+        link_type="is_about",
+    )
+
+
+async def _load_note_timelog_ids(
+    session: AsyncSession,
+    *,
+    note_ids: list[UUID],
+) -> dict[UUID, list[UUID]]:
+    return await get_target_ids_for_sources(
+        session,
+        source_model="note",
+        source_ids=note_ids,
+        target_model="timelog",
+        link_type="captured_from",
+    )
+
+
 async def export_resource_snapshot(
     session: AsyncSession,
     *,
@@ -480,6 +547,15 @@ async def export_resource_snapshot(
         if resource == "event"
         else {}
     )
+    note_task_map = (
+        await _load_note_task_ids(session, note_ids=entity_ids) if resource == "note" else {}
+    )
+    note_person_map = (
+        await _load_note_person_ids(session, note_ids=entity_ids) if resource == "note" else {}
+    )
+    note_timelog_map = (
+        await _load_note_timelog_ids(session, note_ids=entity_ids) if resource == "note" else {}
+    )
 
     for payload in payloads:
         entity_id = UUID(str(payload["id"]))
@@ -489,6 +565,16 @@ async def export_resource_snapshot(
             payload["person_ids"] = [str(person_id) for person_id in person_map.get(entity_id, [])]
         if resource == "event":
             payload["occurrence_exceptions"] = occurrence_map.get(entity_id, [])
+        if resource == "note":
+            payload["person_ids"] = [
+                str(person_id) for person_id in note_person_map.get(entity_id, [])
+            ]
+            payload["task_id"] = (
+                None if note_task_map.get(entity_id) is None else str(note_task_map[entity_id])
+            )
+            payload["timelog_ids"] = [
+                str(timelog_id) for timelog_id in note_timelog_map.get(entity_id, [])
+            ]
     return payloads
 
 
@@ -531,6 +617,34 @@ async def _sync_snapshot_relations(
             entity_type=spec.person_entity_type,
             desired_person_ids=prepared_row.person_ids,
         )
+    if prepared_row.resource == "note":
+        if prepared_row.person_ids is not None:
+            await set_association_links(
+                session,
+                source_model="note",
+                source_id=prepared_row.row_id,
+                target_model="person",
+                target_ids=prepared_row.person_ids,
+                link_type="is_about",
+            )
+        if prepared_row.note_task_supplied:
+            await set_association_links(
+                session,
+                source_model="note",
+                source_id=prepared_row.row_id,
+                target_model="task",
+                target_ids=[] if prepared_row.note_task_id is None else [prepared_row.note_task_id],
+                link_type="relates_to",
+            )
+        if prepared_row.note_timelog_ids is not None:
+            await set_association_links(
+                session,
+                source_model="note",
+                source_id=prepared_row.row_id,
+                target_model="timelog",
+                target_ids=prepared_row.note_timelog_ids,
+                link_type="captured_from",
+            )
     if prepared_row.resource == "event" and prepared_row.occurrence_exceptions is not None:
         await session.execute(
             delete(EventOccurrenceException).where(
@@ -631,6 +745,12 @@ def _normalize_patch_payload(resource: str, payload: dict[str, Any]) -> dict[str
             normalized[field] = None if value is None else _parse_tag_ids(value)
             continue
         if field == "person_ids":
+            normalized[field] = None if value is None else _parse_person_ids(value)
+            continue
+        if field == "task_id" and resource == "note":
+            normalized[field] = None if value is None else UUID(str(value))
+            continue
+        if field == "timelog_ids" and resource == "note":
             normalized[field] = None if value is None else _parse_person_ids(value)
             continue
         normalized[field] = value
@@ -791,12 +911,20 @@ def _batch_update_timelog_kwargs(payload: dict[str, Any]) -> dict[str, Any]:
 
 
 def _batch_update_note_kwargs(payload: dict[str, Any]) -> dict[str, Any]:
-    if "content" not in payload:
-        raise DataOperationError("Note batch update requires `content`.")
-    return {
-        "note_id": UUID(str(payload["id"])),
-        "content": payload["content"],
-    }
+    kwargs: dict[str, Any] = {"note_id": UUID(str(payload["id"]))}
+    if "content" in payload:
+        if payload["content"] is None:
+            raise DataOperationError("Note batch update does not allow null `content`.")
+        kwargs["content"] = payload["content"]
+    kwargs.update(_null_means_clear(payload, field="person_ids", clear_flag="clear_people"))
+    kwargs.update(_null_means_clear(payload, field="task_id", clear_flag="clear_task"))
+    kwargs.update(_null_means_clear(payload, field="timelog_ids", clear_flag="clear_timelogs"))
+    if len(kwargs) == 1:
+        raise DataOperationError(
+            "Note batch update requires at least one of `content`, `person_ids`, `task_id`, "
+            "or `timelog_ids`."
+        )
+    return kwargs
 
 
 UPDATE_KWARGS_BUILDERS: dict[str, Any] = {

--- a/src/lifeos_cli/db/services/entity_associations.py
+++ b/src/lifeos_cli/db/services/entity_associations.py
@@ -1,0 +1,341 @@
+"""Helpers for generic weak entity-to-entity associations."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import delete, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from lifeos_cli.db.models.association import Association
+from lifeos_cli.db.models.note import Note
+from lifeos_cli.db.models.person import Person
+from lifeos_cli.db.models.task import Task
+from lifeos_cli.db.models.timelog import Timelog
+
+VALID_ASSOCIATION_MODELS = frozenset({"note", "person", "task", "timelog"})
+VALID_ASSOCIATION_LINK_TYPES = frozenset({"is_about", "relates_to", "captured_from"})
+
+MODEL_MAP: dict[str, Any] = {
+    "note": Note,
+    "person": Person,
+    "task": Task,
+    "timelog": Timelog,
+}
+
+
+def validate_association_model(model_name: str) -> str:
+    """Validate one weak-association model name."""
+    normalized = model_name.strip().lower()
+    if normalized not in VALID_ASSOCIATION_MODELS:
+        allowed = ", ".join(sorted(VALID_ASSOCIATION_MODELS))
+        raise ValueError(f"Unsupported association model {normalized!r}. Expected one of: {allowed}")
+    return normalized
+
+
+def validate_association_link_type(link_type: str) -> str:
+    """Validate one weak-association link type."""
+    normalized = link_type.strip().lower()
+    if normalized not in VALID_ASSOCIATION_LINK_TYPES:
+        allowed = ", ".join(sorted(VALID_ASSOCIATION_LINK_TYPES))
+        raise ValueError(
+            f"Unsupported association link type {normalized!r}. Expected one of: {allowed}"
+        )
+    return normalized
+
+
+def _deduplicate_ids(identifiers: list[UUID]) -> list[UUID]:
+    return list(dict.fromkeys(identifiers))
+
+
+async def _load_existing_ids(
+    session: AsyncSession,
+    *,
+    model_name: str,
+    identifiers: list[UUID],
+) -> set[UUID]:
+    if not identifiers:
+        return set()
+    model_cls = MODEL_MAP[validate_association_model(model_name)]
+    stmt = select(model_cls.id).where(model_cls.id.in_(identifiers), model_cls.deleted_at.is_(None))
+    rows = await session.execute(stmt)
+    return set(rows.scalars().all())
+
+
+async def set_association_links(
+    session: AsyncSession,
+    *,
+    source_model: str,
+    source_id: UUID,
+    target_model: str,
+    target_ids: list[UUID],
+    link_type: str,
+    replace: bool = True,
+) -> None:
+    """Create or replace weak links after validating both endpoints exist."""
+    normalized_source_model = validate_association_model(source_model)
+    normalized_target_model = validate_association_model(target_model)
+    normalized_link_type = validate_association_link_type(link_type)
+    unique_target_ids = _deduplicate_ids(target_ids)
+
+    if source_id not in await _load_existing_ids(
+        session,
+        model_name=normalized_source_model,
+        identifiers=[source_id],
+    ):
+        raise LookupError(
+            f"Unknown source ID for association {normalized_source_model}: {source_id}"
+        )
+
+    existing_target_ids = await _load_existing_ids(
+        session,
+        model_name=normalized_target_model,
+        identifiers=unique_target_ids,
+    )
+    missing_target_ids = [str(target_id) for target_id in unique_target_ids if target_id not in existing_target_ids]
+    if missing_target_ids:
+        raise LookupError(
+            "Unknown target IDs for association "
+            f"{normalized_source_model}->{normalized_target_model}: {', '.join(missing_target_ids)}"
+        )
+
+    if replace:
+        await session.execute(
+            delete(Association).where(
+                Association.source_model == normalized_source_model,
+                Association.source_id == source_id,
+                Association.target_model == normalized_target_model,
+                Association.link_type == normalized_link_type,
+            )
+        )
+
+    existing_links: set[UUID] = set()
+    if existing_target_ids and not replace:
+        stmt = select(Association.target_id).where(
+            Association.source_model == normalized_source_model,
+            Association.source_id == source_id,
+            Association.target_model == normalized_target_model,
+            Association.target_id.in_(existing_target_ids),
+            Association.link_type == normalized_link_type,
+        )
+        rows = await session.execute(stmt)
+        existing_links = set(rows.scalars().all())
+
+    for target_id in unique_target_ids:
+        if target_id in existing_links:
+            continue
+        session.add(
+            Association(
+                source_model=normalized_source_model,
+                source_id=source_id,
+                target_model=normalized_target_model,
+                target_id=target_id,
+                link_type=normalized_link_type,
+            )
+        )
+
+
+async def get_target_ids_for_sources(
+    session: AsyncSession,
+    *,
+    source_model: str,
+    source_ids: list[UUID],
+    target_model: str,
+    link_type: str | None = None,
+) -> dict[UUID, list[UUID]]:
+    """Return mapping source_id -> target_ids for one weak link family."""
+    if not source_ids:
+        return {}
+    normalized_source_model = validate_association_model(source_model)
+    normalized_target_model = validate_association_model(target_model)
+    stmt = select(Association.source_id, Association.target_id).where(
+        Association.source_model == normalized_source_model,
+        Association.source_id.in_(source_ids),
+        Association.target_model == normalized_target_model,
+    ).order_by(Association.created_at.asc(), Association.id.asc())
+    if link_type is not None:
+        stmt = stmt.where(Association.link_type == validate_association_link_type(link_type))
+    rows = await session.execute(stmt)
+    mapping: dict[UUID, list[UUID]] = defaultdict(list)
+    for source_id, target_id in rows.all():
+        mapping[source_id].append(target_id)
+    return dict(mapping)
+
+
+async def get_source_ids_for_target(
+    session: AsyncSession,
+    *,
+    source_model: str,
+    target_model: str,
+    target_id: UUID,
+    link_type: str | None = None,
+) -> list[UUID]:
+    """Return linked source identifiers for one weak-link target."""
+    normalized_source_model = validate_association_model(source_model)
+    normalized_target_model = validate_association_model(target_model)
+    stmt = select(Association.source_id).where(
+        Association.source_model == normalized_source_model,
+        Association.target_model == normalized_target_model,
+        Association.target_id == target_id,
+    ).order_by(Association.created_at.asc(), Association.id.asc())
+    if link_type is not None:
+        stmt = stmt.where(Association.link_type == validate_association_link_type(link_type))
+    rows = await session.execute(stmt)
+    return list(rows.scalars().all())
+
+
+async def count_sources_for_targets(
+    session: AsyncSession,
+    *,
+    source_model: str,
+    target_model: str,
+    target_ids: list[UUID],
+    link_type: str | None = None,
+) -> dict[UUID, int]:
+    """Return mapping target_id -> linked source count."""
+    if not target_ids:
+        return {}
+    normalized_source_model = validate_association_model(source_model)
+    normalized_target_model = validate_association_model(target_model)
+    stmt = (
+        select(Association.target_id, func.count(Association.id))
+        .where(
+            Association.source_model == normalized_source_model,
+            Association.target_model == normalized_target_model,
+            Association.target_id.in_(target_ids),
+        )
+        .group_by(Association.target_id)
+    )
+    if link_type is not None:
+        stmt = stmt.where(Association.link_type == validate_association_link_type(link_type))
+    rows = await session.execute(stmt)
+    return {target_id: count for target_id, count in rows.all()}
+
+
+async def load_people_for_sources(
+    session: AsyncSession,
+    *,
+    source_model: str,
+    source_ids: list[UUID],
+    link_type: str,
+) -> dict[UUID, list[Person]]:
+    """Load people grouped by source identifier."""
+    mapping = await get_target_ids_for_sources(
+        session,
+        source_model=source_model,
+        source_ids=source_ids,
+        target_model="person",
+        link_type=link_type,
+    )
+    all_person_ids = {person_id for person_ids in mapping.values() for person_id in person_ids}
+    if not all_person_ids:
+        return {}
+    stmt = select(Person).where(Person.id.in_(all_person_ids), Person.deleted_at.is_(None))
+    rows = await session.execute(stmt)
+    people_by_id = {person.id: person for person in rows.scalars().all()}
+    return {
+        source_id: [people_by_id[person_id] for person_id in person_ids if person_id in people_by_id]
+        for source_id, person_ids in mapping.items()
+    }
+
+
+async def load_tasks_for_sources(
+    session: AsyncSession,
+    *,
+    source_model: str,
+    source_ids: list[UUID],
+    link_type: str,
+) -> dict[UUID, Task]:
+    """Load one linked task per source identifier."""
+    mapping = await get_target_ids_for_sources(
+        session,
+        source_model=source_model,
+        source_ids=source_ids,
+        target_model="task",
+        link_type=link_type,
+    )
+    all_task_ids = {task_id for task_ids in mapping.values() for task_id in task_ids}
+    if not all_task_ids:
+        return {}
+    stmt = select(Task).where(Task.id.in_(all_task_ids), Task.deleted_at.is_(None))
+    rows = await session.execute(stmt)
+    tasks_by_id = {task.id: task for task in rows.scalars().all()}
+    loaded: dict[UUID, Task] = {}
+    for source_id, task_ids in mapping.items():
+        for task_id in task_ids:
+            task = tasks_by_id.get(task_id)
+            if task is not None:
+                loaded[source_id] = task
+                break
+    return loaded
+
+
+async def load_timelogs_for_sources(
+    session: AsyncSession,
+    *,
+    source_model: str,
+    source_ids: list[UUID],
+    link_type: str,
+) -> dict[UUID, list[Timelog]]:
+    """Load timelogs grouped by source identifier."""
+    mapping = await get_target_ids_for_sources(
+        session,
+        source_model=source_model,
+        source_ids=source_ids,
+        target_model="timelog",
+        link_type=link_type,
+    )
+    all_timelog_ids = {timelog_id for timelog_ids in mapping.values() for timelog_id in timelog_ids}
+    if not all_timelog_ids:
+        return {}
+    stmt = select(Timelog).where(Timelog.id.in_(all_timelog_ids), Timelog.deleted_at.is_(None))
+    rows = await session.execute(stmt)
+    timelogs_by_id = {timelog.id: timelog for timelog in rows.scalars().all()}
+    return {
+        source_id: [
+            timelogs_by_id[timelog_id]
+            for timelog_id in timelog_ids
+            if timelog_id in timelogs_by_id
+        ]
+        for source_id, timelog_ids in mapping.items()
+    }
+
+
+async def load_notes_for_targets(
+    session: AsyncSession,
+    *,
+    target_model: str,
+    target_ids: list[UUID],
+    link_type: str,
+) -> dict[UUID, list[Note]]:
+    """Load notes grouped by target identifier."""
+    if not target_ids:
+        return {}
+    normalized_target_model = validate_association_model(target_model)
+    normalized_link_type = validate_association_link_type(link_type)
+    stmt = select(Association.target_id, Association.source_id).where(
+        Association.source_model == "note",
+        Association.target_model == normalized_target_model,
+        Association.target_id.in_(target_ids),
+        Association.link_type == normalized_link_type,
+    ).order_by(Association.created_at.asc(), Association.id.asc())
+    rows = await session.execute(stmt)
+    reverse_mapping: dict[UUID, list[UUID]] = defaultdict(list)
+    for target_id, note_id in rows.all():
+        reverse_mapping[target_id].append(note_id)
+    all_note_ids = {note_id for note_ids in reverse_mapping.values() for note_id in note_ids}
+    if not all_note_ids:
+        return {}
+    note_stmt = (
+        select(Note)
+        .where(Note.id.in_(all_note_ids), Note.deleted_at.is_(None))
+        .order_by(Note.created_at.desc(), Note.id.desc())
+    )
+    rows = await session.execute(note_stmt)
+    notes_by_id = {note.id: note for note in rows.scalars().all()}
+    return {
+        target_id: [notes_by_id[note_id] for note_id in note_ids if note_id in notes_by_id]
+        for target_id, note_ids in reverse_mapping.items()
+    }

--- a/src/lifeos_cli/db/services/entity_associations.py
+++ b/src/lifeos_cli/db/services/entity_associations.py
@@ -31,7 +31,9 @@ def validate_association_model(model_name: str) -> str:
     normalized = model_name.strip().lower()
     if normalized not in VALID_ASSOCIATION_MODELS:
         allowed = ", ".join(sorted(VALID_ASSOCIATION_MODELS))
-        raise ValueError(f"Unsupported association model {normalized!r}. Expected one of: {allowed}")
+        raise ValueError(
+            f"Unsupported association model {normalized!r}. Expected one of: {allowed}"
+        )
     return normalized
 
 
@@ -94,7 +96,9 @@ async def set_association_links(
         model_name=normalized_target_model,
         identifiers=unique_target_ids,
     )
-    missing_target_ids = [str(target_id) for target_id in unique_target_ids if target_id not in existing_target_ids]
+    missing_target_ids = [
+        str(target_id) for target_id in unique_target_ids if target_id not in existing_target_ids
+    ]
     if missing_target_ids:
         raise LookupError(
             "Unknown target IDs for association "
@@ -150,11 +154,15 @@ async def get_target_ids_for_sources(
         return {}
     normalized_source_model = validate_association_model(source_model)
     normalized_target_model = validate_association_model(target_model)
-    stmt = select(Association.source_id, Association.target_id).where(
-        Association.source_model == normalized_source_model,
-        Association.source_id.in_(source_ids),
-        Association.target_model == normalized_target_model,
-    ).order_by(Association.created_at.asc(), Association.id.asc())
+    stmt = (
+        select(Association.source_id, Association.target_id)
+        .where(
+            Association.source_model == normalized_source_model,
+            Association.source_id.in_(source_ids),
+            Association.target_model == normalized_target_model,
+        )
+        .order_by(Association.created_at.asc(), Association.id.asc())
+    )
     if link_type is not None:
         stmt = stmt.where(Association.link_type == validate_association_link_type(link_type))
     rows = await session.execute(stmt)
@@ -175,11 +183,15 @@ async def get_source_ids_for_target(
     """Return linked source identifiers for one weak-link target."""
     normalized_source_model = validate_association_model(source_model)
     normalized_target_model = validate_association_model(target_model)
-    stmt = select(Association.source_id).where(
-        Association.source_model == normalized_source_model,
-        Association.target_model == normalized_target_model,
-        Association.target_id == target_id,
-    ).order_by(Association.created_at.asc(), Association.id.asc())
+    stmt = (
+        select(Association.source_id)
+        .where(
+            Association.source_model == normalized_source_model,
+            Association.target_model == normalized_target_model,
+            Association.target_id == target_id,
+        )
+        .order_by(Association.created_at.asc(), Association.id.asc())
+    )
     if link_type is not None:
         stmt = stmt.where(Association.link_type == validate_association_link_type(link_type))
     rows = await session.execute(stmt)
@@ -236,7 +248,9 @@ async def load_people_for_sources(
     rows = await session.execute(stmt)
     people_by_id = {person.id: person for person in rows.scalars().all()}
     return {
-        source_id: [people_by_id[person_id] for person_id in person_ids if person_id in people_by_id]
+        source_id: [
+            people_by_id[person_id] for person_id in person_ids if person_id in people_by_id
+        ]
         for source_id, person_ids in mapping.items()
     }
 
@@ -295,47 +309,7 @@ async def load_timelogs_for_sources(
     timelogs_by_id = {timelog.id: timelog for timelog in rows.scalars().all()}
     return {
         source_id: [
-            timelogs_by_id[timelog_id]
-            for timelog_id in timelog_ids
-            if timelog_id in timelogs_by_id
+            timelogs_by_id[timelog_id] for timelog_id in timelog_ids if timelog_id in timelogs_by_id
         ]
         for source_id, timelog_ids in mapping.items()
-    }
-
-
-async def load_notes_for_targets(
-    session: AsyncSession,
-    *,
-    target_model: str,
-    target_ids: list[UUID],
-    link_type: str,
-) -> dict[UUID, list[Note]]:
-    """Load notes grouped by target identifier."""
-    if not target_ids:
-        return {}
-    normalized_target_model = validate_association_model(target_model)
-    normalized_link_type = validate_association_link_type(link_type)
-    stmt = select(Association.target_id, Association.source_id).where(
-        Association.source_model == "note",
-        Association.target_model == normalized_target_model,
-        Association.target_id.in_(target_ids),
-        Association.link_type == normalized_link_type,
-    ).order_by(Association.created_at.asc(), Association.id.asc())
-    rows = await session.execute(stmt)
-    reverse_mapping: dict[UUID, list[UUID]] = defaultdict(list)
-    for target_id, note_id in rows.all():
-        reverse_mapping[target_id].append(note_id)
-    all_note_ids = {note_id for note_ids in reverse_mapping.values() for note_id in note_ids}
-    if not all_note_ids:
-        return {}
-    note_stmt = (
-        select(Note)
-        .where(Note.id.in_(all_note_ids), Note.deleted_at.is_(None))
-        .order_by(Note.created_at.desc(), Note.id.desc())
-    )
-    rows = await session.execute(note_stmt)
-    notes_by_id = {note.id: note for note in rows.scalars().all()}
-    return {
-        target_id: [notes_by_id[note_id] for note_id in note_ids if note_id in notes_by_id]
-        for target_id, note_ids in reverse_mapping.items()
     }

--- a/src/lifeos_cli/db/services/notes.py
+++ b/src/lifeos_cli/db/services/notes.py
@@ -6,15 +6,27 @@ import re
 from dataclasses import dataclass
 from uuid import UUID
 
-from sqlalchemy import Select, or_, select
+from sqlalchemy import Select, exists, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql.elements import ColumnElement
 
+from lifeos_cli.db.models.association import Association
 from lifeos_cli.db.models.note import Note
 from lifeos_cli.db.services.batching import BatchDeleteResult, batch_delete_records
+from lifeos_cli.db.services.entity_associations import (
+    load_people_for_sources,
+    load_tasks_for_sources,
+    load_timelogs_for_sources,
+    set_association_links,
+)
 
 
 class NoteNotFoundError(LookupError):
     """Raised when a note cannot be found."""
+
+
+class NoteValidationError(ValueError):
+    """Raised when note input cannot be applied."""
 
 
 @dataclass(frozen=True)
@@ -28,10 +40,64 @@ class NoteBatchUpdateResult:
     replacement_count: int
 
 
-def _note_query(*, include_deleted: bool) -> Select[tuple[Note]]:
+def _normalize_note_content(content: str) -> str:
+    """Validate note content while preserving intentional formatting."""
+    if not content.strip():
+        raise NoteValidationError("Note content must not be empty.")
+    return content
+
+
+def _association_exists_clause(
+    *,
+    target_model: str,
+    target_id: UUID,
+    link_type: str,
+) -> ColumnElement[bool]:
+    return exists(
+        select(1).where(
+            Association.source_model == "note",
+            Association.source_id == Note.id,
+            Association.target_model == target_model,
+            Association.target_id == target_id,
+            Association.link_type == link_type,
+        )
+    )
+
+
+def _note_query(
+    *,
+    include_deleted: bool,
+    person_id: UUID | None = None,
+    task_id: UUID | None = None,
+    timelog_id: UUID | None = None,
+) -> Select[tuple[Note]]:
     stmt = select(Note)
     if not include_deleted:
         stmt = stmt.where(Note.deleted_at.is_(None))
+    if person_id is not None:
+        stmt = stmt.where(
+            _association_exists_clause(
+                target_model="person",
+                target_id=person_id,
+                link_type="is_about",
+            )
+        )
+    if task_id is not None:
+        stmt = stmt.where(
+            _association_exists_clause(
+                target_model="task",
+                target_id=task_id,
+                link_type="relates_to",
+            )
+        )
+    if timelog_id is not None:
+        stmt = stmt.where(
+            _association_exists_clause(
+                target_model="timelog",
+                target_id=timelog_id,
+                link_type="captured_from",
+            )
+        )
     return stmt
 
 
@@ -67,13 +133,104 @@ def _apply_content_batch_operation(
     return replacements
 
 
-async def create_note(session: AsyncSession, *, content: str) -> Note:
+async def _attach_note_links(session: AsyncSession, note: Note) -> Note:
+    people_map = await load_people_for_sources(
+        session,
+        source_model="note",
+        source_ids=[note.id],
+        link_type="is_about",
+    )
+    task_map = await load_tasks_for_sources(
+        session,
+        source_model="note",
+        source_ids=[note.id],
+        link_type="relates_to",
+    )
+    timelog_map = await load_timelogs_for_sources(
+        session,
+        source_model="note",
+        source_ids=[note.id],
+        link_type="captured_from",
+    )
+    note.people = people_map.get(note.id, [])
+    note.task = task_map.get(note.id)
+    note.timelogs = timelog_map.get(note.id, [])
+    return note
+
+
+async def _attach_note_links_for_many(
+    session: AsyncSession,
+    note_records: list[Note],
+) -> list[Note]:
+    if not note_records:
+        return []
+    note_ids = [note.id for note in note_records]
+    people_map = await load_people_for_sources(
+        session,
+        source_model="note",
+        source_ids=note_ids,
+        link_type="is_about",
+    )
+    task_map = await load_tasks_for_sources(
+        session,
+        source_model="note",
+        source_ids=note_ids,
+        link_type="relates_to",
+    )
+    timelog_map = await load_timelogs_for_sources(
+        session,
+        source_model="note",
+        source_ids=note_ids,
+        link_type="captured_from",
+    )
+    for note in note_records:
+        note.people = people_map.get(note.id, [])
+        note.task = task_map.get(note.id)
+        note.timelogs = timelog_map.get(note.id, [])
+    return note_records
+
+
+async def create_note(
+    session: AsyncSession,
+    *,
+    content: str,
+    person_ids: list[UUID] | None = None,
+    task_id: UUID | None = None,
+    timelog_ids: list[UUID] | None = None,
+) -> Note:
     """Create and persist a note."""
-    note = Note(content=content)
+    note = Note(content=_normalize_note_content(content))
     session.add(note)
     await session.flush()
+    if person_ids is not None:
+        await set_association_links(
+            session,
+            source_model="note",
+            source_id=note.id,
+            target_model="person",
+            target_ids=person_ids,
+            link_type="is_about",
+        )
+    if task_id is not None:
+        await set_association_links(
+            session,
+            source_model="note",
+            source_id=note.id,
+            target_model="task",
+            target_ids=[task_id],
+            link_type="relates_to",
+        )
+    if timelog_ids is not None:
+        await set_association_links(
+            session,
+            source_model="note",
+            source_id=note.id,
+            target_model="timelog",
+            target_ids=timelog_ids,
+            link_type="captured_from",
+        )
     await session.refresh(note)
-    return note
+    return await _attach_note_links(session, note)
 
 
 async def get_note(
@@ -84,24 +241,35 @@ async def get_note(
 ) -> Note | None:
     """Fetch a note by identifier."""
     stmt = _note_query(include_deleted=include_deleted).where(Note.id == note_id).limit(1)
-    return (await session.execute(stmt)).scalar_one_or_none()
+    note = (await session.execute(stmt)).scalar_one_or_none()
+    if note is None:
+        return None
+    return await _attach_note_links(session, note)
 
 
 async def list_notes(
     session: AsyncSession,
     *,
     include_deleted: bool = False,
+    person_id: UUID | None = None,
+    task_id: UUID | None = None,
+    timelog_id: UUID | None = None,
     limit: int = 100,
     offset: int = 0,
 ) -> list[Note]:
     """Return notes ordered from newest to oldest."""
     stmt = (
-        _note_query(include_deleted=include_deleted)
+        _note_query(
+            include_deleted=include_deleted,
+            person_id=person_id,
+            task_id=task_id,
+            timelog_id=timelog_id,
+        )
         .order_by(Note.created_at.desc(), Note.id.desc())
         .offset(offset)
         .limit(limit)
     )
-    return list((await session.execute(stmt)).scalars())
+    return await _attach_note_links_for_many(session, list((await session.execute(stmt)).scalars()))
 
 
 async def search_notes(
@@ -109,27 +277,112 @@ async def search_notes(
     *,
     query: str,
     include_deleted: bool = False,
+    person_id: UUID | None = None,
+    task_id: UUID | None = None,
+    timelog_id: UUID | None = None,
     limit: int = 100,
     offset: int = 0,
 ) -> list[Note]:
     """Return notes whose content matches any token from the query."""
     tokens = _tokenize_search_query(query)
-    stmt = _note_query(include_deleted=include_deleted)
+    stmt = _note_query(
+        include_deleted=include_deleted,
+        person_id=person_id,
+        task_id=task_id,
+        timelog_id=timelog_id,
+    )
     if tokens:
         stmt = stmt.where(or_(*[Note.content.ilike(f"%{token}%") for token in tokens]))
     stmt = stmt.order_by(Note.created_at.desc(), Note.id.desc()).offset(offset).limit(limit)
-    return list((await session.execute(stmt)).scalars())
+    return await _attach_note_links_for_many(session, list((await session.execute(stmt)).scalars()))
 
 
-async def update_note(session: AsyncSession, *, note_id: UUID, content: str) -> Note:
-    """Update note content."""
+async def update_note(
+    session: AsyncSession,
+    *,
+    note_id: UUID,
+    content: str | None = None,
+    person_ids: list[UUID] | None = None,
+    clear_people: bool = False,
+    task_id: UUID | None = None,
+    clear_task: bool = False,
+    timelog_ids: list[UUID] | None = None,
+    clear_timelogs: bool = False,
+) -> Note:
+    """Update note content and weak associations."""
     note = await get_note(session, note_id=note_id)
     if note is None:
         raise NoteNotFoundError(f"Note {note_id} was not found")
-    note.content = content
+    if (
+        content is None
+        and person_ids is None
+        and not clear_people
+        and task_id is None
+        and not clear_task
+        and timelog_ids is None
+        and not clear_timelogs
+    ):
+        raise NoteValidationError("Provide at least one note field or association to update.")
+
+    if content is not None:
+        note.content = _normalize_note_content(content)
+    if clear_people:
+        await set_association_links(
+            session,
+            source_model="note",
+            source_id=note.id,
+            target_model="person",
+            target_ids=[],
+            link_type="is_about",
+        )
+    elif person_ids is not None:
+        await set_association_links(
+            session,
+            source_model="note",
+            source_id=note.id,
+            target_model="person",
+            target_ids=person_ids,
+            link_type="is_about",
+        )
+    if clear_task:
+        await set_association_links(
+            session,
+            source_model="note",
+            source_id=note.id,
+            target_model="task",
+            target_ids=[],
+            link_type="relates_to",
+        )
+    elif task_id is not None:
+        await set_association_links(
+            session,
+            source_model="note",
+            source_id=note.id,
+            target_model="task",
+            target_ids=[task_id],
+            link_type="relates_to",
+        )
+    if clear_timelogs:
+        await set_association_links(
+            session,
+            source_model="note",
+            source_id=note.id,
+            target_model="timelog",
+            target_ids=[],
+            link_type="captured_from",
+        )
+    elif timelog_ids is not None:
+        await set_association_links(
+            session,
+            source_model="note",
+            source_id=note.id,
+            target_model="timelog",
+            target_ids=timelog_ids,
+            link_type="captured_from",
+        )
     await session.flush()
     await session.refresh(note)
-    return note
+    return await _attach_note_links(session, note)
 
 
 async def delete_note(

--- a/src/lifeos_cli/db/services/notes.py
+++ b/src/lifeos_cli/db/services/notes.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
+from typing import Any
 from uuid import UUID
 
 from sqlalchemy import Select, exists, or_, select
@@ -12,6 +13,9 @@ from sqlalchemy.sql.elements import ColumnElement
 
 from lifeos_cli.db.models.association import Association
 from lifeos_cli.db.models.note import Note
+from lifeos_cli.db.models.person import Person
+from lifeos_cli.db.models.task import Task
+from lifeos_cli.db.models.timelog import Timelog
 from lifeos_cli.db.services.batching import BatchDeleteResult, batch_delete_records
 from lifeos_cli.db.services.entity_associations import (
     load_people_for_sources,
@@ -53,6 +57,12 @@ def _association_exists_clause(
     target_id: UUID,
     link_type: str,
 ) -> ColumnElement[bool]:
+    target_table_by_model: dict[str, Any] = {
+        "person": Person,
+        "task": Task,
+        "timelog": Timelog,
+    }
+    target_table = target_table_by_model[target_model]
     return exists(
         select(1).where(
             Association.source_model == "note",
@@ -60,6 +70,8 @@ def _association_exists_clause(
             Association.target_model == target_model,
             Association.target_id == target_id,
             Association.link_type == link_type,
+            target_table.id == target_id,
+            target_table.deleted_at.is_(None),
         )
     )
 

--- a/src/lifeos_cli/db/services/timelogs.py
+++ b/src/lifeos_cli/db/services/timelogs.py
@@ -22,6 +22,7 @@ from lifeos_cli.db.services.batching import (
     batch_delete_records,
     batch_restore_records,
 )
+from lifeos_cli.db.services.entity_associations import count_sources_for_targets
 from lifeos_cli.db.services.entity_people import load_people_for_entities, sync_entity_people
 from lifeos_cli.db.services.entity_tags import load_tags_for_entities, sync_entity_tags
 from lifeos_cli.db.services.task_effort import recompute_task_effort_after_timelog_change
@@ -57,8 +58,16 @@ async def _attach_timelog_links(session: AsyncSession, timelog: Timelog) -> Time
     people_map = await load_people_for_entities(
         session, entity_ids=[timelog.id], entity_type="timelog"
     )
+    note_count_map = await count_sources_for_targets(
+        session,
+        source_model="note",
+        target_model="timelog",
+        target_ids=[timelog.id],
+        link_type="captured_from",
+    )
     timelog.tags = tags_map.get(timelog.id, [])
     timelog.people = people_map.get(timelog.id, [])
+    timelog.linked_notes_count = note_count_map.get(timelog.id, 0)
     return timelog
 
 
@@ -73,9 +82,17 @@ async def _attach_timelog_links_for_many(
     people_map = await load_people_for_entities(
         session, entity_ids=timelog_ids, entity_type="timelog"
     )
+    note_count_map = await count_sources_for_targets(
+        session,
+        source_model="note",
+        target_model="timelog",
+        target_ids=timelog_ids,
+        link_type="captured_from",
+    )
     for timelog in timelogs:
         timelog.tags = tags_map.get(timelog.id, [])
         timelog.people = people_map.get(timelog.id, [])
+        timelog.linked_notes_count = note_count_map.get(timelog.id, 0)
     return timelogs
 
 

--- a/tests/test_cli_integration_data.py
+++ b/tests/test_cli_integration_data.py
@@ -140,7 +140,18 @@ def test_real_cli_data_round_trip_and_batch_workflow(
     assert_ok(timelog_result)
     timelog_id = extract_created_id(timelog_result.stdout)
 
-    note_result = run_lifeos(integration_context, "note", "add", "Bundle restore checklist")
+    note_result = run_lifeos(
+        integration_context,
+        "note",
+        "add",
+        "Bundle restore checklist",
+        "--person-id",
+        person_id,
+        "--task-id",
+        task_id,
+        "--timelog-id",
+        timelog_id,
+    )
     assert_ok(note_result)
     note_id = extract_created_id(note_result.stdout)
 
@@ -231,6 +242,7 @@ def test_real_cli_data_round_trip_and_batch_workflow(
     assert_ok(restored_timelog_result)
     assert "title: Implementation session" in restored_timelog_result.stdout
     assert "notes: Initial draft" in restored_timelog_result.stdout
+    assert "linked_notes_count: 1" in restored_timelog_result.stdout
     assert "people: Alice" in restored_timelog_result.stdout
     assert "tags: tracked" in restored_timelog_result.stdout
 
@@ -251,6 +263,9 @@ def test_real_cli_data_round_trip_and_batch_workflow(
     restored_note_result = run_lifeos(integration_context, "note", "show", note_id)
     assert_ok(restored_note_result)
     assert "Bundle restore checklist" in restored_note_result.stdout
+    assert "people: Alice" in restored_note_result.stdout
+    assert f"task: {task_id} | Implement data operations" in restored_note_result.stdout
+    assert f"timelogs: {timelog_id} | Implementation session" in restored_note_result.stdout
 
     restored_task_result = run_lifeos(integration_context, "task", "show", task_id)
     assert_ok(restored_task_result)

--- a/tests/test_cli_integration_notes.py
+++ b/tests/test_cli_integration_notes.py
@@ -102,3 +102,101 @@ def test_real_cli_note_workflow(integration_context: IntegrationContext) -> None
         "00000000-0000-0000-0000-000000000000",
     )
     assert_missing(missing_show_result, "00000000-0000-0000-0000-000000000000")
+
+
+def test_real_cli_note_associations_and_timelog_counts(
+    integration_context: IntegrationContext,
+) -> None:
+    init_context(integration_context)
+
+    person_result = run_lifeos(integration_context, "people", "add", "Alice")
+    assert_ok(person_result)
+    person_id = extract_created_id(person_result.stdout)
+
+    vision_result = run_lifeos(integration_context, "vision", "add", "Link notes to work")
+    assert_ok(vision_result)
+    vision_id = extract_created_id(vision_result.stdout)
+
+    task_result = run_lifeos(
+        integration_context,
+        "task",
+        "add",
+        "Investigate note associations",
+        "--vision-id",
+        vision_id,
+    )
+    assert_ok(task_result)
+    task_id = extract_created_id(task_result.stdout)
+
+    timelog_result = run_lifeos(
+        integration_context,
+        "timelog",
+        "add",
+        "Implementation session",
+        "--start-time",
+        "2026-04-10T10:00:00-04:00",
+        "--end-time",
+        "2026-04-10T11:00:00-04:00",
+        "--task-id",
+        task_id,
+    )
+    assert_ok(timelog_result)
+    timelog_id = extract_created_id(timelog_result.stdout)
+
+    note_result = run_lifeos(
+        integration_context,
+        "note",
+        "add",
+        "Association note",
+        "--person-id",
+        person_id,
+        "--task-id",
+        task_id,
+        "--timelog-id",
+        timelog_id,
+    )
+    assert_ok(note_result)
+    note_id = extract_created_id(note_result.stdout)
+
+    note_show_result = run_lifeos(integration_context, "note", "show", note_id)
+    assert_ok(note_show_result)
+    assert "people: Alice" in note_show_result.stdout
+    assert f"task: {task_id} | Investigate note associations" in note_show_result.stdout
+    assert f"timelogs: {timelog_id} | Implementation session" in note_show_result.stdout
+
+    note_list_result = run_lifeos(integration_context, "note", "list", "--person-id", person_id)
+    assert_ok(note_list_result)
+    assert note_id in note_list_result.stdout
+    assert f"\t{task_id}\t1\t1\tAssociation note" in note_list_result.stdout
+
+    note_search_result = run_lifeos(
+        integration_context,
+        "note",
+        "search",
+        "Association",
+        "--task-id",
+        task_id,
+    )
+    assert_ok(note_search_result)
+    assert note_id in note_search_result.stdout
+
+    timelog_show_result = run_lifeos(integration_context, "timelog", "show", timelog_id)
+    assert_ok(timelog_show_result)
+    assert "linked_notes_count: 1" in timelog_show_result.stdout
+
+    clear_timelog_result = run_lifeos(
+        integration_context,
+        "note",
+        "update",
+        note_id,
+        "--clear-timelogs",
+    )
+    assert_ok(clear_timelog_result)
+
+    updated_note_result = run_lifeos(integration_context, "note", "show", note_id)
+    assert_ok(updated_note_result)
+    assert "timelogs: -" in updated_note_result.stdout
+
+    updated_timelog_result = run_lifeos(integration_context, "timelog", "show", timelog_id)
+    assert_ok(updated_timelog_result)
+    assert "linked_notes_count: 0" in updated_timelog_result.stdout

--- a/tests/test_cli_notes.py
+++ b/tests/test_cli_notes.py
@@ -210,7 +210,7 @@ def test_main_note_search_prints_matching_notes(
 
     assert exit_code == 0
     assert (
-        "44444444-4444-4444-4444-444444444444\tactive\t2026-04-09T04:05:06+00:00\t"
+        "44444444-4444-4444-4444-444444444444\tactive\t2026-04-09T04:05:06+00:00\t-\t0\t0\t"
         "meeting notes for april planning" in captured.out
     )
 
@@ -338,8 +338,8 @@ def test_main_note_list_prints_formatted_notes(
 
     assert exit_code == 0
     assert (
-        "22222222-2222-2222-2222-222222222222\tactive\t2026-04-09T01:02:03+00:00\tfirst note"
-        in captured.out
+        "22222222-2222-2222-2222-222222222222\tactive\t2026-04-09T01:02:03+00:00\t-\t0\t0\t"
+        "first note" in captured.out
     )
 
 

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -455,6 +455,65 @@ def test_cli_parser_supports_people_add_command() -> None:
     assert args.nickname == ["ally"]
 
 
+def test_cli_parser_supports_note_add_association_flags() -> None:
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "note",
+            "add",
+            "Association note",
+            "--person-id",
+            "11111111-1111-1111-1111-111111111111",
+            "--task-id",
+            "22222222-2222-2222-2222-222222222222",
+            "--timelog-id",
+            "33333333-3333-3333-3333-333333333333",
+        ]
+    )
+
+    assert args.resource == "note"
+    assert args.note_command == "add"
+    assert args.person_ids == [UUID("11111111-1111-1111-1111-111111111111")]
+    assert args.task_id == UUID("22222222-2222-2222-2222-222222222222")
+    assert args.timelog_ids == [UUID("33333333-3333-3333-3333-333333333333")]
+
+
+def test_cli_parser_supports_note_update_relation_only_command() -> None:
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "note",
+            "update",
+            "11111111-1111-1111-1111-111111111111",
+            "--clear-timelogs",
+        ]
+    )
+
+    assert args.resource == "note"
+    assert args.note_command == "update"
+    assert args.content is None
+    assert args.clear_timelogs is True
+
+
+def test_cli_parser_supports_note_list_relation_filters() -> None:
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "note",
+            "list",
+            "--person-id",
+            "11111111-1111-1111-1111-111111111111",
+            "--timelog-id",
+            "22222222-2222-2222-2222-222222222222",
+        ]
+    )
+
+    assert args.resource == "note"
+    assert args.note_command == "list"
+    assert args.person_id == UUID("11111111-1111-1111-1111-111111111111")
+    assert args.timelog_id == UUID("22222222-2222-2222-2222-222222222222")
+
+
 def test_cli_parser_supports_schedule_show_command() -> None:
     parser = build_parser()
     args = parser.parse_args(["schedule", "show", "--date", "2026-04-10"])

--- a/tests/test_db_maintenance.py
+++ b/tests/test_db_maintenance.py
@@ -30,7 +30,7 @@ def test_build_alembic_config_uses_packaged_migration_resources() -> None:
         ).is_file()
         assert script_location.joinpath(
             "versions",
-            "20260411_0900_add_timelog_stats_groupby_area_tables.py",
+            "20260411_1500_add_generic_associations.py",
         ).is_file()
 
 

--- a/tests/test_note_services.py
+++ b/tests/test_note_services.py
@@ -22,7 +22,11 @@ def test_create_note_flushes_without_committing(monkeypatch: pytest.MonkeyPatch)
     def fake_add(_: object) -> None:
         pass
 
+    async def fake_attach_note_links(_: object, note: object) -> object:
+        return note
+
     session.add = fake_add
+    monkeypatch.setattr(notes, "_attach_note_links", fake_attach_note_links)
 
     note = asyncio.run(notes.create_note(cast(Any, session), content="hello"))
 


### PR DESCRIPTION
## 变更概览
- 引入通用弱关联基础设施，避免为 `note-to-timelog` 单独发明专表
- 以 `note` 资源作为首个接入点，支持 `note -> person`、`note -> task`、`note -> timelog`
- 在 `timelog` 侧补充派生的 `linked_notes_count` 读模型输出

## 数据模型与迁移
- 新增 `associations` 表与对应 ORM 模型
- 使用方向性字段承载弱关联：`source_model`、`source_id`、`target_model`、`target_id`、`link_type`
- 增加模型值域约束与唯一约束，限制首批支持的模型和 link type

## Note 资源
- `note add` 支持关联 people、task、timelog
- `note update` 支持仅更新关联，也支持显式 `--clear-*` 清理链接
- `note list` / `note search` 支持按关联过滤
- `note show` / `note list` 输出补充关联信息与计数
- CLI help、示例与 parser tests 已同步更新

## Timelog 读模型
- `timelog show` / `timelog list` 输出 `linked_notes_count`
- 保留 `timelog.notes` 文本字段语义，不与 linked notes 混用
- 已收敛关联过滤边界，避免软删目标仍命中过滤结果

## 数据生命周期
- `data export` / `data import bundle` / `data batch-update` 已接入 note 关联字段
- `purge` 路径会同步清理 `associations` 中以 note / task / timelog / person 为源或目标的弱关联记录
- 清理了一个未使用的辅助函数，避免无效实现继续留在关联层

## 测试与验证
- 新增和更新了 parser、CLI、service、integration 相关测试
- 已执行：`bash ./scripts/doctor.sh`
- 结果：`259 passed, 10 skipped`

## 相关提交
- `f83feb3` `feat: add generic note associations`
- `f53ff24` `refactor: tighten note association filtering`

Closes #25
Related #21
