### PR TITLE
ci: rebuild release artifacts before publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Run default regression baseline
         run: bash ./scripts/doctor.sh
 
+      - name: Build release artifacts
+        run: uv build --no-sources
+
       - name: Verify published version matches tag
         env:
           RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}


### PR DESCRIPTION
## 背景

`v0.11.1` tag push 后，`Release Publish and Repair` workflow 在版本校验步骤失败。原因是 `doctor.sh` 验证结束后会清理 `dist/`，发布 workflow 后续步骤无法找到 wheel 和 sdist。

## 修改

- 在 release workflow 的 `doctor.sh` 验证通过后，新增独立的 `uv build --no-sources` 发布产物构建步骤。
- 保持 `doctor.sh` 本地验证结束后清理构建产物的行为不变。
- 让版本校验、PyPI 发布和 GitHub Release asset 同步都使用发布 job 中重新生成的 artifacts。

## 验证

- `bash ./scripts/doctor.sh`
- `bash ./scripts/dependency_health.sh`
- 在临时 worktree 检出 `v0.11.1`，执行 `uv build --no-sources` 后用 release workflow 同等版本校验逻辑确认生成 `lifeos_cli-0.11.1-py3-none-any.whl` 与 `lifeos_cli-0.11.1.tar.gz`。

Closes #95
