### PR TITLE
build: harden validation workflow for local integration runs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,20 +59,6 @@ jobs:
       - name: Run default regression baseline
         run: bash ./scripts/doctor.sh
 
-      - name: Export runtime requirements for vulnerability audit
-        run: >
-          uv export --format requirements.txt --no-dev --locked --no-emit-project
-          --output-file /tmp/runtime-requirements.txt >/dev/null
-
-      - name: Run runtime dependency vulnerability audit
-        run: uv run pip-audit --requirement /tmp/runtime-requirements.txt
-
-      - name: Clean previous build artifacts
-        run: rm -rf build dist
-
-      - name: Build package artifacts
-        run: uv build --no-sources
-
       - name: Verify published version matches tag
         env:
           RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -31,20 +31,6 @@ jobs:
       - name: Run default validation
         run: bash ./scripts/doctor.sh
 
-      - name: Export runtime requirements for vulnerability audit
-        run: >
-          uv export --format requirements.txt --no-dev --locked --no-emit-project
-          --output-file /tmp/runtime-requirements.txt >/dev/null
-
-      - name: Run runtime dependency vulnerability audit
-        run: uv run pip-audit --requirement /tmp/runtime-requirements.txt
-
-      - name: Clean previous build artifacts
-        run: rm -rf build dist
-
-      - name: Build package artifacts
-        run: uv build --no-sources
-
   runtime-matrix:
     name: Validate Runtime Matrix (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,9 @@ core.*
 *.db
 *.db-shm
 *.db-wal
+
+# Local environment files
+.env
+.env.local
+.env.*
+!.env.example

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,8 +32,11 @@ bash ./scripts/doctor.sh
 ```
 
 The default validation baseline includes dead-code scanning through `vulture`.
-It runs the default non-integration test suite directly and then calls
+It validates locked dependency resolution, runs lint plus the default non-integration test suite,
+exports runtime requirements for `pip-audit`, builds package artifacts, and then calls
 `bash ./scripts/integration_tests.sh` as the explicit PostgreSQL-backed integration entrypoint.
+When `LIFEOS_TEST_DATABASE_URL` is unset, the integration script reports an explicit skip and
+`doctor.sh` finishes with a warning that PostgreSQL CLI coverage did not run.
 
 If you change CI, packaging metadata, or compatibility declarations, also validate the relevant interpreter targets explicitly. Examples:
 
@@ -55,9 +58,6 @@ If you change dependency or release workflows, also run:
 
 ```bash
 bash ./scripts/dependency_health.sh
-uv export --format requirements.txt --no-dev --locked --no-emit-project --output-file /tmp/runtime-requirements.txt >/dev/null
-uv run pip-audit --requirement /tmp/runtime-requirements.txt
-rm -rf build dist && uv build --no-sources
 ```
 
 Dependency maintenance policy:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,10 @@ LIFEOS_TEST_DATABASE_URL=postgresql+psycopg://postgres:<password>@127.0.0.1:5432
 bash ./scripts/integration_tests.sh
 ```
 
+For local convenience, `scripts/doctor.sh` and `scripts/integration_tests.sh` also load a
+project-root `.env` file when present. Keep `.env` untracked and use it only for machine-local
+development settings such as `LIFEOS_TEST_DATABASE_URL`.
+
 If you change dependency or release workflows, also run:
 
 ```bash

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -1,6 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+LOCAL_ENV_FILE="${REPO_ROOT}/.env"
+
+if [ -f "${LOCAL_ENV_FILE}" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  . "${LOCAL_ENV_FILE}"
+  set +a
+fi
+
 echo "[doctor] sync dependencies"
 uv sync --all-extras --frozen
 

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -2,11 +2,7 @@
 set -euo pipefail
 
 echo "[doctor] sync dependencies"
-if [ "${CI:-}" = "true" ]; then
-  uv sync --all-extras --frozen
-else
-  uv sync --all-extras
-fi
+uv sync --all-extras --frozen
 
 echo "[doctor] run lint"
 uv run pre-commit run --all-files
@@ -14,5 +10,35 @@ uv run pre-commit run --all-files
 echo "[doctor] run tests"
 uv run pytest -m "not integration"
 
+echo "[doctor] export runtime requirements"
+uv export --format requirements.txt --no-dev --locked --no-emit-project \
+  --output-file /tmp/runtime-requirements.txt >/dev/null
+
+echo "[doctor] run runtime dependency vulnerability audit"
+uv run pip-audit --requirement /tmp/runtime-requirements.txt
+
+echo "[doctor] clean build artifacts"
+rm -rf build dist
+
+echo "[doctor] build package artifacts"
+uv build --no-sources
+
 echo "[doctor] run integration tests"
-bash ./scripts/integration_tests.sh
+integration_status="passed"
+if bash ./scripts/integration_tests.sh; then
+  :
+else
+  status=$?
+  if [ "$status" -eq 3 ]; then
+    integration_status="skipped"
+    echo "[doctor] integration tests skipped: PostgreSQL CLI coverage requires LIFEOS_TEST_DATABASE_URL" >&2
+  else
+    exit "$status"
+  fi
+fi
+
+if [ "$integration_status" = "skipped" ]; then
+  echo "[doctor] completed without PostgreSQL CLI integration coverage" >&2
+else
+  echo "[doctor] completed with PostgreSQL CLI integration coverage"
+fi

--- a/scripts/integration_tests.sh
+++ b/scripts/integration_tests.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 if [ -z "${LIFEOS_TEST_DATABASE_URL:-}" ]; then
-  echo "[integration] skip: set LIFEOS_TEST_DATABASE_URL to run CLI integration tests" >&2
-  exit 0
+  echo "[integration] skipped: set LIFEOS_TEST_DATABASE_URL to run PostgreSQL CLI integration tests" >&2
+  exit 3
 fi
 
 uv run pytest -m integration tests/test_cli_integration_*.py

--- a/scripts/integration_tests.sh
+++ b/scripts/integration_tests.sh
@@ -1,6 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+LOCAL_ENV_FILE="${REPO_ROOT}/.env"
+
+if [ -f "${LOCAL_ENV_FILE}" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  . "${LOCAL_ENV_FILE}"
+  set +a
+fi
+
 if [ -z "${LIFEOS_TEST_DATABASE_URL:-}" ]; then
   echo "[integration] skipped: set LIFEOS_TEST_DATABASE_URL to run PostgreSQL CLI integration tests" >&2
   exit 3

--- a/tests/test_repository_contracts.py
+++ b/tests/test_repository_contracts.py
@@ -4,6 +4,7 @@ from typing import Any, cast
 import yaml  # type: ignore[import-untyped]
 from babel.messages import pofile
 
+GITIGNORE_TEXT = Path(".gitignore").read_text()
 DEPENDABOT_CONFIG = yaml.safe_load(Path(".github/dependabot.yml").read_text())
 DOCTOR_TEXT = Path("scripts/doctor.sh").read_text()
 DEPENDENCY_HEALTH_TEXT = Path("scripts/dependency_health.sh").read_text()
@@ -44,6 +45,7 @@ def test_dependabot_configuration_prefers_a_single_grouped_uv_pr() -> None:
 
 
 def test_dependency_scripts_keep_separate_scopes() -> None:
+    assert 'LOCAL_ENV_FILE="${REPO_ROOT}/.env"' in DOCTOR_TEXT
     assert any("uv sync --all-extras --frozen" in line for line in DOCTOR_COMMANDS)
     assert any('uv run pytest -m "not integration"' in line for line in DOCTOR_COMMANDS)
     assert not any("uv pip list --outdated" in line for line in DOCTOR_COMMANDS)
@@ -93,6 +95,7 @@ def test_validate_workflow_runs_real_cli_integration_tests() -> None:
 def test_integration_tests_require_an_explicit_test_database_url() -> None:
     script_text = Path("scripts/integration_tests.sh").read_text()
     assert "LIFEOS_RUN_INTEGRATION" not in script_text
+    assert 'LOCAL_ENV_FILE="${REPO_ROOT}/.env"' in script_text
     assert "LIFEOS_TEST_DATABASE_URL:-" in script_text
     assert "exit 3" in script_text
     assert "uv run pytest -m integration tests/test_cli_integration_*.py" in script_text
@@ -100,6 +103,11 @@ def test_integration_tests_require_an_explicit_test_database_url() -> None:
     assert 'INTEGRATION_DATABASE_URL = os.environ.get("LIFEOS_TEST_DATABASE_URL")' in support_text
     assert "DatabaseSettings.from_env" not in support_text
     assert 'schema = f"lifeos_test_{uuid4().hex[:12]}"' in Path("tests/conftest.py").read_text()
+
+
+def test_gitignore_keeps_local_env_files_untracked() -> None:
+    assert "\n.env\n" in GITIGNORE_TEXT
+    assert "\n.env.local\n" in GITIGNORE_TEXT
 
 
 def test_vulture_whitelist_keeps_intentional_framework_symbols() -> None:

--- a/tests/test_repository_contracts.py
+++ b/tests/test_repository_contracts.py
@@ -1,56 +1,100 @@
 from pathlib import Path
+from typing import Any, cast
 
+import yaml  # type: ignore[import-untyped]
 from babel.messages import pofile
 
-DEPENDABOT_TEXT = Path(".github/dependabot.yml").read_text()
+DEPENDABOT_CONFIG = yaml.safe_load(Path(".github/dependabot.yml").read_text())
 DOCTOR_TEXT = Path("scripts/doctor.sh").read_text()
 DEPENDENCY_HEALTH_TEXT = Path("scripts/dependency_health.sh").read_text()
-PRE_COMMIT_TEXT = Path(".pre-commit-config.yaml").read_text()
-VALIDATE_WORKFLOW_TEXT = Path(".github/workflows/validate.yml").read_text()
+PRE_COMMIT_CONFIG = yaml.safe_load(Path(".pre-commit-config.yaml").read_text())
+VALIDATE_WORKFLOW = yaml.safe_load(Path(".github/workflows/validate.yml").read_text())
 VULTURE_WHITELIST_TEXT = Path("scripts/vulture_whitelist.py").read_text()
 
 
+def _non_comment_shell_lines(text: str) -> list[str]:
+    return [
+        line.strip()
+        for line in text.splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+
+
+def _workflow_job_steps(workflow: dict[str, Any], job_name: str) -> list[dict[str, Any]]:
+    jobs = cast(dict[str, Any], workflow["jobs"])
+    steps = cast(list[dict[str, Any]], jobs[job_name]["steps"])
+    assert isinstance(steps, list)
+    return steps
+
+
+DOCTOR_COMMANDS = _non_comment_shell_lines(DOCTOR_TEXT)
+DEPENDENCY_HEALTH_COMMANDS = _non_comment_shell_lines(DEPENDENCY_HEALTH_TEXT)
+QUALITY_GATE_STEPS = _workflow_job_steps(VALIDATE_WORKFLOW, "quality-gate")
+INTEGRATION_JOB_STEPS = _workflow_job_steps(VALIDATE_WORKFLOW, "integration-postgres")
+
+
 def test_dependabot_configuration_prefers_a_single_grouped_uv_pr() -> None:
-    assert 'package-ecosystem: "uv"' in DEPENDABOT_TEXT
-    assert 'package-ecosystem: "github-actions"' not in DEPENDABOT_TEXT
-    assert "open-pull-requests-limit: 1" in DEPENDABOT_TEXT
-    assert "uv-all-updates" in DEPENDABOT_TEXT
+    updates = DEPENDABOT_CONFIG["updates"]
+    assert isinstance(updates, list)
+    ecosystems = {entry["package-ecosystem"] for entry in updates}
+    assert ecosystems == {"uv"}
+    uv_entry = updates[0]
+    assert uv_entry["open-pull-requests-limit"] == 1
+    assert uv_entry["groups"]["uv-all-updates"]["patterns"] == ["*"]
 
 
 def test_dependency_scripts_keep_separate_scopes() -> None:
-    assert "uv run pytest" in DOCTOR_TEXT
-    assert "uv pip list --outdated" not in DOCTOR_TEXT
-    assert "uv pip list --outdated" in DEPENDENCY_HEALTH_TEXT
-    assert "uv run pip-audit" in DEPENDENCY_HEALTH_TEXT
-    assert "uv run pytest" not in DEPENDENCY_HEALTH_TEXT
+    assert any("uv sync --all-extras --frozen" in line for line in DOCTOR_COMMANDS)
+    assert any('uv run pytest -m "not integration"' in line for line in DOCTOR_COMMANDS)
+    assert not any("uv pip list --outdated" in line for line in DOCTOR_COMMANDS)
+    assert any("uv run pip-audit" in line for line in DOCTOR_COMMANDS)
+    assert any("uv build --no-sources" in line for line in DOCTOR_COMMANDS)
+    assert any("uv pip list --outdated" in line for line in DEPENDENCY_HEALTH_COMMANDS)
+    assert any("uv run pip-audit" in line for line in DEPENDENCY_HEALTH_COMMANDS)
+    assert not any("uv run pytest" in line for line in DEPENDENCY_HEALTH_COMMANDS)
 
 
 def test_dead_code_scan_is_part_of_the_default_validation_gate() -> None:
-    assert "bash ./scripts/dead_code_check.sh" in PRE_COMMIT_TEXT
-    assert "uv run pre-commit run --all-files" in DOCTOR_TEXT
-    assert 'uv run pytest -m "not integration"' in DOCTOR_TEXT
-    assert "bash ./scripts/integration_tests.sh" in DOCTOR_TEXT
+    repo_hooks = PRE_COMMIT_CONFIG["repos"]
+    assert isinstance(repo_hooks, list)
+    local_repo = next(repo for repo in repo_hooks if repo["repo"] == "local")
+    hook_ids = {hook["id"] for hook in local_repo["hooks"]}
+    assert "dead-code" in hook_ids
+    assert any("uv run pre-commit run --all-files" in line for line in DOCTOR_COMMANDS)
+    assert any('uv run pytest -m "not integration"' in line for line in DOCTOR_COMMANDS)
+    assert any("bash ./scripts/integration_tests.sh" in line for line in DOCTOR_COMMANDS)
 
 
 def test_locale_catalog_sync_is_part_of_the_default_validation_gate() -> None:
-    assert "uv run python scripts/check_locale_catalog.py" in PRE_COMMIT_TEXT
+    repo_hooks = PRE_COMMIT_CONFIG["repos"]
+    assert isinstance(repo_hooks, list)
+    local_repo = next(repo for repo in repo_hooks if repo["repo"] == "local")
+    hook_entries = {hook["id"]: hook["entry"] for hook in local_repo["hooks"]}
+    assert hook_entries["locale-catalog-sync"] == "uv run python scripts/check_locale_catalog.py"
 
 
 def test_validate_workflow_runs_real_cli_integration_tests() -> None:
-    expected_database_url = (
-        "postgresql+psycopg://postgres:postgres@127.0.0.1:5432/"  # pragma: allowlist secret
-        "lifeos_test"
+    quality_gate_run_steps = [
+        step["run"] for step in QUALITY_GATE_STEPS if isinstance(step, dict) and "run" in step
+    ]
+    assert any("bash ./scripts/doctor.sh" in run for run in quality_gate_run_steps)
+
+    integration_run_step = next(
+        step for step in INTEGRATION_JOB_STEPS if step.get("name") == "Run CLI integration tests"
     )
-    assert "integration-postgres" in VALIDATE_WORKFLOW_TEXT
-    assert expected_database_url in VALIDATE_WORKFLOW_TEXT
-    assert 'uv run pytest -m "not integration"' in VALIDATE_WORKFLOW_TEXT
-    assert "bash ./scripts/integration_tests.sh" in VALIDATE_WORKFLOW_TEXT
+    integration_env = integration_run_step["env"]
+    assert "LIFEOS_TEST_DATABASE_URL" in integration_env
+    database_url = integration_env["LIFEOS_TEST_DATABASE_URL"]
+    assert "127.0.0.1:5432" in database_url
+    assert "lifeos_test" in database_url
+    assert integration_run_step["run"] == "bash ./scripts/integration_tests.sh"
 
 
 def test_integration_tests_require_an_explicit_test_database_url() -> None:
     script_text = Path("scripts/integration_tests.sh").read_text()
     assert "LIFEOS_RUN_INTEGRATION" not in script_text
     assert "LIFEOS_TEST_DATABASE_URL:-" in script_text
+    assert "exit 3" in script_text
     assert "uv run pytest -m integration tests/test_cli_integration_*.py" in script_text
     support_text = Path("tests/cli_integration_support.py").read_text()
     assert 'INTEGRATION_DATABASE_URL = os.environ.get("LIFEOS_TEST_DATABASE_URL")' in support_text


### PR DESCRIPTION
## 概要

本 PR 聚焦验证链路工程卫生，统一默认校验入口与 CI gate 的边界，并补齐本地 `.env` 对 PostgreSQL CLI integration 测试变量的加载支持。

## scripts

### `scripts/doctor.sh`

- 默认使用 `uv sync --all-extras --frozen`
- 将 runtime requirements 导出、`pip-audit`、`uv build --no-sources` 纳入默认校验入口
- 在脚本启动时自动加载项目根 `.env`（若存在）
- 继续调用 PostgreSQL CLI 集成测试入口，并在 integration 未运行时输出明确状态

### `scripts/integration_tests.sh`

- 在脚本启动时自动加载项目根 `.env`（若存在）
- 为“未配置 `LIFEOS_TEST_DATABASE_URL`”返回专用退出码
- 让 `doctor.sh` 能区分 integration skip 与真实失败

## GitHub Workflows

### `.github/workflows/validate.yml`

- 删除已被 `doctor.sh` 吸收的重复漏洞审计与构建步骤
- 保留独立 PostgreSQL integration job，用真实数据库覆盖 CLI 集成场景

### `.github/workflows/publish.yml`

- 删除已被 `doctor.sh` 吸收的重复漏洞审计与构建步骤
- 保持发布前仍通过统一默认校验入口执行回归基线

## Local Env And Docs

### `.gitignore`

- 显式忽略项目根 `.env` 与本地 env 变体，防止本机测试库配置落库

### `CONTRIBUTING.md`

- 同步默认校验基线的实际组成
- 补充项目根 `.env` 可被脚本自动加载的本地开发说明

## Tests

### `tests/test_repository_contracts.py`

- 从字面量 shell / workflow 文本断言，调整为更多检查 workflow、pre-commit 与脚本职责的结构契约
- 补充对 `doctor.sh` 冻结依赖、漏洞审计、构建步骤的契约断言
- 补充对 `.env` 忽略规则与脚本自动加载行为的契约断言

## 验证

- `uv run pytest tests/test_repository_contracts.py`
- `bash ./scripts/doctor.sh`
  - 本次通过项目根 `.env` 中的 `LIFEOS_TEST_DATABASE_URL` 实际跑通 PostgreSQL CLI integration
  - `323 passed, 10 deselected`
  - integration: `10 passed, 1 deselected`

## Issues

Closes #81
Closes #85
