### PR TITLE
fix: normalize discrete date follow-up flows

### DIFF
--- a/src/lifeos_cli/cli_support/resources/timelog/bulk_add.py
+++ b/src/lifeos_cli/cli_support/resources/timelog/bulk_add.py
@@ -40,32 +40,26 @@ class _ParsedLine:
     start_token: str | None = None
 
 
-def _normalize_line(line: str) -> str:
-    return line.replace("\r", "").replace("\t", " ").replace("\u00a0", " ").strip()
-
-
-def _normalize_spacing_and_symbols(line: str) -> str:
-    return _FULL_WIDTH_SPACE.sub(" ", line).replace("\u00a0", " ").replace("\t", " ").strip()
-
-
 def _normalize_for_matching(line: str) -> str:
     return (
         _FULL_WIDTH_HYPHEN.sub(
-            "-", _FULL_WIDTH_COLON.sub(":", _normalize_spacing_and_symbols(line))
+            "-",
+            _FULL_WIDTH_COLON.sub(
+                ":",
+                _FULL_WIDTH_SPACE.sub(" ", line).replace("\u00a0", " ").replace("\t", " ").strip(),
+            ),
         )
         .replace("  ", " ")
         .strip()
     )
 
 
-def _sanitize_time_token(token: str) -> str:
-    return "".join(character for character in token if character.isdigit() or character == ":")
-
-
 def _parse_time_token(token: str | None, *, field_name: str, line_number: int) -> int:
     if token is None:
         raise ConfigurationError(f"Line {line_number}: missing {field_name} time.")
-    normalized = _sanitize_time_token(token)
+    normalized = "".join(
+        character for character in token if character.isdigit() or character == ":"
+    )
     if not normalized:
         raise ConfigurationError(f"Line {line_number}: invalid {field_name} time {token!r}.")
     if ":" in normalized:
