### PR TITLE
feat: default sqlite init and consolidate database policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,11 +19,8 @@ The following rules apply to coding agent collaboration in this repository. Thes
 
 - Use Simplified Chinese for issues, PR descriptions, comments, and review notes.
 - Use English for code, comments, commit messages, and canonical repository documents.
-- Localized Markdown companions are allowed when they are explicitly scoped, linked from the
-  canonical English document, and kept aligned with it.
-- Keep the root `README.md` in English as the canonical repository entrypoint. Localized companions
-  such as `README.zh-Hans.md` must link back to `README.md`, and `README.md` should link to the
-  available localized companion documents.
+- Localized Markdown companions are allowed when they are explicitly scoped, linked from the canonical English document, and kept aligned with it.
+- Keep the root `README.md` in English as the canonical repository entrypoint. Localized companions such as `README.zh-Hans.md` must link back to `README.md`, and `README.md` should link to the available localized companion documents.
 - For multi-line PR bodies or comments, write to a temporary file first and pass it through `gh`.
 
 ## 4. Validation and Release Safety
@@ -32,9 +29,7 @@ The following rules apply to coding agent collaboration in this repository. Thes
   ```bash
   bash ./scripts/doctor.sh
   ```
-- Treat the dead-code scan as part of the primary validation gate. Do not delete framework-driven
-  symbols only to satisfy generic static analysis; update `scripts/vulture_whitelist.py` when a
-  tool-required symbol must remain intentionally reachable.
+- Treat the dead-code scan as part of the primary validation gate. Do not delete framework-driven symbols only to satisfy generic static analysis; update `scripts/vulture_whitelist.py` when a tool-required symbol must remain intentionally reachable.
 - If changes affect compatibility claims, packaging metadata, or CI, validate the impacted Python versions explicitly.
 - Keep release-related changes aligned with:
   - [pyproject.toml](pyproject.toml)
@@ -46,8 +41,7 @@ The following rules apply to coding agent collaboration in this repository. Thes
 
 - Never commit secrets, tokens, private keys, or `.env` contents.
 - Ensure logs and examples do not expose credentials or sensitive local paths unintentionally.
-- Update [SECURITY.md](SECURITY.md), [README.md](README.md), localized README companions, and
-  release-related docs when changing publishing, dependency, or security-sensitive behavior.
+- Update [SECURITY.md](SECURITY.md), [README.md](README.md), localized README companions, and release-related docs when changing publishing, dependency, or security-sensitive behavior.
 
 ## 6. CLI Help and Tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,10 @@ LIFEOS_TEST_DATABASE_URL=postgresql+psycopg://postgres:<password>@127.0.0.1:5432
 bash ./scripts/integration_tests.sh
 ```
 
+Integration tests normalize `LIFEOS_TEST_DATABASE_URL` to a database name that contains `test`.
+If you point the variable at `.../lifeos`, the test support layer rewrites it to `.../lifeos_test`
+before any CLI setup or cleanup runs.
+
 For local convenience, `scripts/doctor.sh` and `scripts/integration_tests.sh` also load a
 project-root `.env` file when present. Keep `.env` untracked and use it only for machine-local
 development settings such as `LIFEOS_TEST_DATABASE_URL`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,12 +31,7 @@ Run the default validation baseline before opening a PR:
 bash ./scripts/doctor.sh
 ```
 
-The default validation baseline includes dead-code scanning through `vulture`.
-It validates locked dependency resolution, runs lint plus the default non-integration test suite,
-exports runtime requirements for `pip-audit`, builds package artifacts, and then calls
-`bash ./scripts/integration_tests.sh` as the explicit PostgreSQL-backed integration entrypoint.
-When `LIFEOS_TEST_DATABASE_URL` is unset, the integration script reports an explicit skip and
-`doctor.sh` finishes with a warning that PostgreSQL CLI coverage did not run.
+The default validation baseline includes dead-code scanning through `vulture`. It validates locked dependency resolution, runs lint plus the default non-integration test suite, exports runtime requirements for `pip-audit`, builds package artifacts, and then calls `bash ./scripts/integration_tests.sh` as the explicit PostgreSQL-backed integration entrypoint. When `LIFEOS_TEST_DATABASE_URL` is unset, the integration script reports an explicit skip and `doctor.sh` finishes with a warning that PostgreSQL CLI coverage did not run.
 
 If you change CI, packaging metadata, or compatibility declarations, also validate the relevant interpreter targets explicitly. Examples:
 
@@ -54,13 +49,9 @@ LIFEOS_TEST_DATABASE_URL=postgresql+psycopg://postgres:<password>@127.0.0.1:5432
 bash ./scripts/integration_tests.sh
 ```
 
-Integration tests normalize `LIFEOS_TEST_DATABASE_URL` to a database name that contains `test`.
-If you point the variable at `.../lifeos`, the test support layer rewrites it to `.../lifeos_test`
-before any CLI setup or cleanup runs.
+Integration tests normalize `LIFEOS_TEST_DATABASE_URL` to a database name that contains `test`. If you point the variable at `.../lifeos`, the test support layer rewrites it to `.../lifeos_test` before any CLI setup or cleanup runs.
 
-For local convenience, `scripts/doctor.sh` and `scripts/integration_tests.sh` also load a
-project-root `.env` file when present. Keep `.env` untracked and use it only for machine-local
-development settings such as `LIFEOS_TEST_DATABASE_URL`.
+For local convenience, `scripts/doctor.sh` and `scripts/integration_tests.sh` also load a project-root `.env` file when present. Keep `.env` untracked and use it only for machine-local development settings such as `LIFEOS_TEST_DATABASE_URL`.
 
 If you change dependency or release workflows, also run:
 
@@ -71,27 +62,20 @@ bash ./scripts/dependency_health.sh
 Dependency maintenance policy:
 
 - `.github/dependabot.yml` opens a single weekly grouped version-update PR for `uv`.
-- `bash ./scripts/dependency_health.sh` remains the explicit maintainer audit flow for outdated
-  packages and dependency-related health checks.
+- `bash ./scripts/dependency_health.sh` remains the explicit maintainer audit flow for outdated packages and dependency-related health checks.
 
 Static-analysis governance:
 
-- Treat framework-driven symbols as intentional API surface when they are required by the toolchain.
-  Examples in this repository include Alembic revision metadata, pytest fixtures and `pytestmark`,
-  SQLAlchemy declarative hooks, and argparse translation hooks.
+- Treat framework-driven symbols as intentional API surface when they are required by the toolchain. Examples in this repository include Alembic revision metadata, pytest fixtures and `pytestmark`, SQLAlchemy declarative hooks, and argparse translation hooks.
 - Do not delete those symbols just to satisfy a generic dead-code scanner.
-- `scripts/dead_code_check.sh` keeps the name-based ignore list for Alembic revision metadata and
-  module-level `pytestmark`; use `scripts/vulture_whitelist.py` for importable framework symbols
-  that must stay intentionally reachable.
+- `scripts/dead_code_check.sh` keeps the name-based ignore list for Alembic revision metadata and module-level `pytestmark`; use `scripts/vulture_whitelist.py` for importable framework symbols that must stay intentionally reachable.
 - Keep intentional false positives documented in `scripts/vulture_whitelist.py`.
-- If you add a new framework-driven symbol that `vulture` cannot resolve, update the whitelist in
-  the same change.
+- If you add a new framework-driven symbol that `vulture` cannot resolve, update the whitelist in the same change.
 
 ## Change Expectations
 
 - Keep code, comments, commit messages, and canonical repository docs in English.
-- Localized Markdown companions are allowed when the English source stays canonical, the documents
-  are cross-linked, and the localized copy is updated together with the source.
+- Localized Markdown companions are allowed when the English source stays canonical, the documents are cross-linked, and the localized copy is updated together with the source.
 - Keep issue and PR collaboration in Simplified Chinese for this repository.
 - Prefer explicit, additive changes over hidden behavioral shifts.
 - Keep Python compatibility declarations, CI matrices, and packaging metadata consistent with each other.
@@ -118,10 +102,8 @@ Update docs together with code whenever you change:
 Documentation language policy:
 
 - Keep `README.md` as the canonical English entry document.
-- Localized entry documents such as `README.zh-Hans.md` are allowed when they clearly link to the
-  canonical English version and the English version links back to them.
-- Avoid duplicating command-level facts in repository docs across languages. CLI help remains the
-  primary command reference.
+- Localized entry documents such as `README.zh-Hans.md` are allowed when they clearly link to the canonical English version and the English version links back to them.
+- Avoid duplicating command-level facts in repository docs across languages. CLI help remains the primary command reference.
 
 For CLI-facing changes:
 

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ Initialize your local setup:
 lifeos init
 ```
 
-When no database URL is configured yet, `lifeos init` defaults to a local SQLite database at
-`~/.lifeos/lifeos.db`.
+For local-first use, `lifeos init` can bootstrap SQLite without requiring a separate database
+service. Use `lifeos init --help` for backend-specific defaults and examples.
 
 You can run that step yourself, or ask an agent that can run terminal commands to do it for you.
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ Initialize your local setup:
 lifeos init
 ```
 
+Without an explicit `--database-url`, `lifeos init` defaults to a local SQLite database at
+`~/.lifeos/lifeos.db`.
+
 You can run that step yourself, or ask an agent that can run terminal commands to do it for you.
 
 See the available command surface:

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Initialize your local setup:
 lifeos init
 ```
 
