### PR TITLE
chore(web): tighten dependency automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,12 +26,22 @@ updates:
     labels:
       - "frontend"
       - "dependencies"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     groups:
       web-runtime:
         dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
         patterns:
           - "*"
       web-tooling:
         dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
         patterns:
           - "*"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -31,6 +31,24 @@ jobs:
       - name: Run default validation
         run: bash ./scripts/doctor.sh
 
+  frontend:
+    name: Validate Frontend
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: web/package-lock.json
+
+      - name: Run frontend validation
+        run: bash ./scripts/web_validate.sh
+
   runtime-matrix:
     name: Validate Runtime Matrix (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,14 @@ bash ./scripts/doctor.sh
 
 The default validation baseline includes dead-code scanning through `vulture`. It validates locked dependency resolution, runs lint plus the default non-integration test suite, exports runtime requirements for `pip-audit`, builds package artifacts, and then calls `bash ./scripts/integration_tests.sh` as the explicit PostgreSQL-backed integration entrypoint. When `LIFEOS_TEST_DATABASE_URL` is unset, the integration script reports an explicit skip and `doctor.sh` finishes with a warning that PostgreSQL CLI coverage did not run.
 
+For frontend changes, including npm dependency updates, also run:
+
+```bash
+bash ./scripts/web_validate.sh
+```
+
+The frontend validation entrypoint installs the locked npm workspace, builds the Vite app, runs ESLint, and executes the Vitest suite.
+
 If you change CI, packaging metadata, or compatibility declarations, also validate the relevant interpreter targets explicitly. Examples:
 
 ```bash
@@ -65,8 +73,10 @@ Dependency maintenance policy:
 - `.github/dependabot.yml` opens separate weekly version-update PRs for the root `uv` backend workspace and the `web/` npm frontend workspace.
 - Backend dependency updates use the `backend` and `dependencies` labels.
 - Frontend dependency updates use the `frontend` and `dependencies` labels, with runtime and tooling dependency groups kept separate inside the npm workspace.
+- Frontend Dependabot version-update groups only allow semver minor and patch updates. Semver major version updates for the npm workspace are intentionally ignored by routine automation and should be handled as explicit migration tasks with frontend validation coverage. Security updates continue to rely on GitHub Dependabot security update behavior.
 - `bash ./scripts/dependency_health.sh` remains the explicit maintainer audit flow for Python outdated packages and dependency-related health checks.
 - `bash ./scripts/web_dependency_health.sh` remains the explicit maintainer audit flow for frontend outdated packages and dependency-related health checks.
+- `bash ./scripts/web_validate.sh` remains the explicit maintainer and CI validation flow for frontend install, build, lint, and tests.
 - `.github/workflows/frontend-dependency-audit.yml` runs a weekly frontend audit and opens a draft PR when non-force `npm audit fix --package-lock-only` produces changes for `web/package-lock.json` or `web/package.json`.
 
 Static-analysis governance:

--- a/scripts/web_validate.sh
+++ b/scripts/web_validate.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${repo_root}/web"
+
+echo "[web-validate] install locked dependencies"
+npm ci
+
+echo "[web-validate] build frontend"
+npm run build
+
+echo "[web-validate] lint frontend"
+npm run lint
+
+echo "[web-validate] run frontend tests"
+npm test


### PR DESCRIPTION
## 摘要

- 收紧 `/web` Dependabot 常规 version updates：前端运行时和工具链分组只接受 semver minor/patch，并忽略 npm workspace 的 routine semver-major version updates
- 新增 `scripts/web_validate.sh`，统一执行前端 `npm ci`、构建、lint 和测试
- 在默认 PR/Main 验证 workflow 中新增 `Validate Frontend` job
- 更新贡献文档，说明前端验证入口和 major 迁移策略

## 验证

- `bash ./scripts/web_validate.sh`
  - `npm ci` 通过
  - `npm run build` 通过
  - `npm run lint` 通过，保留现有 2 个 warnings
  - `npm test` 通过：45 个测试文件，158 个测试
- `bash ./scripts/doctor.sh` 通过，包括 PostgreSQL CLI 集成测试：13 passed
- `uv run pre-commit run --files .github/dependabot.yml .github/workflows/validate.yml CONTRIBUTING.md scripts/web_validate.sh` 通过
- `bash ./scripts/web_dependency_health.sh` 通过，npm audit 为 0

## 已知情况

- `bash ./scripts/dependency_health.sh` 失败在现有 Python dev dependency audit：`idna`、`pip`、`urllib3` 有已知漏洞；这不是本次前端 bot/CI 改动引入的，需后续由后端依赖维护处理。

Closes #142
