### PR TITLE
chore(deps): automate frontend dependency audits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,29 @@ updates:
     commit-message:
       prefix: "deps"
     labels:
+      - "backend"
       - "dependencies"
     groups:
       uv-all-updates:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/web"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2
+    commit-message:
+      prefix: "deps(web)"
+    labels:
+      - "frontend"
+      - "dependencies"
+    groups:
+      web-runtime:
+        dependency-type: "production"
+        patterns:
+          - "*"
+      web-tooling:
+        dependency-type: "development"
         patterns:
           - "*"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 jobs:
-  dependency-health:
+  python-dependency-health:
     name: Audit Development Dependencies (Python 3.10 Baseline)
     runs-on: ubuntu-latest
 
@@ -29,3 +29,21 @@ jobs:
 
       - name: Run dependency health checks
         run: bash ./scripts/dependency_health.sh
+
+  web-dependency-health:
+    name: Audit Web Dependencies
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: web/package-lock.json
+
+      - name: Run web dependency health checks
+        run: bash ./scripts/web_dependency_health.sh

--- a/.github/workflows/frontend-dependency-audit.yml
+++ b/.github/workflows/frontend-dependency-audit.yml
@@ -1,0 +1,139 @@
+name: Frontend Dependency Audit and Auto-Fix
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 4 * * 1"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  frontend-dependency-audit:
+    name: Audit frontend dependencies and propose fixes
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Run frontend dependency audit
+        id: audit
+        run: |
+          set +e
+          npm audit --json > /tmp/web-npm-audit.json
+          audit_exit=$?
+          set -e
+
+          echo "audit_exit=$audit_exit" >> "$GITHUB_OUTPUT"
+
+          node <<'EOF' >> "$GITHUB_STEP_SUMMARY"
+          const fs = require("fs");
+          const path = "/tmp/web-npm-audit.json";
+
+          console.log("## Frontend dependency audit");
+          console.log("");
+
+          if (!fs.existsSync(path)) {
+            console.log("`npm audit` did not produce a JSON report.");
+            process.exit(0);
+          }
+
+          const report = JSON.parse(fs.readFileSync(path, "utf8"));
+          const totals = report.metadata?.vulnerabilities ?? {};
+          const total = totals.total ?? 0;
+
+          console.log(`Total vulnerabilities: ${total}`);
+          console.log("");
+          console.log(`- Critical: ${totals.critical ?? 0}`);
+          console.log(`- High: ${totals.high ?? 0}`);
+          console.log(`- Moderate: ${totals.moderate ?? 0}`);
+          console.log(`- Low: ${totals.low ?? 0}`);
+          console.log(`- Info: ${totals.info ?? 0}`);
+          EOF
+
+          if [ "$audit_exit" -ne 0 ]; then
+            echo "::warning title=Frontend dependency audit::Known vulnerabilities were found in frontend dependencies. Review the job summary and uploaded report."
+          fi
+
+      - name: Attempt non-force frontend audit fix
+        id: fix
+        run: |
+          set +e
+          npm audit fix --package-lock-only
+          fix_exit=$?
+          set -e
+
+          echo "fix_exit=$fix_exit" >> "$GITHUB_OUTPUT"
+
+          if git diff --quiet -- package-lock.json package.json; then
+            echo "changes_detected=false" >> "$GITHUB_OUTPUT"
+            echo "No package manifest changes were produced by npm audit fix." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "changes_detected=true" >> "$GITHUB_OUTPUT"
+            {
+              echo ""
+              echo "## Non-force fix result"
+              echo ""
+              echo '`npm audit fix --package-lock-only` produced dependency updates.'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          if [ "$fix_exit" -ne 0 ]; then
+            {
+              echo ""
+              echo "Non-force audit fix did not fully resolve all reported issues."
+              echo "Manual dependency upgrades may still be required."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload frontend dependency audit report
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: web-npm-audit
+          path: /tmp/web-npm-audit.json
+          if-no-files-found: ignore
+
+      - name: Create frontend audit fix pull request
+        if: steps.fix.outputs.changes_detected == 'true'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          title: "chore(web): apply npm audit fix updates (#133)"
+          body: |
+            ## 变更说明
+            本 PR 由前端依赖审计工作流自动发起，用于应用非强制的 `npm audit fix` 结果。
+
+            ## 自动化范围
+            - 工作流: `.github/workflows/frontend-dependency-audit.yml`
+            - 修复方式: `npm audit fix --package-lock-only`
+            - 限制: 不使用 `--force`
+
+            ## 说明
+            - 本 PR 仅包含 `npm audit fix` 自动可处理的前端依赖清单和锁文件变更
+            - 若审计结果仍存在未修复问题，需要人工评估并升级依赖
+
+            ## 关联
+            - Related #133
+          branch: "chore/web-npm-audit-fix"
+          base: main
+          commit-message: "chore(web): apply npm audit fix updates (#133)"
+          delete-branch: true
+          draft: true
+          add-paths: |
+            web/package-lock.json
+            web/package.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,12 +57,17 @@ If you change dependency or release workflows, also run:
 
 ```bash
 bash ./scripts/dependency_health.sh
+bash ./scripts/web_dependency_health.sh
 ```
 
 Dependency maintenance policy:
 
-- `.github/dependabot.yml` opens a single weekly grouped version-update PR for `uv`.
-- `bash ./scripts/dependency_health.sh` remains the explicit maintainer audit flow for outdated packages and dependency-related health checks.
+- `.github/dependabot.yml` opens separate weekly version-update PRs for the root `uv` backend workspace and the `web/` npm frontend workspace.
+- Backend dependency updates use the `backend` and `dependencies` labels.
+- Frontend dependency updates use the `frontend` and `dependencies` labels, with runtime and tooling dependency groups kept separate inside the npm workspace.
+- `bash ./scripts/dependency_health.sh` remains the explicit maintainer audit flow for Python outdated packages and dependency-related health checks.
+- `bash ./scripts/web_dependency_health.sh` remains the explicit maintainer audit flow for frontend outdated packages and dependency-related health checks.
+- `.github/workflows/frontend-dependency-audit.yml` runs a weekly frontend audit and opens a draft PR when non-force `npm audit fix --package-lock-only` produces changes for `web/package-lock.json` or `web/package.json`.
 
 Static-analysis governance:
 

--- a/scripts/web_dependency_health.sh
+++ b/scripts/web_dependency_health.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${repo_root}/web"
+
+echo "[web-dependency-health] install locked dependencies"
+npm ci
+
+echo "[web-dependency-health] list outdated packages"
+npm outdated --long || true
+
+echo "[web-dependency-health] run frontend dependency vulnerability audit"
+npm audit --audit-level=low

--- a/tests/test_repository_contracts.py
+++ b/tests/test_repository_contracts.py
@@ -9,7 +9,14 @@ DEPENDABOT_CONFIG = yaml.safe_load(Path(".github/dependabot.yml").read_text())
 DOCTOR_TEXT = Path("scripts/doctor.sh").read_text()
 DEAD_CODE_CHECK_TEXT = Path("scripts/dead_code_check.sh").read_text()
 DEPENDENCY_HEALTH_TEXT = Path("scripts/dependency_health.sh").read_text()
+WEB_DEPENDENCY_HEALTH_TEXT = Path("scripts/web_dependency_health.sh").read_text()
 PRE_COMMIT_CONFIG = yaml.safe_load(Path(".pre-commit-config.yaml").read_text())
+DEPENDENCY_REVIEW_WORKFLOW = yaml.safe_load(
+    Path(".github/workflows/dependency-review.yml").read_text()
+)
+FRONTEND_DEPENDENCY_AUDIT_WORKFLOW = yaml.safe_load(
+    Path(".github/workflows/frontend-dependency-audit.yml").read_text()
+)
 VALIDATE_WORKFLOW = yaml.safe_load(Path(".github/workflows/validate.yml").read_text())
 VULTURE_WHITELIST_TEXT = Path("scripts/vulture_whitelist.py").read_text()
 LOAD_LOCAL_ENV_TEXT = Path("scripts/load_local_env.sh").read_text()
@@ -46,18 +53,32 @@ def _flatten_json_catalog_keys(catalog: dict[str, Any]) -> dict[str, str]:
 
 DOCTOR_COMMANDS = _non_comment_shell_lines(DOCTOR_TEXT)
 DEPENDENCY_HEALTH_COMMANDS = _non_comment_shell_lines(DEPENDENCY_HEALTH_TEXT)
+WEB_DEPENDENCY_HEALTH_COMMANDS = _non_comment_shell_lines(WEB_DEPENDENCY_HEALTH_TEXT)
 QUALITY_GATE_STEPS = _workflow_job_steps(VALIDATE_WORKFLOW, "quality-gate")
 INTEGRATION_JOB_STEPS = _workflow_job_steps(VALIDATE_WORKFLOW, "integration-postgres")
 
 
-def test_dependabot_configuration_prefers_a_single_grouped_uv_pr() -> None:
+def test_dependabot_configuration_keeps_backend_and_frontend_updates_separate() -> None:
     updates = DEPENDABOT_CONFIG["updates"]
     assert isinstance(updates, list)
-    ecosystems = {entry["package-ecosystem"] for entry in updates}
-    assert ecosystems == {"uv"}
-    uv_entry = updates[0]
+    entries = {entry["package-ecosystem"]: entry for entry in updates}
+    assert set(entries) == {"uv", "npm"}
+
+    uv_entry = entries["uv"]
+    assert uv_entry["directory"] == "/"
     assert uv_entry["open-pull-requests-limit"] == 1
+    assert uv_entry["labels"] == ["backend", "dependencies"]
     assert uv_entry["groups"]["uv-all-updates"]["patterns"] == ["*"]
+
+    npm_entry = entries["npm"]
+    assert npm_entry["directory"] == "/web"
+    assert npm_entry["open-pull-requests-limit"] == 2
+    assert npm_entry["commit-message"]["prefix"] == "deps(web)"
+    assert npm_entry["labels"] == ["frontend", "dependencies"]
+    assert npm_entry["groups"]["web-runtime"]["dependency-type"] == "production"
+    assert npm_entry["groups"]["web-runtime"]["patterns"] == ["*"]
+    assert npm_entry["groups"]["web-tooling"]["dependency-type"] == "development"
+    assert npm_entry["groups"]["web-tooling"]["patterns"] == ["*"]
 
 
 def test_dependency_scripts_keep_separate_scopes() -> None:
@@ -74,6 +95,57 @@ def test_dependency_scripts_keep_separate_scopes() -> None:
     assert any("uv pip list --outdated" in line for line in DEPENDENCY_HEALTH_COMMANDS)
     assert any("uv run pip-audit" in line for line in DEPENDENCY_HEALTH_COMMANDS)
     assert not any("uv run pytest" in line for line in DEPENDENCY_HEALTH_COMMANDS)
+    assert any("npm ci" in line for line in WEB_DEPENDENCY_HEALTH_COMMANDS)
+    assert any("npm outdated --long || true" in line for line in WEB_DEPENDENCY_HEALTH_COMMANDS)
+    assert any("npm audit --audit-level=low" in line for line in WEB_DEPENDENCY_HEALTH_COMMANDS)
+    assert not any("uv " in line for line in WEB_DEPENDENCY_HEALTH_COMMANDS)
+
+
+def test_dependency_review_workflow_audits_backend_and_frontend_dependencies() -> None:
+    jobs = DEPENDENCY_REVIEW_WORKFLOW["jobs"]
+    assert set(jobs) == {"python-dependency-health", "web-dependency-health"}
+
+    python_steps = _workflow_job_steps(DEPENDENCY_REVIEW_WORKFLOW, "python-dependency-health")
+    python_run_steps = [step["run"] for step in python_steps if "run" in step]
+    assert "bash ./scripts/dependency_health.sh" in python_run_steps
+
+    web_steps = _workflow_job_steps(DEPENDENCY_REVIEW_WORKFLOW, "web-dependency-health")
+    web_run_steps = [step["run"] for step in web_steps if "run" in step]
+    assert "bash ./scripts/web_dependency_health.sh" in web_run_steps
+    setup_node_step = next(
+        step for step in web_steps if step.get("uses") == "actions/setup-node@v6"
+    )
+    assert setup_node_step["with"]["cache"] == "npm"
+    assert setup_node_step["with"]["cache-dependency-path"] == "web/package-lock.json"
+
+
+def test_frontend_dependency_audit_workflow_creates_non_force_fix_prs() -> None:
+    assert FRONTEND_DEPENDENCY_AUDIT_WORKFLOW["permissions"] == {
+        "contents": "write",
+        "pull-requests": "write",
+    }
+
+    steps = _workflow_job_steps(FRONTEND_DEPENDENCY_AUDIT_WORKFLOW, "frontend-dependency-audit")
+    run_steps = [step["run"] for step in steps if "run" in step]
+    joined_run_steps = "\n".join(run_steps)
+    assert "npm audit --json > /tmp/web-npm-audit.json" in joined_run_steps
+    assert "npm audit fix --package-lock-only" in joined_run_steps
+    assert "--force" not in joined_run_steps
+
+    create_pr_step = next(
+        step for step in steps if step.get("uses") == "peter-evans/create-pull-request@v8"
+    )
+    create_pr_inputs = create_pr_step["with"]
+    assert create_pr_inputs["base"] == "main"
+    assert create_pr_inputs["branch"] == "chore/web-npm-audit-fix"
+    assert create_pr_inputs["draft"] is True
+    assert create_pr_inputs["title"] == "chore(web): apply npm audit fix updates (#133)"
+    assert create_pr_inputs["commit-message"] == ("chore(web): apply npm audit fix updates (#133)")
+    assert create_pr_inputs["add-paths"].splitlines() == [
+        "web/package-lock.json",
+        "web/package.json",
+    ]
+    assert "labels" not in create_pr_inputs
 
 
 def test_dead_code_scan_is_part_of_the_default_validation_gate() -> None:


### PR DESCRIPTION
## 变更说明

- 为后端 `uv` 和前端 `/web` npm 配置独立 Dependabot version update 入口，避免前后端依赖升级合并到同一个 PR。
- 为后端和前端依赖更新分别使用 `backend` / `frontend` 与 `dependencies` 标签。
- 新增前端依赖健康检查脚本，并在 dependency review workflow 中增加独立 Web job。
- 新增前端依赖审计自动修复 workflow：每周运行 `npm audit`，并在 `npm audit fix --package-lock-only` 产生变更时创建 draft PR。
- 自动修复 workflow 不使用 `--force`，且仅允许提交 `web/package-lock.json` 和 `web/package.json`。
- 更新英文贡献文档和仓库契约测试，锁定上述自动化边界。

## 设计说明

- 本 PR 没有开启 `dependabot_security_updates`。前端安全修复 PR 由显式 workflow 通过非强制 `npm audit fix --package-lock-only` 产生。
- `dependency-review.yml` 保持只读权限；只有新增的前端 audit fix workflow 具备 `contents: write` 和 `pull-requests: write`，权限边界更清楚。
- 前端常规升级由 Dependabot npm entry 处理；前端 audit fix 由单独 workflow 处理，两类 PR 不混在一起。

## 验证

- `uv run pytest tests/test_repository_contracts.py`
- `bash ./scripts/web_dependency_health.sh`
- `bash ./scripts/doctor.sh`

## 已知情况

- `bash ./scripts/dependency_health.sh` 当前失败于既有 Python dev 依赖漏洞：`idna`、`pip`、`urllib3`。这不是本 PR 引入，且 `doctor.sh` 中 runtime dependency audit 已通过。建议后续单独用后端依赖升级 PR 处理。

## 关联

Closes #133