-Without an explicit `--database-url`, `lifeos init` defaults to a local SQLite database at
+When no database URL is configured yet, `lifeos init` defaults to a local SQLite database at
 `~/.lifeos/lifeos.db`.
 
 You can run that step yourself, or ask an agent that can run terminal commands to do it for you.

--- a/README.md
+++ b/README.md
@@ -10,13 +10,11 @@
 |_____||___| |_|    |_____| \___/  |____/
 ```
 
-`lifeos-cli` is a terminal-native LifeOS for people who want one structured system for intentions,
-plans, execution, reflection, and reality.
+`lifeos-cli` is a terminal-native LifeOS for people who want one structured system for intentions, plans, execution, reflection, and reality.
 
 ## Why It Exists
 
-Most personal systems fragment life into disconnected tools. Tasks live in one place, calendars in
-another, notes somewhere else, and actual time spent disappears into scattered logs.
+Most personal systems fragment life into disconnected tools. Tasks live in one place, calendars in another, notes somewhere else, and actual time spent disappears into scattered logs.
 
 That makes it unnecessarily hard to answer practical questions such as:
 
@@ -31,8 +29,7 @@ It gives structure to both sides of life:
 - intention: visions, tasks, habits, and planned events
 - reality: notes, timelogs, completed habit actions, and relationship records
 
-The goal is not just storage, but one CLI interface for self-management, reflection, and
-automation.
+The goal is not just storage, but one CLI interface for self-management, reflection, and automation.
 
 ## Getting Started
 
@@ -59,8 +56,7 @@ Initialize your local setup:
 lifeos init
 ```
 
-For local-first use, `lifeos init` can bootstrap SQLite without requiring a separate database
-service. Use `lifeos init --help` for backend-specific defaults and examples.
+For local-first use, `lifeos init` can bootstrap SQLite without requiring a separate database service. Use `lifeos init --help` for backend-specific defaults and examples.
 
 You can run that step yourself, or ask an agent that can run terminal commands to do it for you.
 