@@ -141,7 +135,7 @@ def parse_bulk_timelog_text(
     normalized_first_start_time = to_storage_timezone(first_start_time)
     initial_cursor = to_preferred_timezone(normalized_first_start_time)
     lines = [
-        (line_number, _normalize_line(line))
+        (line_number, line.replace("\r", "").replace("\t", " ").replace("\u00a0", " ").strip())
         for line_number, line in enumerate(raw_text.splitlines(), start=1)
     ]
     active_lines = [(line_number, line) for line_number, line in lines if line]

--- a/src/lifeos_cli/cli_support/resources/timelog/handlers.py
+++ b/src/lifeos_cli/cli_support/resources/timelog/handlers.py
@@ -600,6 +600,15 @@ async def handle_timelog_stats_rebuild_async(args: argparse.Namespace) -> int:
         print("No linked-area timelogs found for the selected rebuild scope.")
         return 0
     print(f"Rebuilt timelog stats grouped by area for {len(rebuilt_dates)} dates.")
-    print(f"start_date: {rebuilt_dates[0].isoformat()}")
-    print(f"end_date: {rebuilt_dates[-1].isoformat()}")
+    if date_selection.date_values:
+        label = "date" if len(date_selection.date_values) == 1 else "dates"
+        selected_dates = ", ".join(
+            target_date.isoformat() for target_date in date_selection.date_values
+        )
+        print(f"{label}: {selected_dates}")
+    else:
+        rebuilt_start_date = min(rebuilt_dates)
+        rebuilt_end_date = max(rebuilt_dates)
+        print(f"start_date: {rebuilt_start_date.isoformat()}")
+        print(f"end_date: {rebuilt_end_date.isoformat()}")
     return 0

--- a/src/lifeos_cli/cli_support/time_args.py
+++ b/src/lifeos_cli/cli_support/time_args.py
@@ -34,13 +34,6 @@ class ResolvedDateTimeQuery:
     end_date: date | None
     window_start: datetime | None
     window_end: datetime | None
-
-
-def _normalize_discrete_date_values(date_values: list[date] | None) -> tuple[date, ...]:
-    """Return repeated CLI local dates in first-seen order without duplicates."""
-    return tuple(dict.fromkeys(date_values or ()))
-
-
 def parse_date_value(value: str) -> date:
     """Parse one ISO local date value."""
     try:
@@ -81,7 +74,7 @@ def resolve_date_selection_arguments(
     explicit_inverted_message: str = "The --end-date value must be on or after --start-date.",
 ) -> ResolvedDateSelection:
     """Resolve repeated discrete dates or one explicit inclusive date range."""
-    selected_dates = _normalize_discrete_date_values(date_values)
+    selected_dates = tuple(dict.fromkeys(date_values or ()))
     if selected_dates and (start_date is not None or end_date is not None):
         raise DateArgumentError(conflict_message)
     if start_date is not None or end_date is not None:

--- a/src/lifeos_cli/cli_support/time_args.py
+++ b/src/lifeos_cli/cli_support/time_args.py
@@ -34,6 +34,8 @@ class ResolvedDateTimeQuery:
     end_date: date | None
     window_start: datetime | None
     window_end: datetime | None
+
+
 def parse_date_value(value: str) -> date:
     """Parse one ISO local date value."""
     try:

--- a/src/lifeos_cli/cli_support/time_args.py
+++ b/src/lifeos_cli/cli_support/time_args.py
@@ -36,6 +36,11 @@ class ResolvedDateTimeQuery:
     window_end: datetime | None
 
 
+def _normalize_discrete_date_values(date_values: list[date] | None) -> tuple[date, ...]:
+    """Return repeated CLI local dates in first-seen order without duplicates."""
+    return tuple(dict.fromkeys(date_values or ()))
+
+
 def parse_date_value(value: str) -> date:
     """Parse one ISO local date value."""
     try:
@@ -76,7 +81,7 @@ def resolve_date_selection_arguments(
     explicit_inverted_message: str = "The --end-date value must be on or after --start-date.",
 ) -> ResolvedDateSelection:
     """Resolve repeated discrete dates or one explicit inclusive date range."""
-    selected_dates = tuple(date_values or ())
+    selected_dates = _normalize_discrete_date_values(date_values)
     if selected_dates and (start_date is not None or end_date is not None):
         raise DateArgumentError(conflict_message)
     if start_date is not None or end_date is not None:

--- a/src/lifeos_cli/db/services/events.py
+++ b/src/lifeos_cli/db/services/events.py
@@ -515,7 +515,7 @@ def _normalize_event_filters(filters: EventQueryFilters) -> EventQueryFilters:
         task_id=filters.task_id,
         person_id=filters.person_id,
         tag_id=filters.tag_id,
-        date_values=filters.date_values,
+        date_values=tuple(deduplicate_preserving_order(filters.date_values)),
         start_date=filters.start_date,
         end_date=filters.end_date,
         window_start=filters.window_start,

--- a/src/lifeos_cli/db/services/habit_queries.py
+++ b/src/lifeos_cli/db/services/habit_queries.py
@@ -273,26 +273,6 @@ def _build_habit_action_views_for_occurrence_dates(
     return views
 
 
-def _build_habit_occurrence_views(
-    *,
-    habit: Habit,
-    materialized_actions: list[HabitAction],
-    start_date: date,
-    end_date: date,
-    include_deleted: bool,
-) -> list[HabitActionView]:
-    return _build_habit_action_views_for_occurrence_dates(
-        habit=habit,
-        materialized_actions=materialized_actions,
-        occurrence_dates=_iter_habit_window_dates(
-            habit=habit,
-            start_date=start_date,
-            end_date=end_date,
-        ),
-        include_deleted=include_deleted,
-    )
-
-
 def _build_habit_occurrence_views_for_dates(
     *,
     habit: Habit,
@@ -401,11 +381,14 @@ async def _build_habit_action_views(
         habit_start = range_start if action_window is None else action_window[0]
         habit_end = range_end if action_window is None else action_window[1]
         views.extend(
-            _build_habit_occurrence_views(
+            _build_habit_action_views_for_occurrence_dates(
                 habit=habit,
                 materialized_actions=actions_by_habit.get(habit.id, []),
-                start_date=habit_start,
-                end_date=habit_end,
+                occurrence_dates=_iter_habit_window_dates(
+                    habit=habit,
+                    start_date=habit_start,
+                    end_date=habit_end,
+                ),
                 include_deleted=include_deleted,
             )
         )

--- a/src/lifeos_cli/db/services/habit_queries.py
+++ b/src/lifeos_cli/db/services/habit_queries.py
@@ -273,55 +273,6 @@ def _build_habit_action_views_for_occurrence_dates(
     return views
 
 
-def _build_habit_occurrence_views_for_dates(
-    *,
-    habit: Habit,
-    materialized_actions: list[HabitAction],
-    target_dates: tuple[date, ...],
-    include_deleted: bool,
-) -> list[HabitActionView]:
-    occurrence_dates = [
-        target_date
-        for target_date in target_dates
-        if habit_occurs_on_date(
-            start_date=habit.start_date,
-            end_date=habit.end_date,
-            cadence_weekdays=habit.cadence_weekdays,
-            target_date=target_date,
-        )
-    ]
-    return _build_habit_action_views_for_occurrence_dates(
-        habit=habit,
-        materialized_actions=materialized_actions,
-        occurrence_dates=occurrence_dates,
-        include_deleted=include_deleted,
-    )
-
-
-def _filter_habit_action_views(
-    views: list[HabitActionView],
-    *,
-    status: str | None,
-) -> list[HabitActionView]:
-    if status is None:
-        return views
-    normalized_status = validate_habit_action_status(status)
-    return [view for view in views if view.status == normalized_status]
-
-
-def _sort_habit_action_views(views: list[HabitActionView]) -> list[HabitActionView]:
-    return sorted(
-        views,
-        key=lambda view: (
-            view.action_date,
-            view.habit_title,
-            view.habit_id,
-            view.id is None,
-            str(view.id or view.habit_id),
-        ),
-    )
-
-
 async def _build_habit_action_views(
     session: AsyncSession,
     *,
@@ -367,11 +318,21 @@ async def _build_habit_action_views(
     views: list[HabitActionView] = []
     for habit in habits:
         if normalized_target_dates:
+            occurrence_dates = [
+                target_date
+                for target_date in normalized_target_dates
+                if habit_occurs_on_date(
+                    start_date=habit.start_date,
+                    end_date=habit.end_date,
+                    cadence_weekdays=habit.cadence_weekdays,
+                    target_date=target_date,
+                )
+            ]
             views.extend(
-                _build_habit_occurrence_views_for_dates(
+                _build_habit_action_views_for_occurrence_dates(
                     habit=habit,
                     materialized_actions=actions_by_habit.get(habit.id, []),
-                    target_dates=normalized_target_dates,
+                    occurrence_dates=occurrence_dates,
                     include_deleted=include_deleted,
                 )
             )
@@ -392,7 +353,19 @@ async def _build_habit_action_views(
                 include_deleted=include_deleted,
             )
         )
-    return _sort_habit_action_views(_filter_habit_action_views(views, status=status))
+    if status is not None:
+        normalized_status = validate_habit_action_status(status)
+        views = [view for view in views if view.status == normalized_status]
+    return sorted(
+        views,
+        key=lambda view: (
+            view.action_date,
+            view.habit_title,
+            view.habit_id,
+            view.id is None,
+            str(view.id or view.habit_id),
+        ),
+    )
 
 
 async def get_habit(

--- a/src/lifeos_cli/db/services/habit_queries.py
+++ b/src/lifeos_cli/db/services/habit_queries.py
@@ -6,7 +6,7 @@ from datetime import date, datetime, timedelta
 from typing import Any, cast
 from uuid import UUID
 
-from sqlalchemy import func, select, text
+from sqlalchemy import and_, func, or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -14,6 +14,7 @@ from lifeos_cli.application.time_preferences import get_operational_date
 from lifeos_cli.db.models.habit import Habit
 from lifeos_cli.db.models.habit_action import HabitAction
 from lifeos_cli.db.models.task import Task
+from lifeos_cli.db.services.collection_utils import deduplicate_preserving_order
 from lifeos_cli.db.services.habit_support import (
     HabitActionLike,
     HabitActionNotFoundError,
@@ -68,6 +69,11 @@ def _normalize_action_window(
 
 def _habit_end_expr() -> Any:
     return Habit.start_date + (Habit.duration_days - 1) * text("INTERVAL '1 day'")
+
+
+def _normalize_target_dates(target_dates: tuple[date, ...] | list[date]) -> tuple[date, ...]:
+    """Return requested local dates in first-seen order without duplicates."""
+    return tuple(deduplicate_preserving_order(target_dates))
 
 
 def _build_habit_action_view(
@@ -152,6 +158,7 @@ async def _load_materialized_actions_for_habits(
     habit_ids: list[UUID],
     start_date: date | None,
     end_date: date | None,
+    target_dates: tuple[date, ...] = (),
     include_deleted: bool,
 ) -> list[HabitAction]:
     if not habit_ids:
@@ -159,9 +166,11 @@ async def _load_materialized_actions_for_habits(
     stmt = select(HabitAction).where(HabitAction.habit_id.in_(habit_ids))
     if not include_deleted:
         stmt = stmt.where(HabitAction.deleted_at.is_(None))
-    if start_date is not None:
+    if target_dates:
+        stmt = stmt.where(HabitAction.action_date.in_(target_dates))
+    elif start_date is not None:
         stmt = stmt.where(HabitAction.action_date >= start_date)
-    if end_date is not None:
+    if not target_dates and end_date is not None:
         stmt = stmt.where(HabitAction.action_date <= end_date)
     stmt = stmt.order_by(
         HabitAction.action_date.asc(),
@@ -177,6 +186,7 @@ async def _load_candidate_habits(
     habit_id: UUID | None,
     include_deleted: bool,
     action_window: tuple[date, date] | None,
+    target_dates: tuple[date, ...] = (),
 ) -> list[Habit]:
     if habit_id is not None:
         habit = await get_habit(session, habit_id=habit_id, include_deleted=include_deleted)
@@ -187,19 +197,28 @@ async def _load_candidate_habits(
     stmt = select(Habit).options(selectinload(Habit.task))
     if not include_deleted:
         stmt = stmt.where(Habit.deleted_at.is_(None))
-    if action_window is not None:
+    if target_dates:
+        habit_end_expr = _habit_end_expr()
+        stmt = stmt.where(
+            or_(
+                *(
+                    and_(Habit.start_date <= target_date, habit_end_expr >= target_date)
+                    for target_date in target_dates
+                )
+            )
+        )
+    elif action_window is not None:
         start_date, end_date = action_window
         stmt = stmt.where(Habit.start_date <= end_date, _habit_end_expr() >= start_date)
     stmt = stmt.order_by(Habit.created_at.desc(), Habit.id.desc())
     return list((await session.execute(stmt)).scalars())
 
 
-def _build_habit_occurrence_views(
+def _build_habit_action_views_for_occurrence_dates(
     *,
     habit: Habit,
     materialized_actions: list[HabitAction],
-    start_date: date,
-    end_date: date,
+    occurrence_dates: list[date],
     include_deleted: bool,
 ) -> list[HabitActionView]:
     active_actions_by_date = {
@@ -208,11 +227,7 @@ def _build_habit_occurrence_views(
     deleted_actions = [action for action in materialized_actions if action.deleted_at is not None]
     views: list[HabitActionView] = []
 
-    for action_date in _iter_habit_window_dates(
-        habit=habit,
-        start_date=start_date,
-        end_date=end_date,
-    ):
+    for action_date in occurrence_dates:
         materialized = active_actions_by_date.get(action_date)
         if materialized is None:
             views.append(
@@ -244,6 +259,7 @@ def _build_habit_occurrence_views(
         )
 
     if include_deleted:
+        occurrence_date_set = set(occurrence_dates)
         views.extend(
             _build_habit_action_view(
                 action_id=action.id,
@@ -257,9 +273,54 @@ def _build_habit_occurrence_views(
                 deleted_at=action.deleted_at,
             )
             for action in deleted_actions
-            if start_date <= action.action_date <= end_date
+            if action.action_date in occurrence_date_set
         )
     return views
+
+
+def _build_habit_occurrence_views(
+    *,
+    habit: Habit,
+    materialized_actions: list[HabitAction],
+    start_date: date,
+    end_date: date,
+    include_deleted: bool,
+) -> list[HabitActionView]:
+    return _build_habit_action_views_for_occurrence_dates(
+        habit=habit,
+        materialized_actions=materialized_actions,
+        occurrence_dates=_iter_habit_window_dates(
+            habit=habit,
+            start_date=start_date,
+            end_date=end_date,
+        ),
+        include_deleted=include_deleted,
+    )
+
+
+def _build_habit_occurrence_views_for_dates(
+    *,
+    habit: Habit,
+    materialized_actions: list[HabitAction],
+    target_dates: tuple[date, ...],
+    include_deleted: bool,
+) -> list[HabitActionView]:
+    occurrence_dates = [
+        target_date
+        for target_date in target_dates
+        if habit_occurs_on_date(
+            start_date=habit.start_date,
+            end_date=habit.end_date,
+            cadence_weekdays=habit.cadence_weekdays,
+            target_date=target_date,
+        )
+    ]
+    return _build_habit_action_views_for_occurrence_dates(
+        habit=habit,
+        materialized_actions=materialized_actions,
+        occurrence_dates=occurrence_dates,
+        include_deleted=include_deleted,
+    )
 
 
 def _filter_habit_action_views(
@@ -292,19 +353,25 @@ async def _build_habit_action_views(
     habit_id: UUID | None,
     status: str | None,
     action_window: tuple[date, date] | None,
+    target_dates: tuple[date, ...] = (),
     include_deleted: bool,
 ) -> list[HabitActionView]:
+    normalized_target_dates = _normalize_target_dates(target_dates)
     habits = await _load_candidate_habits(
         session,
         habit_id=habit_id,
         include_deleted=include_deleted,
         action_window=action_window,
+        target_dates=normalized_target_dates,
     )
     if not habits:
         return []
 
     habit_ids = [habit.id for habit in habits]
-    if action_window is None:
+    if normalized_target_dates:
+        range_start = None
+        range_end = None
+    elif action_window is None:
         range_start = min(habit.start_date for habit in habits)
         range_end = max(habit.end_date for habit in habits)
     else:
@@ -315,6 +382,7 @@ async def _build_habit_action_views(
         habit_ids=habit_ids,
         start_date=range_start,
         end_date=range_end,
+        target_dates=normalized_target_dates,
         include_deleted=include_deleted,
     )
     actions_by_habit: dict[UUID, list[HabitAction]] = {habit_id: [] for habit_id in habit_ids}
@@ -323,6 +391,18 @@ async def _build_habit_action_views(
 
     views: list[HabitActionView] = []
     for habit in habits:
+        if normalized_target_dates:
+            views.extend(
+                _build_habit_occurrence_views_for_dates(
+                    habit=habit,
+                    materialized_actions=actions_by_habit.get(habit.id, []),
+                    target_dates=normalized_target_dates,
+                    include_deleted=include_deleted,
+                )
+            )
+            continue
+        assert range_start is not None
+        assert range_end is not None
         habit_start = range_start if action_window is None else action_window[0]
         habit_end = range_end if action_window is None else action_window[1]
         views.extend(
@@ -510,21 +590,18 @@ async def list_habit_actions(
     offset: int = 0,
 ) -> list[HabitActionView]:
     """List habit-action occurrence views with optional filters."""
-    selected_dates = set(date_values)
+    target_dates = _normalize_target_dates(date_values)
     action_window = (
-        (min(selected_dates), max(selected_dates))
-        if selected_dates
-        else _normalize_action_window(start_date=start_date, end_date=end_date)
+        None if target_dates else _normalize_action_window(start_date=start_date, end_date=end_date)
     )
     views = await _build_habit_action_views(
         session,
         habit_id=habit_id,
         status=status,
         action_window=action_window,
+        target_dates=target_dates,
         include_deleted=include_deleted,
     )
-    if selected_dates:
-        views = [view for view in views if view.action_date in selected_dates]
     paged_views = views[offset : offset + limit]
     synthetic_views = [view for view in paged_views if view.id is None]
     if not synthetic_views or include_deleted:
@@ -597,21 +674,18 @@ async def count_habit_actions(
     include_deleted: bool = False,
 ) -> int:
     """Count habit-action occurrence views with the same filters used by list_habit_actions."""
-    selected_dates = set(date_values)
+    target_dates = _normalize_target_dates(date_values)
     action_window = (
-        (min(selected_dates), max(selected_dates))
-        if selected_dates
-        else _normalize_action_window(start_date=start_date, end_date=end_date)
+        None if target_dates else _normalize_action_window(start_date=start_date, end_date=end_date)
     )
     views = await _build_habit_action_views(
         session,
         habit_id=habit_id,
         status=status,
         action_window=action_window,
+        target_dates=target_dates,
         include_deleted=include_deleted,
     )
-    if selected_dates:
-        views = [view for view in views if view.action_date in selected_dates]
     return len(views)
 
 

--- a/src/lifeos_cli/db/services/habit_queries.py
+++ b/src/lifeos_cli/db/services/habit_queries.py
@@ -71,11 +71,6 @@ def _habit_end_expr() -> Any:
     return Habit.start_date + (Habit.duration_days - 1) * text("INTERVAL '1 day'")
 
 
-def _normalize_target_dates(target_dates: tuple[date, ...] | list[date]) -> tuple[date, ...]:
-    """Return requested local dates in first-seen order without duplicates."""
-    return tuple(deduplicate_preserving_order(target_dates))
-
-
 def _build_habit_action_view(
     *,
     action_id: UUID | None,
@@ -356,7 +351,7 @@ async def _build_habit_action_views(
     target_dates: tuple[date, ...] = (),
     include_deleted: bool,
 ) -> list[HabitActionView]:
-    normalized_target_dates = _normalize_target_dates(target_dates)
+    normalized_target_dates = tuple(deduplicate_preserving_order(target_dates))
     habits = await _load_candidate_habits(
         session,
         habit_id=habit_id,
@@ -590,7 +585,7 @@ async def list_habit_actions(
     offset: int = 0,
 ) -> list[HabitActionView]:
     """List habit-action occurrence views with optional filters."""
-    target_dates = _normalize_target_dates(date_values)
+    target_dates = tuple(deduplicate_preserving_order(date_values))
     action_window = (
         None if target_dates else _normalize_action_window(start_date=start_date, end_date=end_date)
     )
@@ -674,7 +669,7 @@ async def count_habit_actions(
     include_deleted: bool = False,
 ) -> int:
     """Count habit-action occurrence views with the same filters used by list_habit_actions."""
-    target_dates = _normalize_target_dates(date_values)
+    target_dates = tuple(deduplicate_preserving_order(date_values))
     action_window = (
         None if target_dates else _normalize_action_window(start_date=start_date, end_date=end_date)
     )

--- a/src/lifeos_cli/db/services/schedule_queries.py
+++ b/src/lifeos_cli/db/services/schedule_queries.py
@@ -18,7 +18,6 @@ from lifeos_cli.db.models.task import Task
 from lifeos_cli.db.services.event_support import EventOccurrenceQuery
 from lifeos_cli.db.services.events import EventOccurrence, list_event_occurrences
 from lifeos_cli.db.services.habit_actions import list_habit_actions_in_range
-from lifeos_cli.db.services.read_models import HabitActionView
 
 
 @dataclass(frozen=True)
@@ -151,29 +150,6 @@ def _map_task_item(task: Task) -> ScheduleTaskItem:
     )
 
 
-def _map_habit_action_item(action: HabitActionView) -> ScheduleHabitActionItem:
-    return ScheduleHabitActionItem(
-        id=action.id,
-        habit_id=action.habit_id,
-        habit_title=action.habit_title,
-        action_date=action.action_date,
-        status=action.status,
-        notes=action.notes,
-    )
-
-
-def _map_event_item(event: EventOccurrence) -> ScheduleEventItem:
-    return ScheduleEventItem(
-        id=event.id,
-        title=event.title,
-        status=event.status,
-        event_type=event.event_type,
-        start_time=event.start_time,
-        end_time=event.end_time,
-        task_id=event.task_id,
-    )
-
-
 def _is_overdue_unfinished_task(item: ScheduleTaskItem, *, local_today: date) -> bool:
     return item.status not in {"cancelled", "done"} and item.planning_cycle_end_date < local_today
 
@@ -208,8 +184,29 @@ async def list_schedule_in_range(
     events = await _load_schedule_events(session, start_date=start_date, end_date=end_date)
 
     task_items = [_map_task_item(task) for task in tasks]
-    action_items = [_map_habit_action_item(action) for action in habit_actions]
-    event_items = [_map_event_item(event) for event in events]
+    action_items = [
+        ScheduleHabitActionItem(
+            id=action.id,
+            habit_id=action.habit_id,
+            habit_title=action.habit_title,
+            action_date=action.action_date,
+            status=action.status,
+            notes=action.notes,
+        )
+        for action in habit_actions
+    ]
+    event_items = [
+        ScheduleEventItem(
+            id=event.id,
+            title=event.title,
+            status=event.status,
+            event_type=event.event_type,
+            start_time=event.start_time,
+            end_time=event.end_time,
+            task_id=event.task_id,
+        )
+        for event in events
+    ]
 
     days: list[ScheduleDay] = []
     for current_date in dates:

--- a/src/lifeos_cli/db/services/timelog_stats.py
+++ b/src/lifeos_cli/db/services/timelog_stats.py
@@ -558,7 +558,7 @@ async def rebuild_timelog_stats_groupby_area(
             return ()
         local_dates = iter_date_range(*date_range)
     elif date_values:
-        local_dates = tuple(dict.fromkeys(date_values))
+        local_dates = tuple(sorted(set(date_values)))
     elif start_date is not None or end_date is not None:
         if start_date is None or end_date is None:
             raise TimelogStatsValidationError(

--- a/src/lifeos_cli/db/services/timelogs.py
+++ b/src/lifeos_cli/db/services/timelogs.py
@@ -133,15 +133,6 @@ class _TimelogDependencyChange:
     current: _TimelogDependencySnapshot
 
 
-def _empty_timelog_dependency_snapshot() -> _TimelogDependencySnapshot:
-    return _TimelogDependencySnapshot(
-        task_id=None,
-        start_time=None,
-        end_time=None,
-        area_id=None,
-    )
-
-
 async def _recompute_timelog_dependents(
     session: AsyncSession,
     *,
@@ -447,7 +438,12 @@ async def create_timelog(
     await _flush_and_recompute_timelog_dependents(
         session,
         change=_TimelogDependencyChange(
-            previous=_empty_timelog_dependency_snapshot(),
+            previous=_TimelogDependencySnapshot(
+                task_id=None,
+                start_time=None,
+                end_time=None,
+                area_id=None,
+            ),
             current=_capture_timelog_dependency_snapshot(timelog),
         ),
     )
@@ -617,7 +613,12 @@ async def delete_timelog(session: AsyncSession, *, timelog_id: UUID) -> None:
                 end_time=old_end_time,
                 area_id=old_area_id,
             ),
-            current=_empty_timelog_dependency_snapshot(),
+            current=_TimelogDependencySnapshot(
+                task_id=None,
+                start_time=None,
+                end_time=None,
+                area_id=None,
+            ),
         ),
     )
 

--- a/src/lifeos_cli/db/services/timelogs.py
+++ b/src/lifeos_cli/db/services/timelogs.py
@@ -387,7 +387,10 @@ def _apply_timelog_window_filters(stmt: Any, *, filters: TimelogQueryFilters) ->
 
 def _resolve_timelog_filters(filters: TimelogQueryFilters) -> TimelogQueryFilters:
     if filters.date_values:
-        return filters
+        return replace(
+            filters,
+            date_values=tuple(deduplicate_preserving_order(filters.date_values)),
+        )
     if filters.start_date is not None and filters.end_date is not None:
         window_start, window_end = get_utc_window_for_local_date_range(
             filters.start_date,

--- a/src/lifeos_cli/i18n.py
+++ b/src/lifeos_cli/i18n.py
@@ -20,14 +20,9 @@ LOCALES_DIR = Path(__file__).with_name("locales")
 DEFAULT_LOCALE = "en"
 
 
-def _normalize_locale_tag(locale_tag: str) -> str:
-    """Convert a BCP-47-like tag into the locale directory naming convention."""
-    return locale_tag.strip().replace("-", "_")
-
-
 def _locale_candidates(locale_tag: str) -> list[str]:
     """Return locale lookup candidates from most specific to least specific."""
-    normalized = _normalize_locale_tag(locale_tag)
+    normalized = locale_tag.strip().replace("-", "_")
     parts = [part for part in normalized.split("_") if part]
     if not parts:
         return [DEFAULT_LOCALE]

--- a/tests/test_cli_schedule.py
+++ b/tests/test_cli_schedule.py
@@ -216,6 +216,38 @@ def test_main_schedule_list_treats_repeated_dates_as_discrete_days(
     assert "date: 2026-04-10" in captured.out
 
 
+def test_main_schedule_list_deduplicates_repeated_dates(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    requested_dates: list[date] = []
+
+    async def fake_get_schedule_for_date(
+        session: object,
+        *,
+        target_date: date,
+        hide_overdue_unfinished: bool,
+    ) -> schedules.ScheduleDay:
+        requested_dates.append(target_date)
+        assert hide_overdue_unfinished is False
+        return schedules.ScheduleDay(
+            local_date=target_date,
+            tasks=(),
+            habit_actions=(),
+            events=(),
+        )
+
+    monkeypatch.setattr(db_session, "session_scope", make_session_scope())
+    monkeypatch.setattr(schedules, "get_schedule_for_date", fake_get_schedule_for_date)
+
+    exit_code = cli.main(["schedule", "list", "--date", "2026-04-10", "--date", "2026-04-10"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert requested_dates == [date(2026, 4, 10)]
+    assert captured.out.count("date: 2026-04-10") == 1
+
+
 def test_main_schedule_list_accepts_explicit_date_range(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],

--- a/tests/test_cli_time_args.py
+++ b/tests/test_cli_time_args.py
@@ -23,6 +23,16 @@ def test_resolve_date_selection_arguments_treats_repeated_date_as_discrete_dates
     assert selection.end_date is None
 
 
+def test_resolve_date_selection_arguments_deduplicates_repeated_dates() -> None:
+    selection = resolve_date_selection_arguments(
+        date_values=[date(2026, 4, 10), date(2026, 4, 10), date(2026, 4, 11)],
+    )
+
+    assert selection.date_values == (date(2026, 4, 10), date(2026, 4, 11))
+    assert selection.start_date is None
+    assert selection.end_date is None
+
+
 def test_resolve_date_selection_arguments_treats_explicit_bounds_as_inclusive_range() -> None:
     selection = resolve_date_selection_arguments(
         date_values=None,

--- a/tests/test_cli_timelog_stats.py
+++ b/tests/test_cli_timelog_stats.py
@@ -95,5 +95,71 @@ def test_main_timelog_stats_rebuild_reports_discrete_date_scope(
 
     assert exit_code == 0
     assert "Rebuilt timelog stats grouped by area for 2 dates." in captured.out
+    assert "dates: 2026-04-01, 2026-04-03" in captured.out
+    assert "start_date:" not in captured.out
+    assert "end_date:" not in captured.out
+
+
+def test_main_timelog_stats_rebuild_normalizes_discrete_date_boundaries(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    async def fake_rebuild(session: object, **kwargs: object) -> tuple[date, ...]:
+        assert kwargs["date_values"] == (date(2026, 4, 3), date(2026, 4, 1))
+        return (date(2026, 4, 3), date(2026, 4, 1))
+
+    monkeypatch.setattr(db_session, "session_scope", make_session_scope())
+    monkeypatch.setattr(timelog_stats, "rebuild_timelog_stats_groupby_area", fake_rebuild)
+
+    exit_code = cli.main(
+        [
+            "timelog",
+            "stats",
+            "rebuild",
+            "--date",
+            "2026-04-03",
+            "--date",
+            "2026-04-01",
+            "--date",
+            "2026-04-03",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "Rebuilt timelog stats grouped by area for 2 dates." in captured.out
+    assert "dates: 2026-04-03, 2026-04-01" in captured.out
+    assert "start_date:" not in captured.out
+    assert "end_date:" not in captured.out
+
+
+def test_main_timelog_stats_rebuild_range_reports_explicit_boundaries(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    async def fake_rebuild(session: object, **kwargs: object) -> tuple[date, ...]:
+        assert kwargs["date_values"] == ()
+        assert kwargs["start_date"] == date(2026, 4, 1)
+        assert kwargs["end_date"] == date(2026, 4, 3)
+        return (date(2026, 4, 1), date(2026, 4, 2), date(2026, 4, 3))
+
+    monkeypatch.setattr(db_session, "session_scope", make_session_scope())
+    monkeypatch.setattr(timelog_stats, "rebuild_timelog_stats_groupby_area", fake_rebuild)
+
+    exit_code = cli.main(
+        [
+            "timelog",
+            "stats",
+            "rebuild",
+            "--start-date",
+            "2026-04-01",
+            "--end-date",
+            "2026-04-03",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "Rebuilt timelog stats grouped by area for 3 dates." in captured.out
     assert "start_date: 2026-04-01" in captured.out
     assert "end_date: 2026-04-03" in captured.out

--- a/tests/test_domain_services_tasks_and_habits.py
+++ b/tests/test_domain_services_tasks_and_habits.py
@@ -1116,3 +1116,104 @@ def test_list_habit_actions_materializes_listed_occurrences(
     assert len(views) == 1
     assert views[0].id == action_id
     assert views[0].habit_title == "Daily Exercise"
+
+
+def test_build_habit_action_views_uses_discrete_target_dates_without_gap_expansion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    habit_id = UUID("77777777-7777-7777-7777-777777777777")
+    selected_dates = (date(2026, 4, 1), date(2026, 4, 30))
+    habit = SimpleNamespace(
+        id=habit_id,
+        title="Daily Exercise",
+        start_date=date(2026, 4, 1),
+        end_date=date(2026, 4, 30),
+        cadence_weekdays=None,
+    )
+
+    async def fake_load_candidate_habits(*args: object, **kwargs: object) -> list[object]:
+        assert kwargs["action_window"] is None
+        assert kwargs["target_dates"] == selected_dates
+        return [habit]
+
+    async def fake_load_materialized_actions(*args: object, **kwargs: object) -> list[object]:
+        assert kwargs["start_date"] is None
+        assert kwargs["end_date"] is None
+        assert kwargs["target_dates"] == selected_dates
+        return []
+
+    monkeypatch.setattr(habit_queries, "_load_candidate_habits", fake_load_candidate_habits)
+    monkeypatch.setattr(
+        habit_queries,
+        "_load_materialized_actions_for_habits",
+        fake_load_materialized_actions,
+    )
+
+    views = asyncio.run(
+        habit_queries._build_habit_action_views(
+            cast(Any, object()),
+            habit_id=None,
+            status=None,
+            action_window=None,
+            target_dates=selected_dates,
+            include_deleted=False,
+        )
+    )
+
+    assert [view.action_date for view in views] == [date(2026, 4, 1), date(2026, 4, 30)]
+
+
+def test_list_and_count_habit_actions_pass_discrete_dates_to_builder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_calls: list[dict[str, object]] = []
+    action_dates = (date(2026, 4, 3), date(2026, 4, 1))
+
+    async def fake_build_views(*args: object, **kwargs: object) -> list[object]:
+        captured_calls.append(kwargs)
+        return [
+            SimpleNamespace(
+                id=UUID("88888888-8888-8888-8888-888888888888"),
+                habit_id=UUID("77777777-7777-7777-7777-777777777777"),
+                habit_title="Daily Exercise",
+                action_date=action_dates[0],
+                status="pending",
+                notes=None,
+                created_at=None,
+                updated_at=None,
+                deleted_at=None,
+            ),
+            SimpleNamespace(
+                id=UUID("99999999-9999-9999-9999-999999999999"),
+                habit_id=UUID("77777777-7777-7777-7777-777777777777"),
+                habit_title="Daily Exercise",
+                action_date=action_dates[1],
+                status="pending",
+                notes=None,
+                created_at=None,
+                updated_at=None,
+                deleted_at=None,
+            ),
+        ]
+
+    monkeypatch.setattr(habit_queries, "_build_habit_action_views", fake_build_views)
+
+    views = asyncio.run(
+        habits.list_habit_actions(
+            cast(Any, object()),
+            date_values=(date(2026, 4, 3), date(2026, 4, 1), date(2026, 4, 3)),
+        )
+    )
+    count = asyncio.run(
+        habits.count_habit_actions(
+            cast(Any, object()),
+            date_values=(date(2026, 4, 3), date(2026, 4, 1), date(2026, 4, 3)),
+        )
+    )
+
+    assert [view.action_date for view in views] == [date(2026, 4, 3), date(2026, 4, 1)]
+    assert count == 2
+    assert captured_calls[0]["target_dates"] == (date(2026, 4, 3), date(2026, 4, 1))
+    assert captured_calls[0]["action_window"] is None
+    assert captured_calls[1]["target_dates"] == (date(2026, 4, 3), date(2026, 4, 1))
+    assert captured_calls[1]["action_window"] is None

--- a/tests/test_domain_services_time.py
+++ b/tests/test_domain_services_time.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock
@@ -761,6 +761,26 @@ def test_list_events_with_one_sided_window_uses_overlap_query(
     statement_sql = str(session.statements[0])
     assert "end_time IS NULL OR" in statement_sql
     assert "end_time >=" in statement_sql
+
+
+def test_normalize_event_filters_deduplicates_discrete_dates() -> None:
+    filters = events._normalize_event_filters(
+        events.EventQueryFilters(
+            date_values=(date(2026, 4, 10), date(2026, 4, 10), date(2026, 4, 12))
+        )
+    )
+
+    assert filters.date_values == (date(2026, 4, 10), date(2026, 4, 12))
+
+
+def test_resolve_timelog_filters_deduplicates_discrete_dates() -> None:
+    filters = timelogs._resolve_timelog_filters(
+        timelogs.TimelogQueryFilters(
+            date_values=(date(2026, 4, 10), date(2026, 4, 10), date(2026, 4, 12))
+        )
+    )
+
+    assert filters.date_values == (date(2026, 4, 10), date(2026, 4, 12))
 
 
 def test_update_timelog_can_clear_optional_fields(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_timelog_stats.py
+++ b/tests/test_timelog_stats.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Iterator
 from datetime import date, datetime, timezone
+from typing import Any, cast
 
 import pytest
 
@@ -66,3 +68,38 @@ def test_get_year_bounds_returns_full_calendar_year() -> None:
 
     assert start_date == date(2026, 1, 1)
     assert end_date == date(2026, 12, 31)
+
+
+def test_rebuild_timelog_stats_groupby_area_sorts_and_deduplicates_discrete_dates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_daily_dates: list[tuple[date, ...]] = []
+    captured_aggregated_dates: list[tuple[date, ...]] = []
+
+    async def fake_recompute_daily(_: object, *, local_dates: tuple[date, ...]) -> None:
+        captured_daily_dates.append(local_dates)
+
+    async def fake_recompute_aggregated(_: object, *, local_dates: tuple[date, ...]) -> None:
+        captured_aggregated_dates.append(local_dates)
+
+    monkeypatch.setattr(
+        timelog_stats,
+        "recompute_daily_timelog_stats_groupby_area_for_dates",
+        fake_recompute_daily,
+    )
+    monkeypatch.setattr(
+        timelog_stats,
+        "recompute_aggregated_timelog_stats_groupby_area_for_dates",
+        fake_recompute_aggregated,
+    )
+
+    rebuilt_dates = asyncio.run(
+        timelog_stats.rebuild_timelog_stats_groupby_area(
+            cast(Any, object()),
+            date_values=(date(2026, 4, 3), date(2026, 4, 1), date(2026, 4, 3)),
+        )
+    )
+
+    assert rebuilt_dates == (date(2026, 4, 1), date(2026, 4, 3))
+    assert captured_daily_dates == [(date(2026, 4, 1), date(2026, 4, 3))]
+    assert captured_aggregated_dates == [(date(2026, 4, 1), date(2026, 4, 3))]


### PR DESCRIPTION
## 概要
- 承接 `#103` 合并后的 follow-up，统一离散 `--date` 在后续链路中的语义。
- 修复将离散日期误当成连续范围的问题，并清理重复 `--date` 的共性处理缺口。
- 额外完成多轮全仓薄壳函数审查，移除无新增语义、仅单点转发的私有 helper，保持调用点直接、可读。
- 补齐 CLI 与 service 层回归测试，覆盖离散日期、显式范围与重复日期场景。

## 按模块说明

### `cli_support/time_args.py`
- 共享日期参数解析现在会对重复 `--date` 去重，并保留首次出现顺序。
- 明确保持两套语义：重复 `--date` 表示离散日期集合，`--start-date/--end-date` 表示包含端点的连续范围。
- 内联无新增语义的私有离散日期归一化薄壳，保留最小必要逻辑。

### `db/services/habit_queries.py`
- `habit-action list/count` 改为真正按离散 `target_dates` 处理，不再先折叠成 `min/max` 连续窗口后再展开中间日期。
- 候选 habit 过滤与 materialized action 查询都按离散日期执行，避免稀疏日期查询时生成无意义的中间 occurrence。
- 继续内联只在局部使用、没有额外语义增益的 occurrence/filter/sort 私有 helper。

### `db/services/events.py` / `db/services/timelogs.py`
- 对离散日期过滤做统一去重，避免重复同一天时出现冗余查询与不一致行为。
- 删除只用于构造空依赖快照的局部私有 helper，直接在调用点构造快照值。

### `db/services/timelog_stats.py` / `cli_support/resources/timelog/handlers.py`
- `timelog stats rebuild` 的离散日期重建会使用稳定的排序去重结果。
- 当用户使用离散 `--date` 时，CLI 输出 `date:` / `dates:`；只有显式 `--start-date/--end-date` 时才输出 `start_date:` / `end_date:`。

### `i18n.py` / `db/services/schedule_queries.py` / `cli_support/resources/timelog/bulk_add.py`
- 在全仓审查中，移除了只做一层 locale/tag 规范化、单次映射转发、或局部输入归一化的私有薄壳函数，直接内联到唯一调用点。
- 保留其余格式化、排序和领域语义 helper，不做机械性删除。

### `tests`
- 新增并更新共享日期解析、`schedule list`、`timelog stats rebuild`、`habit-action list/count`、`event` / `timelog` service 过滤等回归测试。
- 已通过 `bash ./scripts/doctor.sh` 全量校验，包括 PostgreSQL CLI 集成测试。

## 关联
- Closes #105
- Related #102
