### PR TITLE
fix(datetime): normalize SQLite UTC storage semantics

### DIFF
--- a/src/lifeos_cli/application/datetime_utils.py
+++ b/src/lifeos_cli/application/datetime_utils.py
@@ -1,0 +1,28 @@
+"""Datetime helpers for storage and API boundaries."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import overload
+
+
+@overload
+def normalize_storage_datetime(value: None) -> None: ...
+
+
+@overload
+def normalize_storage_datetime(value: datetime) -> datetime: ...
+
+
+def normalize_storage_datetime(value: datetime | None) -> datetime | None:
+    """Return stored datetimes as UTC-aware values, treating naive storage values as UTC."""
+    if value is None:
+        return None
+    if value.tzinfo is not None and value.utcoffset() is not None:
+        return value.astimezone(timezone.utc)
+    return value.replace(tzinfo=timezone.utc)
+
+
+def format_utc_iso(value: datetime) -> str:
+    """Render one stored datetime as an explicit UTC ISO string."""
+    return normalize_storage_datetime(value).isoformat().replace("+00:00", "Z")

--- a/src/lifeos_cli/db/services/data_ops.py
+++ b/src/lifeos_cli/db/services/data_ops.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any
 from uuid import UUID
@@ -210,14 +210,19 @@ DELETE_ARG_NAMES: dict[str, str] = {
 
 
 def _normalize_json_datetime(value: str) -> datetime:
-    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
 
 
 def _serialize_scalar(value: Any) -> Any:
     if isinstance(value, UUID):
         return str(value)
     if isinstance(value, datetime):
-        return value.isoformat()
+        if value.tzinfo is None or value.utcoffset() is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
     if isinstance(value, date):
         return value.isoformat()
     return value

--- a/src/lifeos_cli/db/services/data_ops.py
+++ b/src/lifeos_cli/db/services/data_ops.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from datetime import date, datetime, timezone
+from datetime import date, datetime
 from pathlib import Path
 from typing import Any
 from uuid import UUID
@@ -13,6 +13,7 @@ from zipfile import ZIP_DEFLATED, BadZipFile, ZipFile
 from sqlalchemy import delete, insert, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from lifeos_cli.application.datetime_utils import format_utc_iso, normalize_storage_datetime
 from lifeos_cli.application.package_metadata import get_installed_package_version
 from lifeos_cli.config import get_database_settings, get_preferences_settings
 from lifeos_cli.db.base import Base
@@ -211,18 +212,14 @@ DELETE_ARG_NAMES: dict[str, str] = {
 
 def _normalize_json_datetime(value: str) -> datetime:
     parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
-    if parsed.tzinfo is None or parsed.utcoffset() is None:
-        return parsed.replace(tzinfo=timezone.utc)
-    return parsed.astimezone(timezone.utc)
+    return normalize_storage_datetime(parsed)
 
 
 def _serialize_scalar(value: Any) -> Any:
     if isinstance(value, UUID):
         return str(value)
     if isinstance(value, datetime):
-        if value.tzinfo is None or value.utcoffset() is None:
-            value = value.replace(tzinfo=timezone.utc)
-        return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+        return format_utc_iso(value)
     if isinstance(value, date):
         return value.isoformat()
     return value

--- a/src/lifeos_cli/db/services/event_support.py
+++ b/src/lifeos_cli/db/services/event_support.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import date, datetime, timezone
+from datetime import date, datetime
 from typing import Protocol
 from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from lifeos_cli.application.datetime_utils import normalize_storage_datetime
 from lifeos_cli.config import get_preferences_settings
 from lifeos_cli.db.models.area import Area
 from lifeos_cli.db.models.task import Task
@@ -242,25 +243,16 @@ class RecurringEventLike(Protocol):
     recurrence_until: datetime | None
 
 
-def as_utc_aware(value: datetime | None) -> datetime | None:
-    """Interpret timezone-naive storage datetimes as UTC."""
-    if value is None:
-        return None
-    if value.tzinfo is not None and value.utcoffset() is not None:
-        return value.astimezone(timezone.utc)
-    return value.replace(tzinfo=timezone.utc)
-
-
 def _build_event_series(event: RecurringEventLike) -> SeriesDefinition:
     if event.recurrence_frequency is None:
         raise EventValidationError("Recurring event operations require recurrence_frequency.")
     return build_series_definition(
-        anchor_start=as_utc_aware(event.start_time) or event.start_time,
-        anchor_end=as_utc_aware(event.end_time),
+        anchor_start=normalize_storage_datetime(event.start_time),
+        anchor_end=normalize_storage_datetime(event.end_time),
         frequency=event.recurrence_frequency,
         interval=event.recurrence_interval,
         count=event.recurrence_count,
-        until=as_utc_aware(event.recurrence_until),
+        until=normalize_storage_datetime(event.recurrence_until),
         week_starts_on=get_preferences_settings().week_starts_on,
     )
 
@@ -273,7 +265,7 @@ def event_is_recurring(event: RecurringEventLike) -> bool:
 def get_event_occurrence_index(event: RecurringEventLike, *, instance_start: datetime) -> int:
     """Return the zero-based occurrence index for one recurring event instance."""
     try:
-        normalized_instance_start = as_utc_aware(instance_start) or instance_start
+        normalized_instance_start = normalize_storage_datetime(instance_start)
         return get_occurrence_index(
             _build_event_series(event),
             instance_start=normalized_instance_start,
@@ -287,7 +279,7 @@ def validate_event_instance_start(event: RecurringEventLike, *, instance_start: 
     if not event_is_recurring(event):
         raise EventValidationError("Instance-level operations require a recurring master event")
     try:
-        normalized_instance_start = as_utc_aware(instance_start) or instance_start
+        normalized_instance_start = normalize_storage_datetime(instance_start)
         validate_occurrence_start(
             _build_event_series(event),
             instance_start=normalized_instance_start,
@@ -301,7 +293,7 @@ def get_previous_event_occurrence_start(
 ) -> datetime | None:
     """Return the previous occurrence start for one recurring event instance."""
     try:
-        normalized_instance_start = as_utc_aware(instance_start) or instance_start
+        normalized_instance_start = normalize_storage_datetime(instance_start)
         return get_previous_occurrence_start(
             _build_event_series(event),
             instance_start=normalized_instance_start,
@@ -319,8 +311,8 @@ def get_event_occurrence_starts_in_range(
     """Return occurrence start times that overlap the requested window."""
     if not event_is_recurring(event):
         return []
-    normalized_window_start = as_utc_aware(window_start) or window_start
-    normalized_window_end = as_utc_aware(window_end) or window_end
+    normalized_window_start = normalize_storage_datetime(window_start)
+    normalized_window_end = normalize_storage_datetime(window_end)
     return get_occurrence_starts_in_range(
         _build_event_series(event),
         window_start=normalized_window_start,

--- a/src/lifeos_cli/db/services/event_support.py
+++ b/src/lifeos_cli/db/services/event_support.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from typing import Protocol
 from uuid import UUID
 
@@ -242,16 +242,25 @@ class RecurringEventLike(Protocol):
     recurrence_until: datetime | None
 
 
+def as_utc_aware(value: datetime | None) -> datetime | None:
+    """Interpret timezone-naive storage datetimes as UTC."""
+    if value is None:
+        return None
+    if value.tzinfo is not None and value.utcoffset() is not None:
+        return value.astimezone(timezone.utc)
+    return value.replace(tzinfo=timezone.utc)
+
+
 def _build_event_series(event: RecurringEventLike) -> SeriesDefinition:
     if event.recurrence_frequency is None:
         raise EventValidationError("Recurring event operations require recurrence_frequency.")
     return build_series_definition(
-        anchor_start=event.start_time,
-        anchor_end=event.end_time,
+        anchor_start=as_utc_aware(event.start_time) or event.start_time,
+        anchor_end=as_utc_aware(event.end_time),
         frequency=event.recurrence_frequency,
         interval=event.recurrence_interval,
         count=event.recurrence_count,
-        until=event.recurrence_until,
+        until=as_utc_aware(event.recurrence_until),
         week_starts_on=get_preferences_settings().week_starts_on,
     )
 
@@ -264,7 +273,11 @@ def event_is_recurring(event: RecurringEventLike) -> bool:
 def get_event_occurrence_index(event: RecurringEventLike, *, instance_start: datetime) -> int:
     """Return the zero-based occurrence index for one recurring event instance."""
     try:
-        return get_occurrence_index(_build_event_series(event), instance_start=instance_start)
+        normalized_instance_start = as_utc_aware(instance_start) or instance_start
+        return get_occurrence_index(
+            _build_event_series(event),
+            instance_start=normalized_instance_start,
+        )
     except RecurrenceValidationError as exc:
         raise EventValidationError(str(exc)) from exc
 
@@ -274,7 +287,11 @@ def validate_event_instance_start(event: RecurringEventLike, *, instance_start: 
     if not event_is_recurring(event):
         raise EventValidationError("Instance-level operations require a recurring master event")
     try:
-        validate_occurrence_start(_build_event_series(event), instance_start=instance_start)
+        normalized_instance_start = as_utc_aware(instance_start) or instance_start
+        validate_occurrence_start(
+            _build_event_series(event),
+            instance_start=normalized_instance_start,
+        )
     except RecurrenceValidationError as exc:
         raise EventValidationError(str(exc)) from exc
 
@@ -284,9 +301,10 @@ def get_previous_event_occurrence_start(
 ) -> datetime | None:
     """Return the previous occurrence start for one recurring event instance."""
     try:
+        normalized_instance_start = as_utc_aware(instance_start) or instance_start
         return get_previous_occurrence_start(
             _build_event_series(event),
-            instance_start=instance_start,
+            instance_start=normalized_instance_start,
         )
     except RecurrenceValidationError as exc:
         raise EventValidationError(str(exc)) from exc
@@ -301,10 +319,12 @@ def get_event_occurrence_starts_in_range(
     """Return occurrence start times that overlap the requested window."""
     if not event_is_recurring(event):
         return []
+    normalized_window_start = as_utc_aware(window_start) or window_start
+    normalized_window_end = as_utc_aware(window_end) or window_end
     return get_occurrence_starts_in_range(
         _build_event_series(event),
-        window_start=window_start,
-        window_end=window_end,
+        window_start=normalized_window_start,
+        window_end=normalized_window_end,
     )
 
 

--- a/src/lifeos_cli/db/services/events.py
+++ b/src/lifeos_cli/db/services/events.py
@@ -34,6 +34,7 @@ from lifeos_cli.db.services.event_support import (
     EventQueryFilters,
     EventUpdateInput,
     EventValidationError,
+    as_utc_aware,
     ensure_event_area_exists,
     ensure_event_task_exists,
     event_is_recurring,
@@ -123,10 +124,11 @@ async def _get_event_model(
 
 
 def _event_duration(event: Event | EventOccurrence) -> timedelta | None:
-    end_time = event.end_time
+    start_time = as_utc_aware(event.start_time) or event.start_time
+    end_time = as_utc_aware(event.end_time)
     if end_time is None:
         return None
-    return end_time - event.start_time
+    return end_time - start_time
 
 
 def _event_overlaps_window(
@@ -135,8 +137,11 @@ def _event_overlaps_window(
     window_start: datetime,
     window_end: datetime,
 ) -> bool:
-    end_time = event.end_time
-    return event.start_time <= window_end and (end_time is None or end_time >= window_start)
+    start_time = as_utc_aware(event.start_time) or event.start_time
+    end_time = as_utc_aware(event.end_time)
+    window_start = as_utc_aware(window_start) or window_start
+    window_end = as_utc_aware(window_end) or window_end
+    return start_time <= window_end and (end_time is None or end_time >= window_start)
 
 
 def _event_occurrence_end(
@@ -190,7 +195,8 @@ async def _load_skip_exceptions(
     rows = list((await session.execute(stmt)).scalars())
     result: dict[UUID, set[datetime]] = {}
     for row in rows:
-        result.setdefault(row.master_event_id, set()).add(row.instance_start)
+        instance_start = as_utc_aware(row.instance_start) or row.instance_start
+        result.setdefault(row.master_event_id, set()).add(instance_start)
     return result
 
 
@@ -721,7 +727,10 @@ async def list_event_occurrences(
     override_stmt = _apply_event_query_filters(override_stmt, filters=normalized_filters)
     overrides = list((await session.execute(override_stmt)).scalars())
     override_keys = {
-        (override.recurrence_parent_event_id, override.recurrence_instance_start): override
+        (
+            override.recurrence_parent_event_id,
+            as_utc_aware(override.recurrence_instance_start) or override.recurrence_instance_start,
+        ): override
         for override in overrides
         if override.recurrence_parent_event_id is not None
         and override.recurrence_instance_start is not None
@@ -731,17 +740,18 @@ async def list_event_occurrences(
     for master in masters:
         if not event_is_recurring(master):
             if _event_overlaps_window(master, window_start=window_start, window_end=window_end):
+                start_time = as_utc_aware(master.start_time) or master.start_time
                 occurrences.append(
                     EventOccurrence(
                         id=master.id,
                         title=master.title,
                         status=master.status,
                         event_type=master.event_type,
-                        start_time=master.start_time,
-                        end_time=master.end_time,
+                        start_time=start_time,
+                        end_time=as_utc_aware(master.end_time),
                         task_id=master.task_id,
-                        deleted_at=master.deleted_at,
-                        instance_start=master.start_time,
+                        deleted_at=as_utc_aware(master.deleted_at),
+                        instance_start=start_time,
                     )
                 )
             continue
@@ -770,17 +780,18 @@ async def list_event_occurrences(
             )
 
     for override in overrides:
+        override_start = as_utc_aware(override.start_time) or override.start_time
         occurrences.append(
             EventOccurrence(
                 id=override.id,
                 title=override.title,
                 status=override.status,
                 event_type=override.event_type,
-                start_time=override.start_time,
-                end_time=override.end_time,
+                start_time=override_start,
+                end_time=as_utc_aware(override.end_time),
                 task_id=override.task_id,
-                deleted_at=override.deleted_at,
-                instance_start=override.recurrence_instance_start or override.start_time,
+                deleted_at=as_utc_aware(override.deleted_at),
+                instance_start=(as_utc_aware(override.recurrence_instance_start) or override_start),
             )
         )
 

--- a/src/lifeos_cli/db/services/events.py
+++ b/src/lifeos_cli/db/services/events.py
@@ -11,6 +11,7 @@ from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from lifeos_cli.application.datetime_utils import normalize_storage_datetime
 from lifeos_cli.application.time_preferences import (
     get_utc_window_for_local_date_range,
     to_storage_timezone,
@@ -34,7 +35,6 @@ from lifeos_cli.db.services.event_support import (
     EventQueryFilters,
     EventUpdateInput,
     EventValidationError,
-    as_utc_aware,
     ensure_event_area_exists,
     ensure_event_task_exists,
     event_is_recurring,
@@ -124,8 +124,8 @@ async def _get_event_model(
 
 
 def _event_duration(event: Event | EventOccurrence) -> timedelta | None:
-    start_time = as_utc_aware(event.start_time) or event.start_time
-    end_time = as_utc_aware(event.end_time)
+    start_time = normalize_storage_datetime(event.start_time)
+    end_time = normalize_storage_datetime(event.end_time)
     if end_time is None:
         return None
     return end_time - start_time
@@ -137,10 +137,10 @@ def _event_overlaps_window(
     window_start: datetime,
     window_end: datetime,
 ) -> bool:
-    start_time = as_utc_aware(event.start_time) or event.start_time
-    end_time = as_utc_aware(event.end_time)
-    window_start = as_utc_aware(window_start) or window_start
-    window_end = as_utc_aware(window_end) or window_end
+    start_time = normalize_storage_datetime(event.start_time)
+    end_time = normalize_storage_datetime(event.end_time)
+    window_start = normalize_storage_datetime(window_start)
+    window_end = normalize_storage_datetime(window_end)
     return start_time <= window_end and (end_time is None or end_time >= window_start)
 
 
@@ -195,7 +195,7 @@ async def _load_skip_exceptions(
     rows = list((await session.execute(stmt)).scalars())
     result: dict[UUID, set[datetime]] = {}
     for row in rows:
-        instance_start = as_utc_aware(row.instance_start) or row.instance_start
+        instance_start = normalize_storage_datetime(row.instance_start)
         result.setdefault(row.master_event_id, set()).add(instance_start)
     return result
 
@@ -729,7 +729,7 @@ async def list_event_occurrences(
     override_keys = {
         (
             override.recurrence_parent_event_id,
-            as_utc_aware(override.recurrence_instance_start) or override.recurrence_instance_start,
+            normalize_storage_datetime(override.recurrence_instance_start),
         ): override
         for override in overrides
         if override.recurrence_parent_event_id is not None
@@ -740,7 +740,7 @@ async def list_event_occurrences(
     for master in masters:
         if not event_is_recurring(master):
             if _event_overlaps_window(master, window_start=window_start, window_end=window_end):
-                start_time = as_utc_aware(master.start_time) or master.start_time
+                start_time = normalize_storage_datetime(master.start_time)
                 occurrences.append(
                     EventOccurrence(
                         id=master.id,
@@ -748,9 +748,9 @@ async def list_event_occurrences(
                         status=master.status,
                         event_type=master.event_type,
                         start_time=start_time,
-                        end_time=as_utc_aware(master.end_time),
+                        end_time=normalize_storage_datetime(master.end_time),
                         task_id=master.task_id,
-                        deleted_at=as_utc_aware(master.deleted_at),
+                        deleted_at=normalize_storage_datetime(master.deleted_at),
                         instance_start=start_time,
                     )
                 )
@@ -780,7 +780,7 @@ async def list_event_occurrences(
             )
 
     for override in overrides:
-        override_start = as_utc_aware(override.start_time) or override.start_time
+        override_start = normalize_storage_datetime(override.start_time)
         occurrences.append(
             EventOccurrence(
                 id=override.id,
@@ -788,10 +788,12 @@ async def list_event_occurrences(
                 status=override.status,
                 event_type=override.event_type,
                 start_time=override_start,
-                end_time=as_utc_aware(override.end_time),
+                end_time=normalize_storage_datetime(override.end_time),
                 task_id=override.task_id,
-                deleted_at=as_utc_aware(override.deleted_at),
-                instance_start=(as_utc_aware(override.recurrence_instance_start) or override_start),
+                deleted_at=normalize_storage_datetime(override.deleted_at),
+                instance_start=(
+                    normalize_storage_datetime(override.recurrence_instance_start) or override_start
+                ),
             )
         )
 

--- a/src/lifeos_cli/db/services/timelog_stats.py
+++ b/src/lifeos_cli/db/services/timelog_stats.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from calendar import monthrange
 from collections import defaultdict
 from dataclasses import dataclass
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from uuid import UUID
 
 from sqlalchemy import delete, func, select
@@ -63,6 +63,13 @@ def iter_date_range(start_date: date, end_date: date) -> tuple[date, ...]:
     return tuple(dates)
 
 
+def _as_utc_aware(value: datetime) -> datetime:
+    """Interpret timezone-naive storage datetimes as UTC."""
+    if value.tzinfo is not None and value.utcoffset() is not None:
+        return value.astimezone(timezone.utc)
+    return value.replace(tzinfo=timezone.utc)
+
+
 def get_month_bounds(target_month: date) -> tuple[date, date]:
     """Return the first and last local dates for one month."""
     month_start = target_month.replace(day=1)
@@ -80,6 +87,8 @@ def iter_local_dates_for_timelog_window(
     end_time: datetime,
 ) -> tuple[date, ...]:
     """Return every configured local operational date touched by a timelog window."""
+    start_time = _as_utc_aware(start_time)
+    end_time = _as_utc_aware(end_time)
     if end_time <= start_time:
         return ()
     final_moment = end_time - timedelta(microseconds=1)
@@ -94,6 +103,10 @@ def overlap_minutes_for_window(
     window_end: datetime,
 ) -> int:
     """Return whole overlap minutes for one half-open window intersection."""
+    start_time = _as_utc_aware(start_time)
+    end_time = _as_utc_aware(end_time)
+    window_start = _as_utc_aware(window_start)
+    window_end = _as_utc_aware(window_end)
     overlap_start = max(start_time, window_start)
     overlap_end = min(end_time, window_end)
     if overlap_end <= overlap_start:

--- a/src/lifeos_cli/db/services/timelog_stats.py
+++ b/src/lifeos_cli/db/services/timelog_stats.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 from calendar import monthrange
 from collections import defaultdict
 from dataclasses import dataclass
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, datetime, timedelta
 from uuid import UUID
 
 from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from lifeos_cli.application.datetime_utils import normalize_storage_datetime
 from lifeos_cli.application.time_preferences import (
     get_operational_date,
     get_utc_window_for_local_date,
@@ -63,13 +64,6 @@ def iter_date_range(start_date: date, end_date: date) -> tuple[date, ...]:
     return tuple(dates)
 
 
-def _as_utc_aware(value: datetime) -> datetime:
-    """Interpret timezone-naive storage datetimes as UTC."""
-    if value.tzinfo is not None and value.utcoffset() is not None:
-        return value.astimezone(timezone.utc)
-    return value.replace(tzinfo=timezone.utc)
-
-
 def get_month_bounds(target_month: date) -> tuple[date, date]:
     """Return the first and last local dates for one month."""
     month_start = target_month.replace(day=1)
@@ -87,8 +81,8 @@ def iter_local_dates_for_timelog_window(
     end_time: datetime,
 ) -> tuple[date, ...]:
     """Return every configured local operational date touched by a timelog window."""
-    start_time = _as_utc_aware(start_time)
-    end_time = _as_utc_aware(end_time)
+    start_time = normalize_storage_datetime(start_time)
+    end_time = normalize_storage_datetime(end_time)
     if end_time <= start_time:
         return ()
     final_moment = end_time - timedelta(microseconds=1)
@@ -103,10 +97,10 @@ def overlap_minutes_for_window(
     window_end: datetime,
 ) -> int:
     """Return whole overlap minutes for one half-open window intersection."""
-    start_time = _as_utc_aware(start_time)
-    end_time = _as_utc_aware(end_time)
-    window_start = _as_utc_aware(window_start)
-    window_end = _as_utc_aware(window_end)
+    start_time = normalize_storage_datetime(start_time)
+    end_time = normalize_storage_datetime(end_time)
+    window_start = normalize_storage_datetime(window_start)
+    window_end = normalize_storage_datetime(window_end)
     overlap_start = max(start_time, window_start)
     overlap_end = min(end_time, window_end)
     if overlap_end <= overlap_start:

--- a/src/lifeos_web/routers/planned_events.py
+++ b/src/lifeos_web/routers/planned_events.py
@@ -21,6 +21,7 @@ from lifeos_cli.db.services.events import EventOccurrence
 from lifeos_cli.db.services.read_models import EventView
 from lifeos_web.deps import get_db_session
 from lifeos_web.schemas import ListResponse, Pagination, PlannedEventCreate, PlannedEventUpdate
+from lifeos_web.serialization import datetime_to_utc_iso
 
 router = APIRouter(prefix="/planned-events", tags=["planned-events"])
 SessionDep = Annotated[AsyncSession, Depends(get_db_session)]
@@ -88,7 +89,9 @@ def _planned_event_payload(
             "interval": source_event.recurrence_interval,
             "count": source_event.recurrence_count,
             "until": (
-                source_event.recurrence_until.isoformat() if source_event.recurrence_until else None
+                datetime_to_utc_iso(source_event.recurrence_until)
+                if source_event.recurrence_until
+                else None
             ),
         }
     if is_occurrence:
@@ -96,8 +99,8 @@ def _planned_event_payload(
     else:
         assert isinstance(event, EventView)
         master_id = event.recurrence_parent_event_id or event.id
-    created_at = event.created_at.isoformat() if isinstance(event, EventView) else ""
-    updated_at = event.updated_at.isoformat() if isinstance(event, EventView) else ""
+    created_at = datetime_to_utc_iso(event.created_at) if isinstance(event, EventView) else ""
+    updated_at = datetime_to_utc_iso(event.updated_at) if isinstance(event, EventView) else ""
     area_id = source_event.area_id if source_event else None
     priority = source_event.priority if source_event else 0
     is_all_day = source_event.is_all_day if source_event else False
@@ -105,8 +108,8 @@ def _planned_event_payload(
     return {
         "id": str(event.id),
         "title": event.title,
-        "start_time": event.start_time.isoformat(),
-        "end_time": event.end_time.isoformat() if event.end_time else None,
+        "start_time": datetime_to_utc_iso(event.start_time),
+        "end_time": datetime_to_utc_iso(event.end_time) if event.end_time else None,
         "priority": priority,
         "dimension_id": str(area_id) if area_id else None,
         "task_id": str(event.task_id) if event.task_id else None,

--- a/src/lifeos_web/routers/planned_events.py
+++ b/src/lifeos_web/routers/planned_events.py
@@ -10,6 +10,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from lifeos_cli.application.datetime_utils import format_utc_iso
 from lifeos_cli.db.services import events as event_services
 from lifeos_cli.db.services.event_support import (
     EventCreateInput,
@@ -21,7 +22,6 @@ from lifeos_cli.db.services.events import EventOccurrence
 from lifeos_cli.db.services.read_models import EventView
 from lifeos_web.deps import get_db_session
 from lifeos_web.schemas import ListResponse, Pagination, PlannedEventCreate, PlannedEventUpdate
-from lifeos_web.serialization import datetime_to_utc_iso
 
 router = APIRouter(prefix="/planned-events", tags=["planned-events"])
 SessionDep = Annotated[AsyncSession, Depends(get_db_session)]
@@ -89,7 +89,7 @@ def _planned_event_payload(
             "interval": source_event.recurrence_interval,
             "count": source_event.recurrence_count,
             "until": (
-                datetime_to_utc_iso(source_event.recurrence_until)
+                format_utc_iso(source_event.recurrence_until)
                 if source_event.recurrence_until
                 else None
             ),
@@ -99,8 +99,8 @@ def _planned_event_payload(
     else:
         assert isinstance(event, EventView)
         master_id = event.recurrence_parent_event_id or event.id
-    created_at = datetime_to_utc_iso(event.created_at) if isinstance(event, EventView) else ""
-    updated_at = datetime_to_utc_iso(event.updated_at) if isinstance(event, EventView) else ""
+    created_at = format_utc_iso(event.created_at) if isinstance(event, EventView) else ""
+    updated_at = format_utc_iso(event.updated_at) if isinstance(event, EventView) else ""
     area_id = source_event.area_id if source_event else None
     priority = source_event.priority if source_event else 0
     is_all_day = source_event.is_all_day if source_event else False
@@ -108,8 +108,8 @@ def _planned_event_payload(
     return {
         "id": str(event.id),
         "title": event.title,
-        "start_time": datetime_to_utc_iso(event.start_time),
-        "end_time": datetime_to_utc_iso(event.end_time) if event.end_time else None,
+        "start_time": format_utc_iso(event.start_time),
+        "end_time": format_utc_iso(event.end_time) if event.end_time else None,
         "priority": priority,
         "dimension_id": str(area_id) if area_id else None,
         "task_id": str(event.task_id) if event.task_id else None,

--- a/src/lifeos_web/serialization.py
+++ b/src/lifeos_web/serialization.py
@@ -3,10 +3,17 @@
 from __future__ import annotations
 
 from dataclasses import asdict, is_dataclass
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from enum import Enum
 from typing import Any, cast
 from uuid import UUID
+
+
+def datetime_to_utc_iso(value: datetime) -> str:
+    """Render stored datetimes as explicit UTC ISO strings for Web clients."""
+    if value.tzinfo is None or value.utcoffset() is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
 def to_jsonable(value: Any) -> Any:
@@ -20,7 +27,7 @@ def to_jsonable(value: Any) -> Any:
     if isinstance(value, UUID):
         return str(value)
     if isinstance(value, datetime):
-        return value.isoformat()
+        return datetime_to_utc_iso(value)
     if isinstance(value, date):
         return value.isoformat()
     if isinstance(value, Enum):

--- a/src/lifeos_web/serialization.py
+++ b/src/lifeos_web/serialization.py
@@ -3,17 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import asdict, is_dataclass
-from datetime import date, datetime, timezone
+from datetime import date, datetime
 from enum import Enum
 from typing import Any, cast
 from uuid import UUID
 
-
-def datetime_to_utc_iso(value: datetime) -> str:
-    """Render stored datetimes as explicit UTC ISO strings for Web clients."""
-    if value.tzinfo is None or value.utcoffset() is None:
-        value = value.replace(tzinfo=timezone.utc)
-    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+from lifeos_cli.application.datetime_utils import format_utc_iso
 
 
 def to_jsonable(value: Any) -> Any:
@@ -27,7 +22,7 @@ def to_jsonable(value: Any) -> Any:
     if isinstance(value, UUID):
         return str(value)
     if isinstance(value, datetime):
-        return datetime_to_utc_iso(value)
+        return format_utc_iso(value)
     if isinstance(value, date):
         return value.isoformat()
     if isinstance(value, Enum):

--- a/tests/test_data_ops.py
+++ b/tests/test_data_ops.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import asynccontextmanager
+from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
@@ -9,6 +10,7 @@ from uuid import UUID
 from zipfile import ZIP_DEFLATED, ZipFile
 
 import pytest
+from sqlalchemy import Column, DateTime
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from lifeos_cli.db.backend_policy import backend_policy_for_drivername
@@ -67,6 +69,22 @@ def test_batch_update_resource_parses_typed_timelog_fields(
     assert changes.task_id == UUID("33333333-3333-3333-3333-333333333333")
     assert changes.tag_ids == [UUID("44444444-4444-4444-4444-444444444444")]
     assert changes.person_ids == [UUID("55555555-5555-5555-5555-555555555555")]
+
+
+def test_parse_datetime_snapshot_values_normalizes_offsets_to_utc() -> None:
+    column = Column("start_time", DateTime(timezone=True))
+
+    parsed = data_ops._parse_column_value(column, "2026-06-13T21:00:00-04:00")
+
+    assert parsed == datetime(2026, 6, 14, 1, 0, tzinfo=timezone.utc)
+
+
+def test_serialize_datetime_snapshot_values_uses_explicit_utc() -> None:
+    value = datetime.fromisoformat("2026-06-13T21:00:00-04:00")
+
+    serialized = data_ops._serialize_scalar(value)
+
+    assert serialized == "2026-06-14T01:00:00Z"
 
 
 def test_batch_update_resource_parses_extended_note_relation_fields(

--- a/tests/test_domain_services_time.py
+++ b/tests/test_domain_services_time.py
@@ -613,6 +613,66 @@ def test_list_event_occurrences_expands_recurring_series_and_skips_exceptions() 
     ]
 
 
+def test_list_event_occurrences_treats_naive_sqlite_datetimes_as_utc() -> None:
+    class _Result:
+        def __init__(self, values: list[object]) -> None:
+            self._values = values
+
+        def scalars(self) -> list[object]:
+            return self._values
+
+    class _Session:
+        def __init__(self) -> None:
+            self._results = [
+                _Result(
+                    [
+                        SimpleNamespace(
+                            id=UUID("abababab-abab-abab-abab-abababababab"),
+                            title="Daily review",
+                            status="planned",
+                            event_type="appointment",
+                            start_time=datetime(2026, 4, 10, 13, 0),
+                            end_time=datetime(2026, 4, 10, 14, 0),
+                            task_id=None,
+                            deleted_at=None,
+                            recurrence_frequency="daily",
+                            recurrence_interval=1,
+                            recurrence_count=3,
+                            recurrence_until=None,
+                            recurrence_parent_event_id=None,
+                        )
+                    ]
+                ),
+                _Result(
+                    [
+                        SimpleNamespace(
+                            master_event_id=UUID("abababab-abab-abab-abab-abababababab"),
+                            instance_start=datetime(2026, 4, 11, 13, 0),
+                        )
+                    ]
+                ),
+                _Result([]),
+            ]
+
+        async def execute(self, statement: object) -> _Result:
+            return self._results.pop(0)
+
+    occurrences = asyncio.run(
+        events.list_event_occurrences(
+            cast(Any, _Session()),
+            query=events.EventOccurrenceQuery(
+                window_start=utc_datetime(2026, 4, 10, 0, 0),
+                window_end=utc_datetime(2026, 4, 12, 23, 59),
+            ),
+        )
+    )
+
+    assert [item.start_time for item in occurrences] == [
+        utc_datetime(2026, 4, 10, 13, 0),
+        utc_datetime(2026, 4, 12, 13, 0),
+    ]
+
+
 def test_list_event_occurrences_expands_monthly_series() -> None:
     class _Result:
         def __init__(self, values: list[object]) -> None:

--- a/tests/test_timelog_stats.py
+++ b/tests/test_timelog_stats.py
@@ -45,6 +45,17 @@ def test_overlap_minutes_for_window_returns_whole_minutes() -> None:
     assert minutes == 30
 
 
+def test_overlap_minutes_for_window_treats_naive_storage_values_as_utc() -> None:
+    minutes = timelog_stats.overlap_minutes_for_window(
+        start_time=datetime(2026, 4, 10, 12, 0),
+        end_time=datetime(2026, 4, 10, 13, 0),
+        window_start=datetime(2026, 4, 10, 12, 30, tzinfo=timezone.utc),
+        window_end=datetime(2026, 4, 10, 13, 30, tzinfo=timezone.utc),
+    )
+
+    assert minutes == 30
+
+
 @pytest.mark.usefixtures("configured_time_preferences")
 def test_resolve_stats_period_uses_configured_week_boundary() -> None:
     start_date, end_date = timelog_stats.resolve_stats_period(

--- a/tests/test_web_cli.py
+++ b/tests/test_web_cli.py
@@ -5,10 +5,11 @@ import os
 from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 from uuid import UUID
 
 import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from lifeos_cli.cli import build_parser
 from lifeos_cli.config import clear_config_cache
@@ -98,7 +99,7 @@ def test_web_timelog_without_dimension_filter_maps_to_lifeos_without_area(
 
     response = asyncio.run(
         timelogs.list_timelogs(
-            object(),
+            cast(AsyncSession, object()),
             page=1,
             size=50,
             without_dimension=True,
@@ -210,7 +211,7 @@ def test_web_task_update_null_planning_cycle_translates_to_clear_flag(
                 planning_cycle_days=None,
                 planning_cycle_start_date=None,
             ),
-            object(),
+            cast(AsyncSession, object()),
         )
     )
 
@@ -240,7 +241,7 @@ def test_web_task_update_null_parent_and_estimated_effort_translate_to_clear_fla
         tasks.update_task(
             UUID("55555555-5555-5555-5555-555555555555"),
             TaskUpdate(parent_task_id=None, estimated_effort=None),
-            object(),
+            cast(AsyncSession, object()),
         )
     )
 
@@ -268,7 +269,7 @@ def test_web_vision_update_null_description_and_experience_clear_flags(
         visions.update_vision(
             UUID("55555555-5555-5555-5555-555555555555"),
             VisionUpdate(description=None, experience_rate_per_hour=None),
-            object(),
+            cast(AsyncSession, object()),
         )
     )
 
@@ -300,8 +301,13 @@ def test_web_habit_update_null_fields_translate_to_clear_flags(
     asyncio.run(
         habits.update_habit(
             UUID("55555555-5555-5555-5555-555555555555"),
-            HabitUpdate(description=None, cadence_weekdays=None, task_id=None),
-            object(),
+            HabitUpdate(
+                description=None,
+                duration_days=None,
+                cadence_weekdays=None,
+                task_id=None,
+            ),
+            cast(AsyncSession, object()),
         )
     )
 
@@ -340,7 +346,7 @@ def test_web_habit_action_update_null_notes_maps_to_clear_notes(
             UUID("66666666-6666-6666-6666-666666666666"),
             UUID("77777777-7777-7777-7777-777777777777"),
             HabitActionUpdate(notes=None),
-            object(),
+            cast(AsyncSession, object()),
         )
     )
 
@@ -382,7 +388,7 @@ def test_web_habit_action_by_date_update_null_notes_maps_to_clear_notes(
             UUID("55555555-5555-5555-5555-555555555555"),
             datetime(2026, 6, 1, tzinfo=timezone.utc).date(),
             HabitActionUpdate(notes=None),
-            object(),
+            cast(AsyncSession, object()),
         )
     )
 
@@ -438,7 +444,7 @@ def test_web_timelog_update_null_fields_translate_to_clear_flags(
                 task_id=None,
                 person_ids=[],
             ),
-            object(),
+            cast(AsyncSession, object()),
         )
     )
 
@@ -491,7 +497,7 @@ def test_web_timelog_batch_task_replace_maps_to_lifeos_task_update(
                 update_type="task",
                 task=TimelogBatchTaskUpdate(mode="replace", task_id=task_id),
             ),
-            object(),
+            cast(AsyncSession, object()),
         )
     )
 
@@ -531,7 +537,7 @@ def test_web_tag_create_maps_to_lifeos_tag_service(
     response = asyncio.run(
         tags.create_tag(
             TagCreate(name="Project", entity_type="note", category="general"),
-            object(),
+            cast(AsyncSession, object()),
         )
     )
 
@@ -587,7 +593,7 @@ def test_web_note_create_maps_selector_associations_to_lifeos_note_service(
                 task_id=task_id,
                 actual_event_ids=[timelog_id],
             ),
-            object(),
+            cast(AsyncSession, object()),
         )
     )
 

--- a/tests/test_web_cli.py
+++ b/tests/test_web_cli.py
@@ -156,6 +156,36 @@ def test_web_timelog_payload_exposes_linked_task_summary() -> None:
     }
 
 
+def test_web_timelog_payload_serializes_naive_storage_datetimes_as_utc() -> None:
+    pytest.importorskip("fastapi")
+
+    from lifeos_web.routers.timelogs import _timelog_payload
+
+    payload = _timelog_payload(
+        TimelogView(
+            id=UUID("11111111-1111-1111-1111-111111111111"),
+            title="SQLite-backed work",
+            tracking_method="manual",
+            start_time=datetime(2026, 6, 13, 21, 0),
+            end_time=datetime(2026, 6, 13, 21, 5),
+            location=None,
+            energy_level=None,
+            notes=None,
+            area_id=None,
+            task_id=None,
+            created_at=datetime(2026, 6, 13, 21, 9, 24),
+            updated_at=datetime(2026, 6, 13, 21, 9, 24),
+            deleted_at=None,
+            linked_notes_count=0,
+            task=None,
+        )
+    )
+
+    assert payload["start_time"] == "2026-06-13T21:00:00Z"
+    assert payload["end_time"] == "2026-06-13T21:05:00Z"
+    assert payload["created_at"] == "2026-06-13T21:09:24Z"
+
+
 def test_web_task_update_null_planning_cycle_translates_to_clear_flag(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## 背景

本分支处理从 PostgreSQL 迁移到 SQLite 后暴露出的时间处理问题。SQLite 驱动回读 `DateTime(timezone=True)` 时会得到 timezone-naive `datetime`，而既有代码在部分路径中假设存储时间是 timezone-aware UTC，导致统计、Web API 序列化、recurrence 展开等行为不一致。

## 主要变更

- 在存储/API 边界新增统一 datetime helper：将存储层 naive datetime 明确解释为 UTC，并输出带 `Z` 的 UTC ISO 字符串。
- 修复 timelog stats 在 SQLite naive datetime 下与 aware window 比较时的时间归一化问题。
- 修复 bundle import/export：带 offset 的 ISO datetime 在导入时归一化为 UTC，导出时显式写出 UTC。
- 修复 planned events / recurrence：recurring master、exception、override 和查询窗口进入 recurrence 计算前统一归一化为 UTC-aware datetime。
- 修复 Web API datetime 序列化，避免返回无时区 ISO 字符串让前端误判本地时间。
- 增加针对 SQLite naive datetime、bundle datetime offset、Web payload UTC 输出的回归测试。

## 影响范围

- 主要影响 SQLite 后端与 Web API 的 datetime 边界行为。
- PostgreSQL 路径仍会得到 timezone-aware datetime；本分支只在进入计算/序列化前执行幂等的 `astimezone(UTC)`，不改变 PostgreSQL 的存储 schema、迁移、连接配置或业务查询语义。
- 本 PR 不关闭多数据库支持规划 issue；它只是修复该工作流中发现的一组 SQLite 时间契约问题。

## 风险与审查结论

- 对 PostgreSQL 用户的风险较低：新增归一化 helper 对 aware datetime 是幂等转换，保持 UTC 语义。
- 对 SQLite 用户是行为修复：naive storage datetime 被明确视为 UTC，而不是被 Python/前端隐式当成本地时间。
- 已清理本分支引入的重复 helper，避免 timelog、event、web serialization 各自维护一份 UTC 归一化逻辑。
- 死代码扫描无新增可删项；没有保留兼容别名或纯转发薄壳。

## 验证

- `uv run pytest tests/test_data_ops.py tests/test_domain_services_time.py tests/test_timelog_stats.py tests/test_web_cli.py`
- `bash ./scripts/dead_code_check.sh`
- `uv run pre-commit run --all-files`
- `bash ./scripts/doctor.sh`
  - 主测试：`558 passed, 19 skipped, 13 deselected`
  - PostgreSQL CLI integration：`13 passed`

Related #107