@@ -91,9 +87,7 @@ For complete CLI usage, workflows, and output conventions, see [docs/cli.md](doc
 
 ## Agent Use (Recommended)
 
-Any agent runtime that can execute terminal commands and inspect command output can operate the
-same CLI. That includes Codex, OpenCode, Swival, Claude Code, Cursor, Gemini CLI, OpenClaw, or
-your own setup.
+Any agent runtime that can execute terminal commands and inspect command output can operate the same CLI. That includes Codex, OpenCode, Swival, Claude Code, Cursor, Gemini CLI, OpenClaw, or your own setup.
 
 - stable grammar: `lifeos <resource> <action> [arguments] [options]`
 - help-first command model, with `--help` as the primary command reference
@@ -117,13 +111,10 @@ The current system already covers the core building blocks of a practical LifeOS
 
 Cross-cutting capabilities:
 
-- a `schedule` read model that aggregates tasks, habit actions, and planned events into day and
-  range views
-- recurring event expansion and recurring habit cadence support, including on-demand habit-action
-  materialization
+- a `schedule` read model that aggregates tasks, habit actions, and planned events into day and range views
+- recurring event expansion and recurring habit cadence support, including on-demand habit-action materialization
 - generic note associations across tasks, visions, events, people, timelogs, and tags
-- persisted runtime configuration for database access plus preferences such as timezone, language,
-  day boundary, week boundary, and vision experience defaults
+- persisted runtime configuration for database access plus preferences such as timezone, language, day boundary, week boundary, and vision experience defaults
 - localized CLI help and stable summary-table output for direct human use and agent consumption
 
 ## Project Policies

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -14,8 +14,7 @@ English: [README.md](README.md)
 
 ## 为什么做它
 
-大多数个人系统会把生活拆散到多个互不相通的工具里。任务在一个地方，日程在另一个地方，笔记在别处，
-实际投入的时间又散落在各种零碎记录里。
+大多数个人系统会把生活拆散到多个互不相通的工具里。任务在一个地方，日程在另一个地方，笔记在别处，实际投入的时间又散落在各种零碎记录里。
 
 这会让一些本来很实际的问题变得很难回答：
 
@@ -88,9 +87,7 @@ lifeos timelog list --date 2026-04-13
 
 ## Agent 使用（推荐）
 
-任意能够执行终端命令并读取命令输出的 agent runtime 都可以操作同一套 CLI。
-这包括但不限于 Codex、OpenCode、Swival、Claude Code、Cursor、Gemini CLI、OpenClaw，
-以及你自己的自定义 agent runtime。
+任意能够执行终端命令并读取命令输出的 agent runtime 都可以操作同一套 CLI。这包括但不限于 Codex、OpenCode、Swival、Claude Code、Cursor、Gemini CLI、OpenClaw，以及你自己的自定义 agent runtime。
 
 - 稳定的命令语法：`lifeos <resource> <action> [arguments] [options]`
 - 以 `--help` 作为主命令参考的 help-first 模型

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -57,7 +57,7 @@ uv tool install --upgrade "lifeos-cli[postgres]"
 lifeos init
 ```
 
-如果当前还没有配置数据库 URL，`lifeos init` 默认会使用位于 `~/.lifeos/lifeos.db` 的本地 SQLite 数据库。
+对于本地优先的单机使用，`lifeos init` 可以直接引导 SQLite，无需额外启动数据库服务。后端默认值和示例以 `lifeos init --help` 为准。
 
 这一步既可以由人类自己执行，也可以交给能执行终端命令的 agent 来代为完成。
 

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -57,7 +57,7 @@ uv tool install --upgrade "lifeos-cli[postgres]"
 lifeos init
 ```
 
-如果没有显式提供 `--database-url`，`lifeos init` 默认会使用位于 `~/.lifeos/lifeos.db` 的本地 SQLite 数据库。
+如果当前还没有配置数据库 URL，`lifeos init` 默认会使用位于 `~/.lifeos/lifeos.db` 的本地 SQLite 数据库。
 
 这一步既可以由人类自己执行，也可以交给能执行终端命令的 agent 来代为完成。
 

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -57,6 +57,8 @@ uv tool install --upgrade "lifeos-cli[postgres]"
 lifeos init
 ```
 
+如果没有显式提供 `--database-url`，`lifeos init` 默认会使用位于 `~/.lifeos/lifeos.db` 的本地 SQLite 数据库。
+
 这一步既可以由人类自己执行，也可以交给能执行终端命令的 agent 来代为完成。
 
 查看 CLI 命令面：

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2,11 +2,9 @@
 
 This document is a secondary overview of the current `lifeos` CLI.
 
-Command-specific facts such as arguments, examples, constraints, and command notes must live in
-`lifeos --help`, `lifeos <resource> --help`, and `lifeos <resource> <action> --help`.
+Command-specific facts such as arguments, examples, constraints, and command notes must live in `lifeos --help`, `lifeos <resource> --help`, and `lifeos <resource> <action> --help`.
 
-Use this document for cross-command guidance only. Do not treat it as the source of truth for
-resource-level command details.
+Use this document for cross-command guidance only. Do not treat it as the source of truth for resource-level command details.
 
 ## Command Grammar
 
@@ -97,8 +95,7 @@ The current command tree is organized around a few stable families:
 - scheduling and tracking resources such as `event`, `schedule`, `timelog`, `habit`, and `habit-action`
 - system and portability commands such as `init`, `config`, `db`, and `data`
 
-Use `lifeos <resource> --help` to enter one family and then follow the resource-level help into the
-action or namespace you need.
+Use `lifeos <resource> --help` to enter one family and then follow the resource-level help into the action or namespace you need.
 
 ## Safety Model
 
@@ -121,5 +118,4 @@ If the caller is an agent or another automation layer:
 - use `Preference language` as the payload language for titles, descriptions, and note content unless the human explicitly asks for another language
 - keep flows identifier-driven after discovery
 - decide whether the record belongs to the human, the agent, or both before writing data
-- prefer resource help and action help over repository docs whenever an operation depends on exact
-  flags, scope rules, or examples
+- prefer resource help and action help over repository docs whenever an operation depends on exact flags, scope rules, or examples

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -59,6 +59,9 @@ Initialize local configuration:
 lifeos init
 ```
 
+When `--database-url` is omitted, `lifeos init` defaults to a local SQLite database file at
+`~/.lifeos/lifeos.db`.
+
 Inspect the effective runtime configuration:
 
 ```bash

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -59,9 +59,6 @@ Initialize local configuration:
 lifeos init
 ```
 
-When no database URL is configured yet, `lifeos init` defaults to a local SQLite database file at
-`~/.lifeos/lifeos.db`.
-
 Inspect the effective runtime configuration:
 
 ```bash

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -59,7 +59,7 @@ Initialize local configuration:
 lifeos init
 ```
 
-When `--database-url` is omitted, `lifeos init` defaults to a local SQLite database file at
+When no database URL is configured yet, `lifeos init` defaults to a local SQLite database file at
 `~/.lifeos/lifeos.db`.
 
 Inspect the effective runtime configuration:

--- a/src/lifeos_cli/application/configuration.py
+++ b/src/lifeos_cli/application/configuration.py
@@ -17,6 +17,7 @@ from lifeos_cli.config import (
     PreferencesSettings,
     database_drivername,
     database_url_supports_schema,
+    default_sqlite_database_url,
     detect_default_language,
     detect_default_timezone,
     ensure_database_driver_available,
@@ -93,7 +94,7 @@ def build_database_settings(request: InitializationRequest) -> DatabaseSettings:
             database_echo=False,
             config_file=config_path,
         )
-    database_url = request.database_url or current.database_url
+    database_url = request.database_url or current.database_url or default_sqlite_database_url()
     database_echo = current.database_echo if request.echo is None else request.echo
     if database_url is not None:
         database_url = validate_database_url(database_url)
@@ -124,11 +125,6 @@ def build_database_settings(request: InitializationRequest) -> DatabaseSettings:
             database_schema = request.prompts.prompt_database_schema(database_schema)
         if request.echo is None:
             database_echo = request.prompts.prompt_database_echo(database_echo)
-
-    if database_url is None:
-        raise ConfigurationError(
-            "Database URL is required. Provide --database-url or run `lifeos init` interactively."
-        )
 
     return DatabaseSettings(
         database_url=database_url,

--- a/src/lifeos_cli/application/configuration.py
+++ b/src/lifeos_cli/application/configuration.py
@@ -15,8 +15,7 @@ from lifeos_cli.config import (
     ConfigurationError,
     DatabaseSettings,
     PreferencesSettings,
-    database_backend_policy,
-    database_url_supports_schema,
+    backend_policy_for_database_url,
     default_sqlite_database_url,
     detect_default_language,
     detect_default_timezone,
@@ -100,7 +99,9 @@ def build_database_settings(request: InitializationRequest) -> DatabaseSettings:
         database_url = validate_database_url(database_url)
         ensure_database_driver_available(database_url)
     supports_database_schema = (
-        database_url_supports_schema(database_url) if database_url is not None else True
+        backend_policy_for_database_url(database_url).supports_schema
+        if database_url is not None
+        else True
     )
     database_schema = (
         request.schema
@@ -118,7 +119,7 @@ def build_database_settings(request: InitializationRequest) -> DatabaseSettings:
         if request.database_url is None:
             database_url = request.prompts.prompt_database_url(database_url)
             ensure_database_driver_available(database_url)
-            supports_database_schema = database_url_supports_schema(database_url)
+            supports_database_schema = backend_policy_for_database_url(database_url).supports_schema
             if not supports_database_schema:
                 database_schema = None
         if request.schema is None and supports_database_schema:
@@ -216,7 +217,7 @@ def set_runtime_config_value(*, key: str, value: str) -> ConfigSetResult:
         validated_database_url = validate_database_url(value)
         ensure_database_driver_available(validated_database_url)
         current_backend = database_settings.database_backend
-        next_backend = database_backend_policy(validated_database_url).backend_name
+        next_backend = backend_policy_for_database_url(validated_database_url).backend_name
         if current_backend is not None and current_backend != next_backend:
             raise ConfigurationError(
                 "Switching between PostgreSQL and SQLite with `config set database.url` is not "

--- a/src/lifeos_cli/application/configuration.py
+++ b/src/lifeos_cli/application/configuration.py
@@ -15,7 +15,7 @@ from lifeos_cli.config import (
     ConfigurationError,
     DatabaseSettings,
     PreferencesSettings,
-    database_drivername,
+    database_backend_policy,
     database_url_supports_schema,
     default_sqlite_database_url,
     detect_default_language,
@@ -216,7 +216,7 @@ def set_runtime_config_value(*, key: str, value: str) -> ConfigSetResult:
         validated_database_url = validate_database_url(value)
         ensure_database_driver_available(validated_database_url)
         current_backend = database_settings.database_backend
-        next_backend = database_drivername(validated_database_url).split("+", maxsplit=1)[0]
+        next_backend = database_backend_policy(validated_database_url).backend_name
         if current_backend is not None and current_backend != next_backend:
             raise ConfigurationError(
                 "Switching between PostgreSQL and SQLite with `config set database.url` is not "

--- a/src/lifeos_cli/application/configuration.py
+++ b/src/lifeos_cli/application/configuration.py
@@ -15,7 +15,7 @@ from lifeos_cli.config import (
     ConfigurationError,
     DatabaseSettings,
     PreferencesSettings,
-    backend_policy_for_database_url,
+    database_policy,
     default_sqlite_database_url,
     detect_default_language,
     detect_default_timezone,
@@ -99,9 +99,7 @@ def build_database_settings(request: InitializationRequest) -> DatabaseSettings:
         database_url = validate_database_url(database_url)
         ensure_database_driver_available(database_url)
     supports_database_schema = (
-        backend_policy_for_database_url(database_url).supports_schema
-        if database_url is not None
-        else True
+        database_policy(database_url).supports_schema if database_url is not None else True
     )
     database_schema = (
         request.schema
@@ -119,7 +117,7 @@ def build_database_settings(request: InitializationRequest) -> DatabaseSettings:
         if request.database_url is None:
             database_url = request.prompts.prompt_database_url(database_url)
             ensure_database_driver_available(database_url)
-            supports_database_schema = backend_policy_for_database_url(database_url).supports_schema
+            supports_database_schema = database_policy(database_url).supports_schema
             if not supports_database_schema:
                 database_schema = None
         if request.schema is None and supports_database_schema:
@@ -217,7 +215,7 @@ def set_runtime_config_value(*, key: str, value: str) -> ConfigSetResult:
         validated_database_url = validate_database_url(value)
         ensure_database_driver_available(validated_database_url)
         current_backend = database_settings.database_backend
-        next_backend = backend_policy_for_database_url(validated_database_url).backend_name
+        next_backend = database_policy(validated_database_url).backend_name
         if current_backend is not None and current_backend != next_backend:
             raise ConfigurationError(
                 "Switching between PostgreSQL and SQLite with `config set database.url` is not "

--- a/src/lifeos_cli/cli_support/runtime_utils.py
+++ b/src/lifeos_cli/cli_support/runtime_utils.py
@@ -93,29 +93,9 @@ def print_database_runtime_error(exc: BaseException) -> int:
     guidance = None
     if isinstance(exc, OperationalError):
         details = str(exc).lower()
-        backend = settings.database_backend
-        if "no password supplied" in details or "password authentication failed" in details:
-            guidance = (
-                "Authentication failed. Check the username/password in the database URL, "
-                "or update them with `lifeos init`."
-            )
-        elif backend == "postgresql" and "does not exist" in details:
-            guidance = (
-                "The configured PostgreSQL database does not exist yet. Create it first, "
-                "then run `lifeos db upgrade`."
-            )
-        elif backend == "postgresql" and (
-            "connection refused" in details or "could not connect" in details
-        ):
-            guidance = (
-                "PostgreSQL is not reachable. Ensure the server is installed, running, "
-                "and listening on the configured host/port."
-            )
-        elif backend == "sqlite" and "unable to open database file" in details:
-            guidance = (
-                "SQLite could not open the configured database file. Ensure the parent "
-                "directory exists and is writable."
-            )
+        policy = settings.backend_policy
+        if policy is not None:
+            guidance = policy.runtime_error_guidance(details)
     if guidance is not None:
         print(guidance, file=sys.stderr)
     print("Run `lifeos init` to create or update local configuration.", file=sys.stderr)

--- a/src/lifeos_cli/cli_support/system/config_commands.py
+++ b/src/lifeos_cli/cli_support/system/config_commands.py
@@ -106,7 +106,7 @@ def build_config_parser(subparsers: argparse._SubParsersAction[argparse.Argument
                 "lifeos config set preferences.timezone America/Toronto",
                 "lifeos config set database.echo true",
                 "lifeos config set database.url "
-                "postgresql+psycopg://<db-user>:<db-password>@localhost:5432/lifeos "
+                "sqlite+aiosqlite:///$HOME/.lifeos/work.db "
                 "--show-secrets",
                 "lifeos config set preferences.vision_experience_rate_per_hour 120",
             ),

--- a/src/lifeos_cli/cli_support/system/init_commands.py
+++ b/src/lifeos_cli/cli_support/system/init_commands.py
@@ -36,6 +36,7 @@ def build_init_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentPa
                 _(
                     "system.init_commands.configuration_is_written_to_config_lifeos_config_toml_by_default"
                 ),
+                _("system.init_commands.database_url_defaults_to_local_sqlite_file_when_omitted"),
                 _(
                     "system.init_commands.environment_variables_still_override_config_file_values_at_runtime"
                 ),

--- a/src/lifeos_cli/config.py
+++ b/src/lifeos_cli/config.py
@@ -57,7 +57,7 @@ def _parse_database_url(database_url: str) -> tuple[str, URL]:
     return normalized, parsed
 
 
-def backend_policy_for_database_url(database_url: str) -> DatabaseBackendPolicy:
+def database_policy(database_url: str) -> DatabaseBackendPolicy:
     """Return the backend policy for one validated database URL."""
     _, parsed = _parse_database_url(database_url)
     return backend_policy_for_drivername(parsed.drivername)
@@ -65,7 +65,7 @@ def backend_policy_for_database_url(database_url: str) -> DatabaseBackendPolicy:
 
 def ensure_database_driver_available(database_url: str) -> None:
     """Ensure the configured SQLAlchemy driver dependencies are installed."""
-    policy = backend_policy_for_database_url(database_url)
+    policy = database_policy(database_url)
     if policy.required_driver_module is None:
         return
     try:
@@ -114,7 +114,7 @@ def normalize_database_schema(
     """Normalize one schema value against the target database URL."""
     if database_url is None:
         return validate_database_schema_name(configured_schema or DEFAULT_DATABASE_SCHEMA)
-    if backend_policy_for_database_url(database_url).supports_schema:
+    if database_policy(database_url).supports_schema:
         return validate_database_schema_name(configured_schema or DEFAULT_DATABASE_SCHEMA)
     if explicit and configured_schema is not None:
         raise ConfigurationError(
@@ -461,7 +461,7 @@ class DatabaseSettings:
         """Return the backend policy for the configured database URL when available."""
         if self.database_url is None:
             return None
-        return backend_policy_for_database_url(self.database_url)
+        return database_policy(self.database_url)
 
     @property
     def database_backend(self) -> str | None:

--- a/src/lifeos_cli/config.py
+++ b/src/lifeos_cli/config.py
@@ -57,25 +57,15 @@ def _parse_database_url(database_url: str) -> tuple[str, URL]:
     return normalized, parsed
 
 
-def database_drivername(database_url: str) -> str:
-    """Return the SQLAlchemy drivername for one validated database URL."""
-    _, parsed = _parse_database_url(database_url)
-    return parsed.drivername
-
-
-def database_backend_policy(database_url: str) -> DatabaseBackendPolicy:
+def backend_policy_for_database_url(database_url: str) -> DatabaseBackendPolicy:
     """Return the backend policy for one validated database URL."""
-    return backend_policy_for_drivername(database_drivername(database_url))
-
-
-def database_url_supports_schema(database_url: str) -> bool:
-    """Return whether one database URL supports schema binding."""
-    return database_backend_policy(database_url).supports_schema
+    _, parsed = _parse_database_url(database_url)
+    return backend_policy_for_drivername(parsed.drivername)
 
 
 def ensure_database_driver_available(database_url: str) -> None:
     """Ensure the configured SQLAlchemy driver dependencies are installed."""
-    policy = database_backend_policy(database_url)
+    policy = backend_policy_for_database_url(database_url)
     if policy.required_driver_module is None:
         return
     try:
@@ -124,7 +114,7 @@ def normalize_database_schema(
     """Normalize one schema value against the target database URL."""
     if database_url is None:
         return validate_database_schema_name(configured_schema or DEFAULT_DATABASE_SCHEMA)
-    if database_url_supports_schema(database_url):
+    if backend_policy_for_database_url(database_url).supports_schema:
         return validate_database_schema_name(configured_schema or DEFAULT_DATABASE_SCHEMA)
     if explicit and configured_schema is not None:
         raise ConfigurationError(
@@ -353,14 +343,10 @@ def resolve_config_path(env: Mapping[str, str] | None = None) -> Path:
     return DEFAULT_CONFIG_PATH
 
 
-def default_sqlite_database_path(env: Mapping[str, str] | None = None) -> Path:
-    """Return the default file-backed SQLite database path."""
-    return resolve_config_path(env).parent / DEFAULT_SQLITE_DATABASE_FILENAME
-
-
 def default_sqlite_database_url(env: Mapping[str, str] | None = None) -> str:
     """Return the normalized default SQLite database URL."""
-    return validate_database_url(f"sqlite+aiosqlite:///{default_sqlite_database_path(env)}")
+    database_path = resolve_config_path(env).parent / DEFAULT_SQLITE_DATABASE_FILENAME
+    return validate_database_url(f"sqlite+aiosqlite:///{database_path}")
 
 
 def load_config_file(config_path: Path) -> dict[str, Any]:
@@ -471,19 +457,11 @@ class DatabaseSettings:
         return parsed.render_as_string(hide_password=not show_secrets)
 
     @property
-    def database_drivername(self) -> str | None:
-        """Return the configured SQLAlchemy drivername when available."""
-        if self.database_url is None:
-            return None
-        return database_drivername(self.database_url)
-
-    @property
     def backend_policy(self) -> DatabaseBackendPolicy | None:
         """Return the backend policy for the configured database URL when available."""
-        drivername = self.database_drivername
-        if drivername is None:
+        if self.database_url is None:
             return None
-        return backend_policy_for_drivername(drivername)
+        return backend_policy_for_database_url(self.database_url)
 
     @property
     def database_backend(self) -> str | None:

--- a/src/lifeos_cli/config.py
+++ b/src/lifeos_cli/config.py
@@ -16,6 +16,13 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from sqlalchemy.engine import URL, make_url
 from sqlalchemy.exc import ArgumentError
 
+from lifeos_cli.db.backend_policy import (
+    SUPPORTED_DATABASE_DRIVERS,
+    DatabaseBackendPolicy,
+    backend_policy_for_drivername,
+    supported_database_driver_examples,
+)
+
 try:
     import tomllib  # type: ignore[import-not-found]
 except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
@@ -29,13 +36,6 @@ DEFAULT_DAY_STARTS_AT = "00:00"
 DEFAULT_WEEK_STARTS_ON = "monday"
 DEFAULT_VISION_EXPERIENCE_RATE_PER_HOUR = 60
 MAX_VISION_EXPERIENCE_RATE_PER_HOUR = 3600
-SUPPORTED_DATABASE_DRIVERS = frozenset(
-    {
-        "postgresql+psycopg",
-        "sqlite+aiosqlite",
-    }
-)
-SCHEMA_CAPABLE_DATABASE_DRIVERS = frozenset({"postgresql+psycopg"})
 _SCHEMA_NAME_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _LANGUAGE_TAG_PATTERN = re.compile(r"^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$")
 _DAY_STARTS_AT_PATTERN = re.compile(r"^(?P<hour>[01]\d|2[0-3]):(?P<minute>[0-5]\d)$")
@@ -57,38 +57,38 @@ def _parse_database_url(database_url: str) -> tuple[str, URL]:
     return normalized, parsed
 
 
-def _supported_database_driver_examples() -> str:
-    return ", ".join(f"`{driver}://`" for driver in sorted(SUPPORTED_DATABASE_DRIVERS))
-
-
 def database_drivername(database_url: str) -> str:
     """Return the SQLAlchemy drivername for one validated database URL."""
     _, parsed = _parse_database_url(database_url)
     return parsed.drivername
 
 
+def database_backend_policy(database_url: str) -> DatabaseBackendPolicy:
+    """Return the backend policy for one validated database URL."""
+    return backend_policy_for_drivername(database_drivername(database_url))
+
+
 def database_url_supports_schema(database_url: str) -> bool:
     """Return whether one database URL supports schema binding."""
-    return database_drivername(database_url) in SCHEMA_CAPABLE_DATABASE_DRIVERS
+    return database_backend_policy(database_url).supports_schema
 
 
 def ensure_database_driver_available(database_url: str) -> None:
     """Ensure the configured SQLAlchemy driver dependencies are installed."""
-    drivername = database_drivername(database_url)
-    if drivername != "postgresql+psycopg":
+    policy = database_backend_policy(database_url)
+    if policy.required_driver_module is None:
         return
     try:
-        import_module("psycopg")
+        import_module(policy.required_driver_module)
     except ModuleNotFoundError as exc:
         raise ConfigurationError(
-            "PostgreSQL support is not installed. Install the `postgres` extra, for example: "
-            'uv tool install --upgrade "lifeos-cli[postgres]".'
+            policy.missing_driver_message or "Database driver is missing."
         ) from exc
 
 
 def _sqlite_database_file_path(parsed: URL) -> Path | None:
     """Return the on-disk SQLite database path when one file is configured."""
-    if parsed.drivername != "sqlite+aiosqlite":
+    if not backend_policy_for_drivername(parsed.drivername).supports_local_file_storage:
         return None
     database_name = parsed.database
     if database_name is None or database_name in {"", ":memory:"}:
@@ -139,13 +139,14 @@ def validate_database_url(database_url: str) -> str:
     if parsed.drivername not in SUPPORTED_DATABASE_DRIVERS:
         raise ConfigurationError(
             "Database URL must use one of the supported SQLAlchemy drivers: "
-            f"{_supported_database_driver_examples()}."
+            f"{supported_database_driver_examples()}."
         )
-    if parsed.drivername == "postgresql+psycopg" and (
+    policy = backend_policy_for_drivername(parsed.drivername)
+    if policy.backend_name == "postgresql" and (
         parsed.database is None or not parsed.database.strip()
     ):
         raise ConfigurationError("Database URL must include a PostgreSQL database name.")
-    if parsed.drivername == "sqlite+aiosqlite":
+    if policy.supports_local_file_storage:
         return _normalize_sqlite_database_url(parsed)
     return normalized
 
@@ -477,12 +478,20 @@ class DatabaseSettings:
         return database_drivername(self.database_url)
 
     @property
-    def database_backend(self) -> str | None:
-        """Return the configured database backend name when available."""
+    def backend_policy(self) -> DatabaseBackendPolicy | None:
+        """Return the backend policy for the configured database URL when available."""
         drivername = self.database_drivername
         if drivername is None:
             return None
-        return drivername.split("+", maxsplit=1)[0]
+        return backend_policy_for_drivername(drivername)
+
+    @property
+    def database_backend(self) -> str | None:
+        """Return the configured database backend name when available."""
+        policy = self.backend_policy
+        if policy is None:
+            return None
+        return policy.backend_name
 
 
 @dataclass(frozen=True)

--- a/src/lifeos_cli/config.py
+++ b/src/lifeos_cli/config.py
@@ -23,6 +23,7 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
 
 DEFAULT_DATABASE_SCHEMA = "lifeos"
 DEFAULT_CONFIG_PATH = Path.home() / ".lifeos" / "config.toml"
+DEFAULT_SQLITE_DATABASE_FILENAME = "lifeos.db"
 DEFAULT_LANGUAGE = "en"
 DEFAULT_DAY_STARTS_AT = "00:00"
 DEFAULT_WEEK_STARTS_ON = "monday"
@@ -349,6 +350,16 @@ def resolve_config_path(env: Mapping[str, str] | None = None) -> Path:
     if configured_path:
         return Path(configured_path).expanduser()
     return DEFAULT_CONFIG_PATH
+
+
+def default_sqlite_database_path(env: Mapping[str, str] | None = None) -> Path:
+    """Return the default file-backed SQLite database path."""
+    return resolve_config_path(env).parent / DEFAULT_SQLITE_DATABASE_FILENAME
+
+
+def default_sqlite_database_url(env: Mapping[str, str] | None = None) -> str:
+    """Return the normalized default SQLite database URL."""
+    return validate_database_url(f"sqlite+aiosqlite:///{default_sqlite_database_path(env)}")
 
 
 def load_config_file(config_path: Path) -> dict[str, Any]:

--- a/src/lifeos_cli/db/backend_policy.py
+++ b/src/lifeos_cli/db/backend_policy.py
@@ -1,0 +1,89 @@
+"""Backend capability and behavior policy helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+
+ReplaceExistingStrategy = Literal["truncate_cascade", "delete_sorted_tables"]
+
+
+@dataclass(frozen=True)
+class DatabaseBackendPolicy:
+    """Capability and behavior flags for one supported database backend."""
+
+    drivername: str
+    backend_name: str
+    supports_schema: bool
+    supports_local_file_storage: bool
+    enable_foreign_keys_on_connect: bool
+    replace_existing_strategy: ReplaceExistingStrategy
+    required_driver_module: str | None = None
+    missing_driver_message: str | None = None
+
+    def runtime_error_guidance(self, details: str) -> str | None:
+        """Return one actionable runtime error hint when available."""
+        if "no password supplied" in details or "password authentication failed" in details:
+            return (
+                "Authentication failed. Check the username/password in the database URL, "
+                "or update them with `lifeos init`."
+            )
+        if self.backend_name == "postgresql" and "does not exist" in details:
+            return (
+                "The configured PostgreSQL database does not exist yet. Create it first, "
+                "then run `lifeos db upgrade`."
+            )
+        if self.backend_name == "postgresql" and (
+            "connection refused" in details or "could not connect" in details
+        ):
+            return (
+                "PostgreSQL is not reachable. Ensure the server is installed, running, "
+                "and listening on the configured host/port."
+            )
+        if self.backend_name == "sqlite" and "unable to open database file" in details:
+            return (
+                "SQLite could not open the configured database file. Ensure the parent "
+                "directory exists and is writable."
+            )
+        return None
+
+
+_DATABASE_BACKEND_POLICIES: dict[str, DatabaseBackendPolicy] = {
+    "postgresql+psycopg": DatabaseBackendPolicy(
+        drivername="postgresql+psycopg",
+        backend_name="postgresql",
+        supports_schema=True,
+        supports_local_file_storage=False,
+        enable_foreign_keys_on_connect=False,
+        replace_existing_strategy="truncate_cascade",
+        required_driver_module="psycopg",
+        missing_driver_message=(
+            "PostgreSQL support is not installed. Install the `postgres` extra, for example: "
+            'uv tool install --upgrade "lifeos-cli[postgres]".'
+        ),
+    ),
+    "sqlite+aiosqlite": DatabaseBackendPolicy(
+        drivername="sqlite+aiosqlite",
+        backend_name="sqlite",
+        supports_schema=False,
+        supports_local_file_storage=True,
+        enable_foreign_keys_on_connect=True,
+        replace_existing_strategy="delete_sorted_tables",
+    ),
+}
+
+SUPPORTED_DATABASE_DRIVERS = frozenset(_DATABASE_BACKEND_POLICIES)
+
+
+def supported_database_driver_examples() -> str:
+    """Render the supported SQLAlchemy driver prefixes for error messages."""
+    return ", ".join(f"`{driver}://`" for driver in sorted(SUPPORTED_DATABASE_DRIVERS))
+
+
+def backend_policy_for_drivername(drivername: str) -> DatabaseBackendPolicy:
+    """Return the backend policy for one supported SQLAlchemy drivername."""
+    try:
+        return _DATABASE_BACKEND_POLICIES[drivername]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported database drivername: {drivername}") from exc

--- a/src/lifeos_cli/db/backend_policy.py
+++ b/src/lifeos_cli/db/backend_policy.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal
 
-
 ReplaceExistingStrategy = Literal["truncate_cascade", "delete_sorted_tables"]
 
 

--- a/src/lifeos_cli/db/services/data_ops.py
+++ b/src/lifeos_cli/db/services/data_ops.py
@@ -1229,7 +1229,8 @@ async def truncate_supported_data(session: AsyncSession) -> None:
     ]
     if not table_names:
         return
-    if settings.database_backend == "postgresql":
+    policy = settings.backend_policy
+    if policy is not None and policy.replace_existing_strategy == "truncate_cascade":
         await session.execute(text(f"TRUNCATE TABLE {', '.join(table_names)} CASCADE"))
         return
     for table in reversed(Base.metadata.sorted_tables):

--- a/src/lifeos_cli/db/session.py
+++ b/src/lifeos_cli/db/session.py
@@ -20,6 +20,7 @@ from lifeos_cli.config import (
     ensure_database_url_storage_ready,
     get_database_settings,
 )
+from lifeos_cli.db.backend_policy import backend_policy_for_drivername
 
 _CACHED_ENGINE: AsyncEngine | None = None
 
@@ -35,7 +36,8 @@ def _enable_sqlite_foreign_keys(dbapi_connection, _connection_record) -> None:
 
 def configure_async_engine(engine: AsyncEngine) -> AsyncEngine:
     """Apply backend-specific engine configuration."""
-    if engine.sync_engine.url.get_backend_name() != "sqlite":
+    policy = backend_policy_for_drivername(engine.sync_engine.url.drivername)
+    if not policy.enable_foreign_keys_on_connect:
         return engine
 
     event.listen(engine.sync_engine, "connect", _enable_sqlite_foreign_keys)

--- a/src/lifeos_cli/locales/en/cli_messages.json
+++ b/src/lifeos_cli/locales/en/cli_messages.json
@@ -867,6 +867,7 @@
     "init_commands": {
       "configuration_is_written_to_config_lifeos_config_toml_by_default": "Configuration is written to ~/.lifeos/config.toml by default.",
       "create_or_update_local_lifeos_config_file_and_verify_that_database_is": "Create or update the local LifeOS config file and verify that the database is reachable.",
+      "database_url_defaults_to_local_sqlite_file_when_omitted": "When --database-url is omitted, `init` defaults to SQLite at ~/.lifeos/lifeos.db.",
       "database_credentials_may_be_stored_in_plain_text_in_config_file": "Database credentials may be stored in plain text in the config file.",
       "default_iana_timezone_for_local_day_boundaries_and_time_based_summaries": "Default IANA timezone for local day boundaries and time-based summaries",
       "default_vision_experience_points_gained_per_hour_of_actual_effort": "Default vision experience points gained per hour of actual effort",

--- a/src/lifeos_cli/locales/en/cli_messages.json
+++ b/src/lifeos_cli/locales/en/cli_messages.json
@@ -867,7 +867,7 @@
     "init_commands": {
       "configuration_is_written_to_config_lifeos_config_toml_by_default": "Configuration is written to ~/.lifeos/config.toml by default.",
       "create_or_update_local_lifeos_config_file_and_verify_that_database_is": "Create or update the local LifeOS config file and verify that the database is reachable.",
-      "database_url_defaults_to_local_sqlite_file_when_omitted": "When --database-url is omitted, `init` defaults to SQLite at ~/.lifeos/lifeos.db.",
+      "database_url_defaults_to_local_sqlite_file_when_omitted": "When no database URL is configured yet, `init` defaults to SQLite at ~/.lifeos/lifeos.db.",
       "database_credentials_may_be_stored_in_plain_text_in_config_file": "Database credentials may be stored in plain text in the config file.",
       "default_iana_timezone_for_local_day_boundaries_and_time_based_summaries": "Default IANA timezone for local day boundaries and time-based summaries",
       "default_vision_experience_points_gained_per_hour_of_actual_effort": "Default vision experience points gained per hour of actual effort",

--- a/src/lifeos_cli/locales/zh_Hans/cli_messages.json
+++ b/src/lifeos_cli/locales/zh_Hans/cli_messages.json
@@ -867,7 +867,7 @@
     "init_commands": {
       "configuration_is_written_to_config_lifeos_config_toml_by_default": "默认情况下，配置写入 ~/.lifeos/config.toml。",
       "create_or_update_local_lifeos_config_file_and_verify_that_database_is": "Create or update the local LifeOS config file and verify that the database is reachable.",
-      "database_url_defaults_to_local_sqlite_file_when_omitted": "未提供 --database-url 时，`init` 默认使用 ~/.lifeos/lifeos.db 这个 SQLite 文件。",
+      "database_url_defaults_to_local_sqlite_file_when_omitted": "当前还没有配置数据库 URL 时，`init` 默认使用 ~/.lifeos/lifeos.db 这个 SQLite 文件。",
       "database_credentials_may_be_stored_in_plain_text_in_config_file": "数据库凭据可以以纯文本形式存储在配置文件中。",
       "default_iana_timezone_for_local_day_boundaries_and_time_based_summaries": "当地日期边界和基于时间的摘要的默认 IANA 时区",
       "default_vision_experience_points_gained_per_hour_of_actual_effort": "默认 `vision` 每小时实际努力获得的经验值",

--- a/src/lifeos_cli/locales/zh_Hans/cli_messages.json
+++ b/src/lifeos_cli/locales/zh_Hans/cli_messages.json
@@ -867,6 +867,7 @@
     "init_commands": {
       "configuration_is_written_to_config_lifeos_config_toml_by_default": "默认情况下，配置写入 ~/.lifeos/config.toml。",
       "create_or_update_local_lifeos_config_file_and_verify_that_database_is": "Create or update the local LifeOS config file and verify that the database is reachable.",
+      "database_url_defaults_to_local_sqlite_file_when_omitted": "未提供 --database-url 时，`init` 默认使用 ~/.lifeos/lifeos.db 这个 SQLite 文件。",
       "database_credentials_may_be_stored_in_plain_text_in_config_file": "数据库凭据可以以纯文本形式存储在配置文件中。",
       "default_iana_timezone_for_local_day_boundaries_and_time_based_summaries": "当地日期边界和基于时间的摘要的默认 IANA 时区",
       "default_vision_experience_points_gained_per_hour_of_actual_effort": "默认 `vision` 每小时实际努力获得的经验值",

--- a/tests/cli_integration_support.py
+++ b/tests/cli_integration_support.py
@@ -39,15 +39,12 @@ def normalize_integration_database_url(database_url: str) -> str:
     return parsed.set(database=database_name).render_as_string(hide_password=False)
 
 
-def get_integration_database_url_from_env() -> str | None:
-    """Return the normalized integration database URL from the explicit test-only env var."""
-    database_url = os.environ.get("LIFEOS_TEST_DATABASE_URL")
-    if database_url is None:
-        return None
-    return normalize_integration_database_url(database_url)
-
-
-INTEGRATION_DATABASE_URL = get_integration_database_url_from_env()
+_RAW_INTEGRATION_DATABASE_URL = os.environ.get("LIFEOS_TEST_DATABASE_URL")
+INTEGRATION_DATABASE_URL = (
+    normalize_integration_database_url(_RAW_INTEGRATION_DATABASE_URL)
+    if _RAW_INTEGRATION_DATABASE_URL is not None
+    else None
+)
 
 INTEGRATION_PYTESTMARK = [
     pytest.mark.integration,

--- a/tests/cli_integration_support.py
+++ b/tests/cli_integration_support.py
@@ -21,9 +21,33 @@ _ID_PATTERN = re.compile(
     r"([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})",
     re.IGNORECASE,
 )
+_TEST_DATABASE_MARKER = "test"
 
 
-INTEGRATION_DATABASE_URL = os.environ.get("LIFEOS_TEST_DATABASE_URL")
+def normalize_integration_database_url(database_url: str) -> str:
+    """Normalize one integration database URL so it clearly targets a test database."""
+    parsed = make_url(database_url.strip())
+    if parsed.drivername != "postgresql+psycopg":
+        raise RuntimeError(
+            "LIFEOS_TEST_DATABASE_URL must use the `postgresql+psycopg://` SQLAlchemy driver"
+        )
+    database_name = parsed.database
+    if database_name is None or not database_name.strip():
+        raise RuntimeError("LIFEOS_TEST_DATABASE_URL must include a PostgreSQL database name")
+    if _TEST_DATABASE_MARKER not in database_name.casefold():
+        database_name = f"{database_name}_test"
+    return parsed.set(database=database_name).render_as_string(hide_password=False)
+
+
+def get_integration_database_url_from_env() -> str | None:
+    """Return the normalized integration database URL from the explicit test-only env var."""
+    database_url = os.environ.get("LIFEOS_TEST_DATABASE_URL")
+    if database_url is None:
+        return None
+    return normalize_integration_database_url(database_url)
+
+
+INTEGRATION_DATABASE_URL = get_integration_database_url_from_env()
 
 INTEGRATION_PYTESTMARK = [
     pytest.mark.integration,

--- a/tests/test_backend_policy.py
+++ b/tests/test_backend_policy.py
@@ -10,9 +10,7 @@ from lifeos_cli.db.backend_policy import (
 
 
 def test_backend_policy_declares_supported_driver_examples() -> None:
-    assert SUPPORTED_DATABASE_DRIVERS == frozenset(
-        {"postgresql+psycopg", "sqlite+aiosqlite"}
-    )
+    assert SUPPORTED_DATABASE_DRIVERS == frozenset({"postgresql+psycopg", "sqlite+aiosqlite"})
     assert supported_database_driver_examples() == (
         "`postgresql+psycopg://`, `sqlite+aiosqlite://`"
     )

--- a/tests/test_backend_policy.py
+++ b/tests/test_backend_policy.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import pytest
+
+from lifeos_cli.db.backend_policy import (
+    SUPPORTED_DATABASE_DRIVERS,
+    backend_policy_for_drivername,
+    supported_database_driver_examples,
+)
+
+
+def test_backend_policy_declares_supported_driver_examples() -> None:
+    assert SUPPORTED_DATABASE_DRIVERS == frozenset(
+        {"postgresql+psycopg", "sqlite+aiosqlite"}
+    )
+    assert supported_database_driver_examples() == (
+        "`postgresql+psycopg://`, `sqlite+aiosqlite://`"
+    )
+
+
+def test_backend_policy_for_postgresql_declares_schema_and_truncate_capabilities() -> None:
+    policy = backend_policy_for_drivername("postgresql+psycopg")
+    does_not_exist_guidance = policy.runtime_error_guidance("database does not exist")
+
+    assert policy.backend_name == "postgresql"
+    assert policy.supports_schema is True
+    assert policy.supports_local_file_storage is False
+    assert policy.enable_foreign_keys_on_connect is False
+    assert policy.replace_existing_strategy == "truncate_cascade"
+    assert policy.missing_driver_message is not None
+    assert "lifeos-cli[postgres]" in policy.missing_driver_message
+    assert does_not_exist_guidance is not None
+    assert "Create it first" in does_not_exist_guidance
+
+
+def test_backend_policy_for_sqlite_declares_file_and_runtime_capabilities() -> None:
+    policy = backend_policy_for_drivername("sqlite+aiosqlite")
+    sqlite_guidance = policy.runtime_error_guidance("unable to open database file")
+
+    assert policy.backend_name == "sqlite"
+    assert policy.supports_schema is False
+    assert policy.supports_local_file_storage is True
+    assert policy.enable_foreign_keys_on_connect is True
+    assert policy.replace_existing_strategy == "delete_sorted_tables"
+    assert sqlite_guidance is not None
+    assert "parent directory exists and is writable" in sqlite_guidance
+
+
+def test_backend_policy_rejects_unsupported_drivernames() -> None:
+    with pytest.raises(ValueError, match="Unsupported database drivername"):
+        backend_policy_for_drivername("mysql+asyncmy")

--- a/tests/test_cli_help_content.py
+++ b/tests/test_cli_help_content.py
@@ -53,7 +53,7 @@ def test_cli_init_help_avoids_hard_wrapped_description_fragments(capsys) -> None
         in captured.out
     )
     assert "--database-url DATABASE_URL           " in captured.out
-    assert "defaults to SQLite at ~/.lifeos/lifeos.db" in captured.out
+    assert "When no database URL is configured yet" in captured.out
     assert (
         "Create or update the local LifeOS config file and verify that the database\nis reachable."
         not in captured.out

--- a/tests/test_cli_help_content.py
+++ b/tests/test_cli_help_content.py
@@ -53,6 +53,7 @@ def test_cli_init_help_avoids_hard_wrapped_description_fragments(capsys) -> None
         in captured.out
     )
     assert "--database-url DATABASE_URL           " in captured.out
+    assert "defaults to SQLite at ~/.lifeos/lifeos.db" in captured.out
     assert (
         "Create or update the local LifeOS config file and verify that the database\nis reachable."
         not in captured.out
@@ -1016,7 +1017,7 @@ def test_cli_batch_action_ids_help_matches_action_semantics(
         (
             ["config", "set", "--help"],
             "lifeos config set database.url "
-            "postgresql+psycopg://<db-user>:<db-password>@localhost:5432/lifeos "
+            "sqlite+aiosqlite:///$HOME/.lifeos/work.db "
             "--show-secrets",
         ),
         (

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -81,6 +81,40 @@ def test_main_init_non_interactive_writes_config(
     clear_config_cache()
 
 
+def test_main_init_non_interactive_defaults_to_sqlite_when_database_url_is_omitted(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    config_path = tmp_path / "config.toml"
+    database_path = config_path.parent / "lifeos.db"
+    clear_config_cache()
+    monkeypatch.setenv("LIFEOS_CONFIG_FILE", str(config_path))
+    monkeypatch.setattr(
+        config_handlers,
+        "run_configured_database_subcommand_in_subprocess",
+        _noop_database_subcommand,
+    )
+
+    exit_code = cli.main(
+        [
+            "init",
+            "--non-interactive",
+            "--skip-ping",
+            "--skip-migrate",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert f"Database URL: sqlite+aiosqlite:///{database_path}" in captured.out
+    assert "Database schema:" not in captured.out
+    content = config_path.read_text(encoding="utf-8")
+    assert f'url = "sqlite+aiosqlite:///{database_path}"' in content
+    assert "schema =" not in content
+    clear_config_cache()
+
+
 def test_main_init_does_not_prompt_for_explicit_database_url(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -171,6 +205,46 @@ def test_main_init_sqlite_does_not_prompt_for_schema_or_write_schema(
     assert "Database schema:" not in captured.out
     assert all(not prompt.startswith("Database schema") for prompt in prompts)
     assert "schema =" not in config_path.read_text(encoding="utf-8")
+    clear_config_cache()
+
+
+def test_main_init_interactive_accepts_default_sqlite_database_url(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    config_path = tmp_path / "config.toml"
+    database_path = config_path.parent / "lifeos.db"
+    prompts: list[str] = []
+    clear_config_cache()
+    monkeypatch.setenv("LIFEOS_CONFIG_FILE", str(config_path))
+    monkeypatch.setattr(
+        config_handlers,
+        "run_configured_database_subcommand_in_subprocess",
+        _noop_database_subcommand,
+    )
+    monkeypatch.setattr(config_handlers.sys.stdin, "isatty", lambda: True)
+
+    def fake_input(prompt: str) -> str:
+        prompts.append(prompt)
+        return ""
+
+    monkeypatch.setattr(builtins, "input", fake_input)
+
+    exit_code = cli.main(
+        [
+            "init",
+            "--skip-ping",
+            "--skip-migrate",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert prompts[0] == f"Database URL [sqlite+aiosqlite:///{database_path}]: "
+    assert "Database schema:" not in captured.out
+    assert all(not prompt.startswith("Database schema") for prompt in prompts)
+    assert f'url = "sqlite+aiosqlite:///{database_path}"' in config_path.read_text(encoding="utf-8")
     clear_config_cache()
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,7 +14,7 @@ from lifeos_cli.config import (
     ConfigurationError,
     DatabaseSettings,
     PreferencesSettings,
-    default_sqlite_database_path,
+    backend_policy_for_database_url,
     default_sqlite_database_url,
     detect_default_language,
     ensure_database_driver_available,
@@ -260,14 +260,6 @@ def test_resolve_config_path_defaults_to_lifeos_home_directory() -> None:
     assert DEFAULT_CONFIG_PATH == Path.home() / ".lifeos" / "config.toml"
 
 
-def test_default_sqlite_database_path_follows_config_directory(tmp_path: Path) -> None:
-    config_path = tmp_path / "nested" / "config.toml"
-
-    assert default_sqlite_database_path({"LIFEOS_CONFIG_FILE": str(config_path)}) == (
-        config_path.parent / "lifeos.db"
-    )
-
-
 def test_default_sqlite_database_url_uses_default_file_name(tmp_path: Path) -> None:
     config_path = tmp_path / "nested" / "config.toml"
     expected_path = config_path.parent / "lifeos.db"
@@ -275,6 +267,13 @@ def test_default_sqlite_database_url_uses_default_file_name(tmp_path: Path) -> N
     assert default_sqlite_database_url({"LIFEOS_CONFIG_FILE": str(config_path)}) == (
         f"sqlite+aiosqlite:///{expected_path}"
     )
+
+
+def test_backend_policy_for_database_url_uses_database_drivername() -> None:
+    policy = backend_policy_for_database_url("sqlite+aiosqlite:///tmp/lifeos.db")
+
+    assert policy.backend_name == "sqlite"
+    assert policy.supports_schema is False
 
 
 def test_ensure_database_driver_available_requires_postgres_extra(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,6 +14,8 @@ from lifeos_cli.config import (
     ConfigurationError,
     DatabaseSettings,
     PreferencesSettings,
+    default_sqlite_database_path,
+    default_sqlite_database_url,
     detect_default_language,
     ensure_database_driver_available,
     parse_boolean_value,
@@ -258,6 +260,23 @@ def test_resolve_config_path_defaults_to_lifeos_home_directory() -> None:
     assert DEFAULT_CONFIG_PATH == Path.home() / ".lifeos" / "config.toml"
 
 
+def test_default_sqlite_database_path_follows_config_directory(tmp_path: Path) -> None:
+    config_path = tmp_path / "nested" / "config.toml"
+
+    assert default_sqlite_database_path({"LIFEOS_CONFIG_FILE": str(config_path)}) == (
+        config_path.parent / "lifeos.db"
+    )
+
+
+def test_default_sqlite_database_url_uses_default_file_name(tmp_path: Path) -> None:
+    config_path = tmp_path / "nested" / "config.toml"
+    expected_path = config_path.parent / "lifeos.db"
+
+    assert default_sqlite_database_url({"LIFEOS_CONFIG_FILE": str(config_path)}) == (
+        f"sqlite+aiosqlite:///{expected_path}"
+    )
+
+
 def test_ensure_database_driver_available_requires_postgres_extra(
     monkeypatch,
 ) -> None:
@@ -326,6 +345,33 @@ def test_build_database_settings_skip_schema_for_sqlite_prompts(
     assert settings.database_url == "sqlite+aiosqlite:///lifeos.db"
     assert settings.database_schema is None
     assert captured_defaults == []
+
+
+def test_build_database_settings_defaults_to_sqlite_when_database_url_is_missing(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "lifeos" / "config.toml"
+    monkeypatch.setenv("LIFEOS_CONFIG_FILE", str(config_path))
+    request = InitializationRequest(
+        database_url=None,
+        schema=None,
+        echo=None,
+        timezone=None,
+        language=None,
+        day_starts_at=None,
+        week_starts_on=None,
+        vision_experience_rate_per_hour=None,
+        non_interactive=True,
+        is_interactive=False,
+        prompts=None,
+    )
+
+    settings = build_database_settings(request)
+
+    assert settings.database_url == f"sqlite+aiosqlite:///{config_path.parent / 'lifeos.db'}"
+    assert settings.database_schema is None
+    assert settings.database_echo is False
 
 
 def test_build_database_settings_rejects_explicit_sqlite_schema(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,7 +14,7 @@ from lifeos_cli.config import (
     ConfigurationError,
     DatabaseSettings,
     PreferencesSettings,
-    backend_policy_for_database_url,
+    database_policy,
     default_sqlite_database_url,
     detect_default_language,
     ensure_database_driver_available,
@@ -269,8 +269,8 @@ def test_default_sqlite_database_url_uses_default_file_name(tmp_path: Path) -> N
     )
 
 
-def test_backend_policy_for_database_url_uses_database_drivername() -> None:
-    policy = backend_policy_for_database_url("sqlite+aiosqlite:///tmp/lifeos.db")
+def test_database_policy_uses_database_drivername() -> None:
+    policy = database_policy("sqlite+aiosqlite:///tmp/lifeos.db")
 
     assert policy.backend_name == "sqlite"
     assert policy.supports_schema is False

--- a/tests/test_data_ops.py
+++ b/tests/test_data_ops.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 from contextlib import asynccontextmanager
 from pathlib import Path
+from types import SimpleNamespace
 from typing import cast
 from uuid import UUID
 from zipfile import ZIP_DEFLATED, ZipFile
@@ -10,6 +11,7 @@ from zipfile import ZIP_DEFLATED, ZipFile
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from lifeos_cli.db.backend_policy import backend_policy_for_drivername
 from lifeos_cli.db.services import data_ops
 
 
@@ -17,6 +19,14 @@ class FakeBatchSession:
     @asynccontextmanager
     async def begin_nested(self):
         yield self
+
+
+class RecordingSession:
+    def __init__(self) -> None:
+        self.statements: list[object] = []
+
+    async def execute(self, statement: object) -> None:
+        self.statements.append(statement)
 
 
 def test_batch_update_resource_parses_typed_timelog_fields(
@@ -206,6 +216,40 @@ def test_import_bundle_applies_base_rows_before_relations(
     assert call_order[0] == ("truncate", "-")
     assert max(base_positions) < min(sync_positions)
     assert call_order[-1] == ("hooks", "people,tag")
+
+
+def test_truncate_supported_data_uses_backend_replace_strategy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    postgres_session = RecordingSession()
+    sqlite_session = RecordingSession()
+
+    monkeypatch.setattr(
+        data_ops,
+        "get_database_settings",
+        lambda: SimpleNamespace(
+            database_schema="lifeos",
+            backend_policy=backend_policy_for_drivername("postgresql+psycopg"),
+        ),
+    )
+    asyncio.run(data_ops.truncate_supported_data(cast(AsyncSession, postgres_session)))
+
+    assert len(postgres_session.statements) == 1
+    assert "TRUNCATE TABLE" in str(postgres_session.statements[0])
+    assert "CASCADE" in str(postgres_session.statements[0])
+
+    monkeypatch.setattr(
+        data_ops,
+        "get_database_settings",
+        lambda: SimpleNamespace(
+            database_schema=None,
+            backend_policy=backend_policy_for_drivername("sqlite+aiosqlite"),
+        ),
+    )
+    asyncio.run(data_ops.truncate_supported_data(cast(AsyncSession, sqlite_session)))
+
+    assert len(sqlite_session.statements) > 1
+    assert all(str(statement).startswith("DELETE FROM ") for statement in sqlite_session.statements)
 
 
 def test_read_bundle_rejects_missing_manifest(tmp_path: Path) -> None:

--- a/tests/test_db_session.py
+++ b/tests/test_db_session.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import AsyncMock
 
 import pytest
+from sqlalchemy.ext.asyncio import AsyncEngine
 
 from lifeos_cli.db import session as db_session
 
@@ -20,3 +22,40 @@ def test_clear_session_cache_disposes_cached_engine(
 
     dispose.assert_awaited_once()
     assert db_session._CACHED_ENGINE is None
+
+
+def test_configure_async_engine_enables_sqlite_foreign_keys_only_for_sqlite(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    listened: list[tuple[object, str, object]] = []
+
+    def fake_listen(target: object, event_name: str, listener: object) -> None:
+        listened.append((target, event_name, listener))
+
+    monkeypatch.setattr(db_session.event, "listen", fake_listen)
+
+    sqlite_engine = cast(
+        AsyncEngine,
+        SimpleNamespace(
+            sync_engine=SimpleNamespace(
+                url=SimpleNamespace(drivername="sqlite+aiosqlite"),
+            )
+        ),
+    )
+    postgres_engine = cast(
+        AsyncEngine,
+        SimpleNamespace(
+            sync_engine=SimpleNamespace(
+                url=SimpleNamespace(drivername="postgresql+psycopg"),
+            )
+        ),
+    )
+
+    assert db_session.configure_async_engine(sqlite_engine) is sqlite_engine
+    assert listened == [
+        (sqlite_engine.sync_engine, "connect", db_session._enable_sqlite_foreign_keys)
+    ]
+
+    listened.clear()
+    assert db_session.configure_async_engine(postgres_engine) is postgres_engine
+    assert listened == []

--- a/tests/test_integration_support_contracts.py
+++ b/tests/test_integration_support_contracts.py
@@ -2,10 +2,24 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from tests.cli_integration_support import normalize_integration_database_url
+
+_RAW_TESTLESS_URL = "postgresql+psycopg://u:p@db/lifeos"  # pragma: allowlist secret
+_NORMALIZED_TEST_URL = "postgresql+psycopg://u:p@db/lifeos_test"  # pragma: allowlist secret
+
 
 def test_integration_support_uses_only_explicit_test_database_url() -> None:
     support_text = Path("tests/cli_integration_support.py").read_text(encoding="utf-8")
 
-    assert 'INTEGRATION_DATABASE_URL = os.environ.get("LIFEOS_TEST_DATABASE_URL")' in support_text
+    assert 'database_url = os.environ.get("LIFEOS_TEST_DATABASE_URL")' in support_text
+    assert "normalize_integration_database_url" in support_text
     assert "DatabaseSettings.from_env" not in support_text
     assert "runtime config" not in support_text
+
+
+def test_normalize_integration_database_url_appends_test_suffix_when_missing() -> None:
+    assert normalize_integration_database_url(_RAW_TESTLESS_URL) == _NORMALIZED_TEST_URL
+
+
+def test_normalize_integration_database_url_keeps_existing_test_marker() -> None:
+    assert normalize_integration_database_url(_NORMALIZED_TEST_URL) == _NORMALIZED_TEST_URL

--- a/tests/test_integration_support_contracts.py
+++ b/tests/test_integration_support_contracts.py
@@ -10,9 +10,11 @@ _NORMALIZED_TEST_URL = "postgresql+psycopg://u:p@db/lifeos_test"  # pragma: allo
 
 def test_integration_support_uses_only_explicit_test_database_url() -> None:
     support_text = Path("tests/cli_integration_support.py").read_text(encoding="utf-8")
+    env_assignment = '_RAW_INTEGRATION_DATABASE_URL = os.environ.get("LIFEOS_TEST_DATABASE_URL")'
 
-    assert 'database_url = os.environ.get("LIFEOS_TEST_DATABASE_URL")' in support_text
+    assert env_assignment in support_text
     assert "normalize_integration_database_url" in support_text
+    assert "get_integration_database_url_from_env" not in support_text
     assert "DatabaseSettings.from_env" not in support_text
     assert "runtime config" not in support_text
 

--- a/tests/test_repository_contracts.py
+++ b/tests/test_repository_contracts.py
@@ -127,7 +127,8 @@ def test_integration_tests_require_an_explicit_test_database_url() -> None:
     assert 'source "${SCRIPT_DIR}/load_local_env.sh"' in script_text
     assert 'load_local_env "${REPO_ROOT}/.env"' in script_text
     support_text = Path("tests/cli_integration_support.py").read_text()
-    assert 'INTEGRATION_DATABASE_URL = os.environ.get("LIFEOS_TEST_DATABASE_URL")' in support_text
+    assert "normalize_integration_database_url" in support_text
+    assert 'database_name = f"{database_name}_test"' in support_text
     assert "DatabaseSettings.from_env" not in support_text
     assert 'schema = f"lifeos_test_{uuid4().hex[:12]}"' in Path("tests/conftest.py").read_text()
 


### PR DESCRIPTION
Related #107
Related #108
Closes #110
Closes #112
Closes #113
Closes #115

## 初始化与配置
- `lifeos init` 在当前尚未配置数据库 URL 时，默认回落到本地 SQLite 文件 `~/.lifeos/lifeos.db`
- 补充默认 SQLite URL 的配置辅助函数，并为默认初始化路径增加覆盖测试
- 保持已有数据库配置的优先级，不让默认值覆盖已有 PostgreSQL / SQLite 配置
- 继续禁止通过 `lifeos config set database.url` 直接跨 backend 切换，避免 schema 与后端策略不一致

## Backend Policy
- 新增统一的 `db/backend_policy.py`，集中声明 backend 名称、schema 能力、SQLite 连接钩子、replace-existing 策略、driver 缺失提示与运行时错误 guidance
- `configuration.py`、`runtime_utils.py`、`db/session.py`、`db/services/data_ops.py` 改为消费统一策略，减少散落的字符串分支
- 进一步收敛配置层 helper：保留 `backend_policy_for_drivername` 与 `database_policy` 两个有明确输入边界的入口，删除薄壳转发函数与重复 helper
- 为 capability 策略补充独立测试，覆盖 PostgreSQL / SQLite 的关键分支行为

## 测试数据库隔离
- 在测试支持层统一规范化 `LIFEOS_TEST_DATABASE_URL`
- 若数据库名缺少明确测试标识，则补齐 test 定位，并保持随机 schema 隔离策略不变
- 移除仅做环境变量读取转发的薄壳 helper，直接在测试支持模块入口完成归一化
- 对 integration test 的 driver 与数据库名增加显式保护，避免测试误用正式库

## CLI Help 与文档
- 更新 `lifeos init` / `lifeos config set` 的帮助文案与示例，改为 SQLite-first
- 将精确的 SQLite 默认路径说明保留在 CLI help，README 只保留高层入口说明，`docs/cli.md` 不再重复命令级细节
- 审查并移除仓库纯文本文档中的普通段落人工硬换行，保留列表、代码块和其它结构性换行
- 更新 `README.md`、`README.zh-Hans.md`、`docs/cli.md`、`CONTRIBUTING.md`、`AGENTS.md`

## 验证
- `bash ./scripts/doctor.sh`
