### PR TITLE
enhance: expose vision names in task and schedule summaries

### DIFF
--- a/src/lifeos_cli/cli_support/resources/schedule/handlers.py
+++ b/src/lifeos_cli/cli_support/resources/schedule/handlers.py
@@ -20,7 +20,15 @@ SCHEDULE_TASK_COLUMNS = (
     "content",
 )
 SCHEDULE_HABIT_ACTION_COLUMNS = ("habit_action_id", "status", "habit_id", "habit_title")
-SCHEDULE_EVENT_COLUMNS = ("event_id", "status", "start_time", "end_time", "task_id", "vision", "title")
+SCHEDULE_EVENT_COLUMNS = (
+    "event_id",
+    "status",
+    "start_time",
+    "end_time",
+    "task_id",
+    "vision",
+    "title",
+)
 
 
 def _format_schedule_task(item: schedule_services.ScheduleTaskItem) -> str:
@@ -35,9 +43,11 @@ def _format_schedule_habit_action(item: schedule_services.ScheduleHabitActionIte
 
 
 def _format_schedule_event(item: schedule_services.ScheduleEventItem) -> str:
+    task_vision_name = item.task_vision_name or "-"
     return (
         f"  {item.id}\t{item.status}\t{format_timestamp(item.start_time)}\t"
-        f"{format_timestamp(item.end_time)}\t{item.task_id or '-'}\t{item.task_vision_name or '-'}\t{item.title}"
+        f"{format_timestamp(item.end_time)}\t{item.task_id or '-'}\t"
+        f"{task_vision_name}\t{item.title}"
     )
 
 

--- a/src/lifeos_cli/cli_support/resources/schedule/handlers.py
+++ b/src/lifeos_cli/cli_support/resources/schedule/handlers.py
@@ -13,18 +13,19 @@ from lifeos_cli.db.services import schedules as schedule_services
 SCHEDULE_TASK_COLUMNS = (
     "task_id",
     "status",
+    "vision",
     "planning_cycle_type",
     "planning_cycle_start_date",
     "planning_cycle_end_date",
     "content",
 )
 SCHEDULE_HABIT_ACTION_COLUMNS = ("habit_action_id", "status", "habit_id", "habit_title")
-SCHEDULE_EVENT_COLUMNS = ("event_id", "status", "start_time", "end_time", "task_id", "title")
+SCHEDULE_EVENT_COLUMNS = ("event_id", "status", "start_time", "end_time", "task_id", "vision", "title")
 
 
 def _format_schedule_task(item: schedule_services.ScheduleTaskItem) -> str:
     return (
-        f"  {item.id}\t{item.status}\t{item.planning_cycle_type}\t"
+        f"  {item.id}\t{item.status}\t{item.vision_name}\t{item.planning_cycle_type}\t"
         f"{item.planning_cycle_start_date}\t{item.planning_cycle_end_date}\t{item.content}"
     )
 
@@ -36,7 +37,7 @@ def _format_schedule_habit_action(item: schedule_services.ScheduleHabitActionIte
 def _format_schedule_event(item: schedule_services.ScheduleEventItem) -> str:
     return (
         f"  {item.id}\t{item.status}\t{format_timestamp(item.start_time)}\t"
-        f"{format_timestamp(item.end_time)}\t{item.task_id or '-'}\t{item.title}"
+        f"{format_timestamp(item.end_time)}\t{item.task_id or '-'}\t{item.task_vision_name or '-'}\t{item.title}"
     )
 
 

--- a/src/lifeos_cli/cli_support/resources/task/handlers.py
+++ b/src/lifeos_cli/cli_support/resources/task/handlers.py
@@ -33,12 +33,12 @@ def _parse_task_order(value: str) -> tuple[UUID, int]:
         raise ValueError("Task order must use <task-id>:<display-order>") from exc
 
 
-TASK_SUMMARY_COLUMNS = ("task_id", "status", "vision_id", "parent_task_id", "content")
+TASK_SUMMARY_COLUMNS = ("task_id", "status", "vision", "parent_task_id", "content")
 
 
 def _format_task_summary(task: task_services.TaskView) -> str:
     status = "deleted" if task.deleted_at is not None else task.status
-    return f"{task.id}\t{status}\t{task.vision_id}\t{task.parent_task_id or '-'}\t{task.content}"
+    return f"{task.id}\t{status}\t{task.vision_name}\t{task.parent_task_id or '-'}\t{task.content}"
 
 
 def _format_task_detail(task: task_services.TaskView) -> str:
@@ -47,6 +47,7 @@ def _format_task_detail(task: task_services.TaskView) -> str:
         (
             f"id: {task.id}",
             f"vision_id: {task.vision_id}",
+            f"vision_name: {task.vision_name}",
             f"parent_task_id: {task.parent_task_id or '-'}",
             f"content: {task.content}",
             f"description: {task.description or '-'}",

--- a/src/lifeos_cli/db/services/events.py
+++ b/src/lifeos_cli/db/services/events.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import selectinload
 
 from lifeos_cli.application.time_preferences import get_utc_window_for_local_date
 from lifeos_cli.db.models.event import Event
+from lifeos_cli.db.models.task import Task
 from lifeos_cli.db.models.event_occurrence_exception import EventOccurrenceException
 from lifeos_cli.db.models.person_association import person_associations
 from lifeos_cli.db.models.tag_association import tag_associations
@@ -56,6 +57,7 @@ class EventOccurrence:
     start_time: datetime
     end_time: datetime | None
     task_id: UUID | None
+    task_vision_name: str | None
     deleted_at: datetime | None
     instance_start: datetime
 
@@ -436,6 +438,7 @@ async def list_event_occurrences(
     )
     if not include_deleted:
         master_stmt = master_stmt.where(Event.deleted_at.is_(None))
+    master_stmt = master_stmt.options(selectinload(Event.task).selectinload(Task.vision))
     master_stmt = _apply_event_query_filters(
         master_stmt,
         title_contains=title_contains,
@@ -457,6 +460,7 @@ async def list_event_occurrences(
     )
     if not include_deleted:
         override_stmt = override_stmt.where(Event.deleted_at.is_(None))
+    override_stmt = override_stmt.options(selectinload(Event.task).selectinload(Task.vision))
     override_stmt = _apply_event_query_filters(
         override_stmt,
         title_contains=title_contains,
@@ -488,6 +492,7 @@ async def list_event_occurrences(
                         start_time=master.start_time,
                         end_time=master.end_time,
                         task_id=master.task_id,
+                        task_vision_name=master.task.vision.name if master.task and master.task.vision else None,
                         deleted_at=master.deleted_at,
                         instance_start=master.start_time,
                     )
@@ -512,6 +517,7 @@ async def list_event_occurrences(
                     start_time=occurrence_start,
                     end_time=_event_occurrence_end(master, occurrence_start=occurrence_start),
                     task_id=master.task_id,
+                    task_vision_name=master.task.vision.name if master.task and master.task.vision else None,
                     deleted_at=master.deleted_at,
                     instance_start=occurrence_start,
                 )
@@ -527,6 +533,7 @@ async def list_event_occurrences(
                 start_time=override.start_time,
                 end_time=override.end_time,
                 task_id=override.task_id,
+                task_vision_name=override.task.vision.name if override.task and override.task.vision else None,
                 deleted_at=override.deleted_at,
                 instance_start=override.recurrence_instance_start or override.start_time,
             )

--- a/src/lifeos_cli/db/services/events.py
+++ b/src/lifeos_cli/db/services/events.py
@@ -13,10 +13,10 @@ from sqlalchemy.orm import selectinload
 
 from lifeos_cli.application.time_preferences import get_utc_window_for_local_date
 from lifeos_cli.db.models.event import Event
-from lifeos_cli.db.models.task import Task
 from lifeos_cli.db.models.event_occurrence_exception import EventOccurrenceException
 from lifeos_cli.db.models.person_association import person_associations
 from lifeos_cli.db.models.tag_association import tag_associations
+from lifeos_cli.db.models.task import Task
 from lifeos_cli.db.services.batching import BatchDeleteResult, batch_delete_records
 from lifeos_cli.db.services.entity_people import load_people_for_entities, sync_entity_people
 from lifeos_cli.db.services.entity_tags import load_tags_for_entities, sync_entity_tags
@@ -140,6 +140,12 @@ def _event_occurrence_end(
 ) -> datetime | None:
     duration = _event_duration(event)
     return occurrence_start + duration if duration is not None else None
+
+
+def _event_task_vision_name(event: Event) -> str | None:
+    task = getattr(event, "task", None)
+    vision = getattr(task, "vision", None)
+    return vision.name if vision else None
 
 
 async def _record_skip_exception(
@@ -492,7 +498,7 @@ async def list_event_occurrences(
                         start_time=master.start_time,
                         end_time=master.end_time,
                         task_id=master.task_id,
-                        task_vision_name=master.task.vision.name if master.task and master.task.vision else None,
+                        task_vision_name=_event_task_vision_name(master),
                         deleted_at=master.deleted_at,
                         instance_start=master.start_time,
                     )
@@ -517,7 +523,7 @@ async def list_event_occurrences(
                     start_time=occurrence_start,
                     end_time=_event_occurrence_end(master, occurrence_start=occurrence_start),
                     task_id=master.task_id,
-                    task_vision_name=master.task.vision.name if master.task and master.task.vision else None,
+                    task_vision_name=_event_task_vision_name(master),
                     deleted_at=master.deleted_at,
                     instance_start=occurrence_start,
                 )
@@ -533,7 +539,7 @@ async def list_event_occurrences(
                 start_time=override.start_time,
                 end_time=override.end_time,
                 task_id=override.task_id,
-                task_vision_name=override.task.vision.name if override.task and override.task.vision else None,
+                task_vision_name=_event_task_vision_name(override),
                 deleted_at=override.deleted_at,
                 instance_start=override.recurrence_instance_start or override.start_time,
             )

--- a/src/lifeos_cli/db/services/read_models.py
+++ b/src/lifeos_cli/db/services/read_models.py
@@ -40,6 +40,7 @@ class TaskSummaryView:
 
     id: UUID
     vision_id: UUID
+    vision_name: str
     parent_task_id: UUID | None
     content: str
     status: str
@@ -108,6 +109,7 @@ class TaskView:
 
     id: UUID
     vision_id: UUID
+    vision_name: str
     parent_task_id: UUID | None
     content: str
     description: str | None
@@ -242,6 +244,7 @@ def build_task_summary(task: Task) -> TaskSummaryView:
     return TaskSummaryView(
         id=task.id,
         vision_id=task.vision_id,
+        vision_name=task.vision.name if getattr(task, "vision", None) else "-",
         parent_task_id=task.parent_task_id,
         content=task.content,
         status=task.status,
@@ -300,6 +303,7 @@ def build_task_view(task: Task, *, people: Sequence[Person] = ()) -> TaskView:
     return TaskView(
         id=task.id,
         vision_id=task.vision_id,
+        vision_name=task.vision.name if getattr(task, "vision", None) else "-",
         parent_task_id=task.parent_task_id,
         content=task.content,
         description=task.description,

--- a/src/lifeos_cli/db/services/schedule_queries.py
+++ b/src/lifeos_cli/db/services/schedule_queries.py
@@ -7,6 +7,7 @@ from datetime import date, datetime, timedelta
 from uuid import UUID
 
 from sqlalchemy import select, text
+from sqlalchemy.orm import selectinload
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from lifeos_cli.application.time_preferences import get_utc_window_for_local_date
@@ -23,6 +24,7 @@ class ScheduleTaskItem:
     id: UUID
     content: str
     status: str
+    vision_name: str
     planning_cycle_type: str
     planning_cycle_days: int
     planning_cycle_start_date: date
@@ -52,6 +54,7 @@ class ScheduleEventItem:
     start_time: datetime
     end_time: datetime | None
     task_id: UUID | None
+    task_vision_name: str | None
 
 
 @dataclass(frozen=True)
@@ -101,6 +104,7 @@ async def _load_schedule_tasks(
             + (Task.planning_cycle_days - 1) * text("INTERVAL '1 day'")
             >= start_date,
         )
+        .options(selectinload(Task.vision))
         .order_by(Task.planning_cycle_start_date.asc(), Task.display_order.asc(), Task.id.asc())
     )
     return list((await session.execute(stmt)).scalars())
@@ -148,6 +152,7 @@ def _map_task_item(task: Task) -> ScheduleTaskItem:
         planning_cycle_days=task.planning_cycle_days,
         planning_cycle_start_date=task.planning_cycle_start_date,
         planning_cycle_end_date=_task_cycle_end_date(task),
+        vision_name=task.vision.name if task.vision else "-",
     )
 
 
@@ -171,6 +176,7 @@ def _map_event_item(event: EventOccurrence) -> ScheduleEventItem:
         start_time=event.start_time,
         end_time=event.end_time,
         task_id=event.task_id,
+        task_vision_name=event.task_vision_name,
     )
 
 

--- a/src/lifeos_cli/db/services/schedule_queries.py
+++ b/src/lifeos_cli/db/services/schedule_queries.py
@@ -7,8 +7,8 @@ from datetime import date, datetime, timedelta
 from uuid import UUID
 
 from sqlalchemy import select, text
-from sqlalchemy.orm import selectinload
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from lifeos_cli.application.time_preferences import get_utc_window_for_local_date
 from lifeos_cli.db.models.task import Task
@@ -144,6 +144,7 @@ def _map_task_item(task: Task) -> ScheduleTaskItem:
     assert task.planning_cycle_type is not None
     assert task.planning_cycle_days is not None
     assert task.planning_cycle_start_date is not None
+    vision = getattr(task, "vision", None)
     return ScheduleTaskItem(
         id=task.id,
         content=task.content,
@@ -152,7 +153,7 @@ def _map_task_item(task: Task) -> ScheduleTaskItem:
         planning_cycle_days=task.planning_cycle_days,
         planning_cycle_start_date=task.planning_cycle_start_date,
         planning_cycle_end_date=_task_cycle_end_date(task),
-        vision_name=task.vision.name if task.vision else "-",
+        vision_name=vision.name if vision else "-",
     )
 
 
@@ -176,7 +177,7 @@ def _map_event_item(event: EventOccurrence) -> ScheduleEventItem:
         start_time=event.start_time,
         end_time=event.end_time,
         task_id=event.task_id,
-        task_vision_name=event.task_vision_name,
+        task_vision_name=getattr(event, "task_vision_name", None),
     )
 
 

--- a/src/lifeos_cli/db/services/task_queries.py
+++ b/src/lifeos_cli/db/services/task_queries.py
@@ -7,6 +7,7 @@ from datetime import date, datetime
 from uuid import UUID
 
 from sqlalchemy import select
+from sqlalchemy.orm import selectinload
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from lifeos_cli.db.models.person import Person
@@ -163,7 +164,7 @@ async def _get_task_model(
     task_id: UUID,
     include_deleted: bool,
 ) -> Task | None:
-    stmt = select(Task).where(Task.id == task_id).limit(1)
+    stmt = select(Task).options(selectinload(Task.vision)).where(Task.id == task_id).limit(1)
     if not include_deleted:
         stmt = stmt.where(Task.deleted_at.is_(None))
     return (await session.execute(stmt)).scalar_one_or_none()
@@ -212,7 +213,7 @@ async def list_tasks(
     offset: int = 0,
 ) -> list[TaskView]:
     """List tasks with basic filters."""
-    stmt = select(Task)
+    stmt = select(Task).options(selectinload(Task.vision))
     if not include_deleted:
         stmt = stmt.where(Task.deleted_at.is_(None))
     if vision_id is not None:
@@ -269,7 +270,7 @@ async def get_vision_task_hierarchy(
     """Load active tasks for a vision as a hierarchy."""
     await ensure_vision_exists(session, vision_id)
     stmt = (
-        select(Task)
+        select(Task).options(selectinload(Task.vision))
         .where(Task.vision_id == vision_id, Task.deleted_at.is_(None))
         .order_by(Task.display_order.asc(), Task.created_at.asc(), Task.id.asc())
     )

--- a/src/lifeos_cli/db/services/task_queries.py
+++ b/src/lifeos_cli/db/services/task_queries.py
@@ -7,8 +7,8 @@ from datetime import date, datetime
 from uuid import UUID
 
 from sqlalchemy import select
-from sqlalchemy.orm import selectinload
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from lifeos_cli.db.models.person import Person
 from lifeos_cli.db.models.person_association import person_associations
@@ -270,7 +270,8 @@ async def get_vision_task_hierarchy(
     """Load active tasks for a vision as a hierarchy."""
     await ensure_vision_exists(session, vision_id)
     stmt = (
-        select(Task).options(selectinload(Task.vision))
+        select(Task)
+        .options(selectinload(Task.vision))
         .where(Task.vision_id == vision_id, Task.deleted_at.is_(None))
         .order_by(Task.display_order.asc(), Task.created_at.asc(), Task.id.asc())
     )

--- a/tests/test_cli_domains.py
+++ b/tests/test_cli_domains.py
@@ -933,6 +933,7 @@ def test_main_task_list_prints_header_and_rows(
                 id=UUID("55555555-5555-5555-5555-555555555555"),
                 status="todo",
                 vision_id=UUID("66666666-6666-6666-6666-666666666666"),
+                vision_name="Launch lifeos-cli",
                 parent_task_id=None,
                 content="Draft release checklist",
                 deleted_at=None,
@@ -947,11 +948,11 @@ def test_main_task_list_prints_header_and_rows(
 
     assert exit_code == 0
     assert captured.out.splitlines() == [
-        "task_id\tstatus\tvision_id\tparent_task_id\tcontent",
+        "task_id\tstatus\tvision\tparent_task_id\tcontent",
         (
             "55555555-5555-5555-5555-555555555555\t"
             "todo\t"
-            "66666666-6666-6666-6666-666666666666\t"
+            "Launch lifeos-cli\t"
             "-\t"
             "Draft release checklist"
         ),

--- a/tests/test_cli_integration_schedule.py
+++ b/tests/test_cli_integration_schedule.py
@@ -94,16 +94,20 @@ def test_real_cli_schedule_workflow(integration_context: IntegrationContext) -> 
     assert "date: 2026-04-10" in schedule_show_result.stdout
     assert "tasks:" in schedule_show_result.stdout
     assert (
-        "  task_id\tstatus\tplanning_cycle_type\tplanning_cycle_start_date\t"
+        "  task_id\tstatus\tvision\tplanning_cycle_type\tplanning_cycle_start_date\t"
         "planning_cycle_end_date\tcontent" in schedule_show_result.stdout
     )
     assert "habit_actions:" in schedule_show_result.stdout
     assert "  habit_action_id\tstatus\thabit_id\thabit_title" in schedule_show_result.stdout
     assert "appointments:" in schedule_show_result.stdout
     assert "timeblocks:" in schedule_show_result.stdout
-    assert "  event_id\tstatus\tstart_time\tend_time\ttask_id\ttitle" in schedule_show_result.stdout
+    assert (
+        "  event_id\tstatus\tstart_time\tend_time\ttask_id\tvision\ttitle"
+        in schedule_show_result.stdout
+    )
     assert "deadlines:" in schedule_show_result.stdout
     assert task_id in schedule_show_result.stdout
+    assert "Launch lifeos-cli" in schedule_show_result.stdout
     assert "Daily Review" in schedule_show_result.stdout
     assert event_id in schedule_show_result.stdout
     assert "Release planning block" in schedule_show_result.stdout
@@ -122,10 +126,14 @@ def test_real_cli_schedule_workflow(integration_context: IntegrationContext) -> 
     assert "date: 2026-04-10" in schedule_list_result.stdout
     assert "date: 2026-04-11" in schedule_list_result.stdout
     assert (
-        "  task_id\tstatus\tplanning_cycle_type\tplanning_cycle_start_date\t"
+        "  task_id\tstatus\tvision\tplanning_cycle_type\tplanning_cycle_start_date\t"
         "planning_cycle_end_date\tcontent" in schedule_list_result.stdout
     )
     assert "  habit_action_id\tstatus\thabit_id\thabit_title" in schedule_list_result.stdout
-    assert "  event_id\tstatus\tstart_time\tend_time\ttask_id\ttitle" in schedule_list_result.stdout
+    assert (
+        "  event_id\tstatus\tstart_time\tend_time\ttask_id\tvision\ttitle"
+        in schedule_list_result.stdout
+    )
     assert task_id in schedule_list_result.stdout
+    assert "Launch lifeos-cli" in schedule_list_result.stdout
     assert schedule_list_result.stdout.count("Daily review") == 2

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -183,8 +183,8 @@ def test_cli_schedule_show_help_explains_task_inclusion_rule(capsys) -> None:
     )
     assert "Task rows come from planning-cycle overlap" in captured.out
     assert (
-        "Task section columns: task_id, status, planning_cycle_type, planning_cycle_start_date, "
-        "planning_cycle_end_date, content."
+        "Task section columns: task_id, status, vision, planning_cycle_type, "
+        "planning_cycle_start_date, planning_cycle_end_date, content."
     ) in captured.out
     assert (
         "Habit action section columns: habit_action_id, status, habit_id, habit_title."
@@ -192,7 +192,7 @@ def test_cli_schedule_show_help_explains_task_inclusion_rule(capsys) -> None:
     )
     assert (
         "Event section columns for appointments, timeblocks, and deadlines: "
-        "event_id, status, start_time, end_time, task_id, title."
+        "event_id, status, start_time, end_time, task_id, vision, title."
     ) in captured.out
 
 
@@ -250,7 +250,7 @@ def test_cli_habit_add_help_describes_extended_cadence_cycles(capsys) -> None:
     [
         (
             ["task", "list", "--help"],
-            "tab-separated columns: task_id, status, vision_id, parent_task_id, content.",
+            "tab-separated columns: task_id, status, vision, parent_task_id, content.",
         ),
         (
             ["event", "list", "--help"],
@@ -316,7 +316,7 @@ def test_cli_task_list_help_supports_zh_hans_locale_and_documents_header_row(
     assert "列出 `task` 以及可选的 `vision`、父级或状态过滤器。" in captured.out
     assert (
         "当存在结果时，`list` 命令会先输出一行表头，随后按制表符分隔输出列："
-        "task_id、status、vision_id、parent_task_id、content。"
+        "task_id、status、vision、parent_task_id、content。"
     ) in captured.out
 
 
@@ -383,7 +383,7 @@ def test_cli_schedule_show_help_supports_zh_hans_locale(
         (
             ["task", "list", "--help"],
             "当存在结果时，`list` 命令会先输出一行表头，随后按制表符分隔输出列："
-            "task_id、status、vision_id、parent_task_id、content。",
+            "task_id、status、vision、parent_task_id、content。",
         ),
         (
             ["habit", "list", "--help"],
@@ -403,8 +403,8 @@ def test_cli_schedule_show_help_supports_zh_hans_locale(
         ),
         (
             ["schedule", "show", "--help"],
-            "`task` 分段的列为：task_id、status、planning_cycle_type、planning_cycle_start_date、"
-            "planning_cycle_end_date、content。",
+            "`task` 分段的列为：task_id、status、vision、planning_cycle_type、"
+            "planning_cycle_start_date、planning_cycle_end_date、content。",
         ),
     ],
 )
@@ -438,8 +438,8 @@ def test_cli_schedule_list_help_documents_section_headers(capsys) -> None:
         in captured.out
     )
     assert (
-        "Task section columns: task_id, status, planning_cycle_type, planning_cycle_start_date, "
-        "planning_cycle_end_date, content."
+        "Task section columns: task_id, status, vision, planning_cycle_type, "
+        "planning_cycle_start_date, planning_cycle_end_date, content."
     ) in captured.out
     assert (
         "Habit action section columns: habit_action_id, status, habit_id, habit_title."
@@ -447,7 +447,7 @@ def test_cli_schedule_list_help_documents_section_headers(capsys) -> None:
     )
     assert (
         "Event section columns for appointments, timeblocks, and deadlines: "
-        "event_id, status, start_time, end_time, task_id, title."
+        "event_id, status, start_time, end_time, task_id, vision, title."
     ) in captured.out
 
 

--- a/tests/test_cli_schedule.py
+++ b/tests/test_cli_schedule.py
@@ -24,6 +24,7 @@ def test_main_schedule_show_prints_grouped_sections(
                     id=UUID("11111111-1111-1111-1111-111111111111"),
                     content="Draft release checklist",
                     status="todo",
+                    vision_name="Launch lifeos-cli",
                     planning_cycle_type="week",
                     planning_cycle_days=7,
                     planning_cycle_start_date=target_date,
@@ -49,6 +50,7 @@ def test_main_schedule_show_prints_grouped_sections(
                     start_time=utc_datetime(2026, 4, 10, 13, 0),
                     end_time=utc_datetime(2026, 4, 10, 14, 0),
                     task_id=None,
+                    task_vision_name=None,
                 ),
             ),
             timeblocks=(),
@@ -65,13 +67,13 @@ def test_main_schedule_show_prints_grouped_sections(
     assert "date: 2026-04-10" in captured.out
     assert "tasks:" in captured.out
     assert (
-        "  task_id\tstatus\tplanning_cycle_type\tplanning_cycle_start_date\t"
+        "  task_id\tstatus\tvision\tplanning_cycle_type\tplanning_cycle_start_date\t"
         "planning_cycle_end_date\tcontent" in captured.out
     )
     assert "habit_actions:" in captured.out
     assert "  habit_action_id\tstatus\thabit_id\thabit_title" in captured.out
     assert "appointments:" in captured.out
-    assert "  event_id\tstatus\tstart_time\tend_time\ttask_id\ttitle" in captured.out
+    assert "  event_id\tstatus\tstart_time\tend_time\ttask_id\tvision\ttitle" in captured.out
     assert "timeblocks:" in captured.out
     assert "deadlines:" in captured.out
     assert "Draft release checklist" in captured.out

--- a/tests/test_schedule_queries.py
+++ b/tests/test_schedule_queries.py
@@ -43,6 +43,7 @@ def test_list_schedule_in_range_groups_tasks_actions_and_events(monkeypatch) -> 
                 id=UUID("11111111-1111-1111-1111-111111111111"),
                 content="Draft release checklist",
                 status="todo",
+                vision=make_record(name="Launch lifeos-cli"),
                 planning_cycle_type="week",
                 planning_cycle_days=2,
                 planning_cycle_start_date=date(2026, 4, 10),
@@ -82,6 +83,7 @@ def test_list_schedule_in_range_groups_tasks_actions_and_events(monkeypatch) -> 
                 start_time=utc_datetime(2026, 4, 10, 23, 30),
                 end_time=utc_datetime(2026, 4, 11, 1, 0),
                 task_id=None,
+                task_vision_name=None,
             )
         ]
 
@@ -110,6 +112,7 @@ def test_list_schedule_in_range_groups_tasks_actions_and_events(monkeypatch) -> 
     assert len(days) == 2
     assert days[0].local_date == date(2026, 4, 10)
     assert [item.content for item in days[0].tasks] == ["Draft release checklist"]
+    assert [item.vision_name for item in days[0].tasks] == ["Launch lifeos-cli"]
     assert [item.habit_title for item in days[0].habit_actions] == ["Daily Review"]
     assert [item.title for item in days[0].appointments] == ["Late call"]
     assert days[0].timeblocks == ()
@@ -152,6 +155,7 @@ def test_list_schedule_in_range_uses_expanded_recurring_event_occurrences(monkey
                 start_time=utc_datetime(2026, 4, 10, 13, 0),
                 end_time=utc_datetime(2026, 4, 10, 13, 30),
                 task_id=None,
+                task_vision_name=None,
             ),
             make_record(
                 id=UUID("33333333-3333-3333-3333-333333333333"),
@@ -161,6 +165,7 @@ def test_list_schedule_in_range_uses_expanded_recurring_event_occurrences(monkey
                 start_time=utc_datetime(2026, 4, 11, 13, 0),
                 end_time=utc_datetime(2026, 4, 11, 13, 30),
                 task_id=None,
+                task_vision_name=None,
             ),
         ]
 
@@ -220,6 +225,7 @@ def test_list_schedule_in_range_groups_events_by_type(monkeypatch) -> None:
                 start_time=utc_datetime(2026, 4, 10, 13, 0),
                 end_time=utc_datetime(2026, 4, 10, 14, 0),
                 task_id=None,
+                task_vision_name=None,
             ),
             make_record(
                 id=UUID("22222222-2222-2222-2222-222222222222"),
@@ -229,6 +235,7 @@ def test_list_schedule_in_range_groups_events_by_type(monkeypatch) -> None:
                 start_time=utc_datetime(2026, 4, 10, 15, 0),
                 end_time=utc_datetime(2026, 4, 10, 16, 0),
                 task_id=None,
+                task_vision_name="Launch lifeos-cli",
             ),
             make_record(
                 id=UUID("33333333-3333-3333-3333-333333333333"),
@@ -238,6 +245,7 @@ def test_list_schedule_in_range_groups_events_by_type(monkeypatch) -> None:
                 start_time=utc_datetime(2026, 4, 10, 17, 0),
                 end_time=None,
                 task_id=None,
+                task_vision_name=None,
             ),
         ]
 
@@ -263,6 +271,7 @@ def test_list_schedule_in_range_groups_events_by_type(monkeypatch) -> None:
 
     assert [item.title for item in days[0].appointments] == ["Doctor appointment"]
     assert [item.title for item in days[0].timeblocks] == ["Focus block"]
+    assert [item.task_vision_name for item in days[0].timeblocks] == ["Launch lifeos-cli"]
     assert [item.title for item in days[0].deadlines] == ["Tax deadline"]
 
 


### PR DESCRIPTION
## 概述
- 为 `task list` 摘要输出显示 `vision` 名称，而不是 `vision_id`
- 为 `schedule` 中的 task/event 分段补充 `vision` 列，便于直接识别任务归属
- 补齐相关 CLI、查询与集成测试断言，并为轻量测试替身补上稳健字段访问

## 验证
- `bash ./scripts/doctor.sh`
- 集成测试按脚本规则未执行：未设置 `LIFEOS_RUN_INTEGRATION=1`

Closes #73
