### PR TITLE
fix: planning, timelog, and task reorder edge cases

### DIFF
--- a/src/lifeos_web/routers/tasks.py
+++ b/src/lifeos_web/routers/tasks.py
@@ -12,7 +12,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from lifeos_cli.db.services import tasks as task_services
 from lifeos_web.deps import get_db_session
-from lifeos_web.schemas import ListResponse, Pagination, TaskCreate, TaskStatusUpdate, TaskUpdate
+from lifeos_web.schemas import (
+    ListResponse,
+    Pagination,
+    TaskCreate,
+    TaskReorderRequest,
+    TaskStatusUpdate,
+    TaskUpdate,
+)
 from lifeos_web.serialization import to_jsonable, to_jsonable_dict
 
 router = APIRouter(prefix="/tasks", tags=["tasks"])
@@ -130,15 +137,6 @@ async def list_tasks(
     )
 
 
-@router.get("/{task_id}")
-async def get_task(task_id: UUID, session: SessionDep) -> dict[str, object]:
-    """Load one task."""
-    task = await task_services.get_task(session, task_id=task_id)
-    if task is None:
-        raise HTTPException(status_code=404, detail=f"Task {task_id} was not found")
-    return to_jsonable_dict(task)
-
-
 @router.post("/")
 async def create_task(
     payload: TaskCreate,
@@ -160,6 +158,38 @@ async def create_task(
         )
     except (LookupError, ValueError) as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return to_jsonable_dict(task)
+
+
+@router.get("/vision/{vision_id}/hierarchy")
+async def get_vision_hierarchy(vision_id: UUID, session: SessionDep) -> dict[str, object]:
+    """Load a frontend-compatible task hierarchy for one vision."""
+    try:
+        hierarchy = await task_services.get_vision_task_hierarchy(session, vision_id=vision_id)
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return {
+        "vision_id": str(hierarchy.vision_id),
+        "root_tasks": [_task_tree_payload(task) for task in hierarchy.root_tasks],
+    }
+
+
+@router.post("/reorder", status_code=204)
+async def reorder_tasks(payload: TaskReorderRequest, session: SessionDep) -> None:
+    """Update display order for multiple tasks."""
+    task_orders = [(item.id, item.display_order) for item in payload.task_orders]
+    try:
+        await task_services.reorder_tasks(session, task_orders=task_orders)
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.get("/{task_id}")
+async def get_task(task_id: UUID, session: SessionDep) -> dict[str, object]:
+    """Load one task."""
+    task = await task_services.get_task(session, task_id=task_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail=f"Task {task_id} was not found")
     return to_jsonable_dict(task)
 
 
@@ -237,19 +267,6 @@ async def update_task_status(
     return to_jsonable_dict(task)
 
 
-@router.get("/vision/{vision_id}/hierarchy")
-async def get_vision_hierarchy(vision_id: UUID, session: SessionDep) -> dict[str, object]:
-    """Load a frontend-compatible task hierarchy for one vision."""
-    try:
-        hierarchy = await task_services.get_vision_task_hierarchy(session, vision_id=vision_id)
-    except LookupError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
-    return {
-        "vision_id": str(hierarchy.vision_id),
-        "root_tasks": [_task_tree_payload(task) for task in hierarchy.root_tasks],
-    }
-
-
 @router.get("/{task_id}/with-subtasks")
 async def get_task_with_subtasks(task_id: UUID, session: SessionDep) -> dict[str, object]:
     """Load one task with nested subtasks."""
@@ -267,19 +284,6 @@ async def get_task_stats(task_id: UUID, session: SessionDep) -> dict[str, object
     except LookupError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     return to_jsonable_dict(stats)
-
-
-@router.post("/reorder", status_code=204)
-async def reorder_tasks(payload: dict[str, Any], session: SessionDep) -> None:
-    """Update display order for multiple tasks."""
-    task_orders = [
-        (UUID(str(item["id"])), int(item["display_order"]))
-        for item in payload.get("task_orders", [])
-    ]
-    try:
-        await task_services.reorder_tasks(session, task_orders=task_orders)
-    except LookupError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 @router.post("/{task_id}/move")

--- a/src/lifeos_web/schemas.py
+++ b/src/lifeos_web/schemas.py
@@ -60,6 +60,19 @@ class TaskStatusUpdate(BaseModel):
     status: str
 
 
+class TaskReorderItem(BaseModel):
+    """One task display-order update."""
+
+    id: UUID
+    display_order: int
+
+
+class TaskReorderRequest(BaseModel):
+    """Payload for reordering tasks from the Web UI."""
+
+    task_orders: list[TaskReorderItem] = Field(default_factory=list)
+
+
 class NoteCreate(BaseModel):
     """Payload for creating a note from the Web UI."""
 

--- a/tests/test_web_cli.py
+++ b/tests/test_web_cli.py
@@ -112,6 +112,46 @@ def test_web_tasks_list_uses_count_for_pagination_and_query(
     assert response.meta["query"] == "Needle"
 
 
+def test_web_tasks_reorder_route_precedes_task_id_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("fastapi")
+
+    from lifeos_web.routers import tasks as task_router
+    from lifeos_web.schemas import TaskReorderItem, TaskReorderRequest
+
+    captured: dict[str, object] = {}
+
+    async def fake_reorder_tasks(_session: object, **kwargs: object) -> None:
+        captured["task_orders"] = kwargs["task_orders"]
+
+    monkeypatch.setattr(task_router.task_services, "reorder_tasks", fake_reorder_tasks)
+
+    task_route_paths = [getattr(route, "path", None) for route in task_router.router.routes]
+
+    task_one_id = "11111111-1111-1111-1111-111111111111"
+    task_two_id = "22222222-2222-2222-2222-222222222222"
+
+    assert task_route_paths.index("/tasks/reorder") < task_route_paths.index("/tasks/{task_id}")
+
+    asyncio.run(
+        task_router.reorder_tasks(
+            TaskReorderRequest(
+                task_orders=[
+                    TaskReorderItem(id=UUID(task_two_id), display_order=0),
+                    TaskReorderItem(id=UUID(task_one_id), display_order=1),
+                ],
+            ),
+            cast(AsyncSession, object()),
+        )
+    )
+
+    assert captured["task_orders"] == [
+        (UUID(task_two_id), 0),
+        (UUID(task_one_id), 1),
+    ]
+
+
 def test_web_static_assets_disable_cache(tmp_path: Path) -> None:
     pytest.importorskip("fastapi")
 

--- a/web/src/components/DraggableTaskList.tsx
+++ b/web/src/components/DraggableTaskList.tsx
@@ -60,7 +60,7 @@ interface DraggableTaskListProps {
   onViewNotes: (task: TaskWithSubtasks) => void;
   expandedTasks?: Set<UUID>;
   onToggleExpansion?: (taskId: UUID) => void;
-  onTasksReorder?: (reorderedTasks: TaskWithSubtasks[]) => void;
+  onTasksReorder?: (reorderedTasks: TaskWithSubtasks[]) => void | Promise<void>;
   habitTaskAssociations?: Record<UUID, Habit[]>;
   // Vision information for planning page
   visions?: Vision[];
@@ -729,34 +729,13 @@ const DraggableTaskList: React.FC<DraggableTaskListProps> = ({
 
       const reorderedSiblings = arrayMove(siblings, oldIndex, newIndex);
 
-      const taskOrders = reorderedSiblings.map(
-        (task: TaskWithSubtasks, index: number) => ({
-          id: task.id,
-          display_order: index,
-        }),
-      );
-
-      try {
-        await tasksApi.reorder(taskOrders);
-        if (onTasksReorder) {
-          const updatedTasks = hierarchyManager.updateTaskOrder(
-            tasks,
-            reorderedSiblings,
-            activeInfo.parentId,
-          );
-          onTasksReorder(updatedTasks);
-        }
-      } catch (error) {
-        logger.error("Failed to reorder tasks:", error);
-        // Even if reorder fails, we should still update the UI to maintain consistency
-        if (onTasksReorder) {
-          const updatedTasks = hierarchyManager.updateTaskOrder(
-            tasks,
-            reorderedSiblings,
-            activeInfo.parentId,
-          );
-          onTasksReorder(updatedTasks);
-        }
+      if (onTasksReorder) {
+        const updatedTasks = hierarchyManager.updateTaskOrder(
+          tasks,
+          reorderedSiblings,
+          activeInfo.parentId,
+        );
+        await onTasksReorder(updatedTasks);
       }
     },
     [hierarchyManager, onTasksReorder, tasks],
@@ -781,13 +760,13 @@ const DraggableTaskList: React.FC<DraggableTaskListProps> = ({
           // For cross-level moves, we need to reload the entire task tree
           // since the structure has changed significantly
           // Send a special signal to indicate cross-level move
-          onTasksReorder([]); // Empty array signals cross-level move
+          await onTasksReorder([]); // Empty array signals cross-level move
         }
       } catch (error) {
         logger.error("Failed to move task:", error);
         // Even if the move fails, we should still request a reload to ensure UI consistency
         if (onTasksReorder) {
-          onTasksReorder([]);
+          await onTasksReorder([]);
         }
       }
     },

--- a/web/src/features/timeLog/controller/useTimeLogAdvancedInteractions.ts
+++ b/web/src/features/timeLog/controller/useTimeLogAdvancedInteractions.ts
@@ -40,7 +40,6 @@ interface TimeLogAdvancedInteractionsReturn {
   resetAdvancedSearch: () => void;
   loadAdvancedSearchResults: () => Promise<void>;
   handleAdvancedSearch: () => void;
-  processedAdvancedSearchData: ProcessedEntry[];
   filteredEntries: ProcessedEntry[];
 }
 
@@ -203,7 +202,6 @@ export function useTimeLogAdvancedInteractions({
     resetAdvancedSearch,
     loadAdvancedSearchResults,
     handleAdvancedSearch,
-    processedAdvancedSearchData,
     filteredEntries,
   };
 }

--- a/web/src/features/timeLog/controller/useTimeLogData.ts
+++ b/web/src/features/timeLog/controller/useTimeLogData.ts
@@ -37,7 +37,6 @@ interface UseTimeLogDataReturn {
   setIsSelectMode: (value: boolean) => void;
   // Advanced search support
   setAdvancedSearchResultsFromHook: (results: ProcessedEntry[]) => void;
-  clearAdvancedSearchResultsFromHook: () => void;
   selectionHandlers: {
     handleSelectEntry: (entryId: UUID, checked: boolean) => void;
     handleSelectAll: () => void;
@@ -287,11 +286,6 @@ export const useTimeLogData = ({
     [],
   );
 
-  const clearAdvancedSearchResultsFromHook = useCallback(() => {
-    // Reset to empty state for advanced search
-    setAdvancedSearchResults([]);
-  }, []);
-
   return {
     processedEntries,
     loading,
@@ -309,7 +303,6 @@ export const useTimeLogData = ({
     cancelBatchDelete,
     setIsSelectMode,
     setAdvancedSearchResultsFromHook,
-    clearAdvancedSearchResultsFromHook,
     selectionHandlers: {
       handleSelectEntry,
       handleSelectAll,

--- a/web/src/features/timeLog/controller/useTimeLogData.ts
+++ b/web/src/features/timeLog/controller/useTimeLogData.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { invalidateTimelogList } from "@/services/api/cacheInvalidation/timelogs";
 import { timelogsApi } from "@/services/api/timelogs";
@@ -73,6 +73,17 @@ export const useTimeLogData = ({
   const [advancedSearchResults, setAdvancedSearchResults] = useState<
     ProcessedEntry[]
   >([]);
+
+  useEffect(() => {
+    if (queryMode === "advanced") {
+      return;
+    }
+
+    setSelectedEntryIds(new Set());
+    setIsSelectMode(false);
+    setDeletingEntryCount(0);
+    setAdvancedSearchResults([]);
+  }, [queryMode]);
 
   // Query for single day entries
   const {

--- a/web/src/hooks/__tests__/useTimeLogData.test.tsx
+++ b/web/src/hooks/__tests__/useTimeLogData.test.tsx
@@ -85,6 +85,19 @@ describe("useTimeLogData", () => {
       { wrapper },
     );
 
+  const setupWithMode = (queryMode: "single" | "advanced" | "import") =>
+    renderHook(
+      ({ mode }) =>
+        useTimeLogData({
+          selectedDate: new Date("2025-01-01T00:00:00Z"),
+          sortOrder: "asc",
+          queryMode: mode,
+          saveScrollPosition: vi.fn(),
+          timezone: "UTC",
+        }),
+      { wrapper, initialProps: { mode: queryMode } },
+    );
+
   beforeEach(() => {
     queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },
@@ -191,5 +204,47 @@ describe("useTimeLogData", () => {
     expect(toastMock.showSuccess).toHaveBeenCalled();
     expect(result.current.selectedEntryIds.size).toBe(0);
     expect(result.current.isSelectMode).toBe(false);
+  });
+
+  it("clears advanced selection state when returning to single-day mode", () => {
+    fetchRangeMock.mockResolvedValue({
+      items: [],
+      pagination: { page: 1, size: 0, total: 0, pages: 0 },
+      meta: {},
+    });
+    processTimeEntriesMock.mockReturnValue([]);
+
+    const { result, rerender } = setupWithMode("advanced");
+
+    act(() => {
+      result.current.setAdvancedSearchResultsFromHook([
+        { id: "event-1", isPlaceholder: false } as never,
+        { id: "event-2", isPlaceholder: false } as never,
+      ]);
+      result.current.setIsSelectMode(true);
+      result.current.selectionHandlers.handleSelectEntry(
+        "event-1" as never,
+        true,
+      );
+      result.current.selectionHandlers.handleSelectEntry(
+        "event-2" as never,
+        true,
+      );
+    });
+
+    act(() => {
+      result.current.requestBatchDelete();
+    });
+
+    expect(result.current.isSelectMode).toBe(true);
+    expect(result.current.selectedEntryIds.size).toBe(2);
+    expect(result.current.deletingEntryCount).toBe(2);
+
+    rerender({ mode: "single" });
+
+    expect(result.current.isSelectMode).toBe(false);
+    expect(result.current.selectedEntryIds.size).toBe(0);
+    expect(result.current.deletingEntryCount).toBe(0);
+    expect(result.current.processedEntries).toEqual([]);
   });
 });

--- a/web/src/pages/PlanningPage.tsx
+++ b/web/src/pages/PlanningPage.tsx
@@ -111,9 +111,14 @@ const PlanningPage: React.FC = () => {
 
   // Compute planning groups directly with useMemo to avoid callback dependency cycles
   const planningGroups = useMemo(() => {
-    if (!calendarAdapter || tasksForView.length === 0) {
+    if (!calendarAdapter) {
       return [];
     }
+
+    if (tasksForView.length === 0 && viewType !== "day") {
+      return [];
+    }
+
     return calendarAdapter.buildPlanningGroups(
       viewType,
       selectedDate,

--- a/web/src/pages/TimeLogPage.tsx
+++ b/web/src/pages/TimeLogPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import type {
   Timelog,
@@ -69,7 +69,6 @@ const TimeLogPage = () => {
     cancelBatchDelete,
     setIsSelectMode,
     setAdvancedSearchResultsFromHook,
-    clearAdvancedSearchResultsFromHook: _clearAdvancedSearchResultsFromHook,
     selectionHandlers,
     advancedSearchParams,
     setAdvancedSearchParams,
@@ -253,33 +252,6 @@ const TimeLogPage = () => {
       handleAdvancedSearch();
     }
   }, [confirmBatchDelete, handleAdvancedSearch, queryMode]);
-
-  // Convert advanced search data to ProcessedEntry format
-  const processedAdvancedSearchData = React.useMemo(() => {
-    if (queryMode === "advanced" && advancedSearch.data.length > 0) {
-      return advancedSearch.data.map((event) => ({
-        ...event,
-        validationResult: {
-          isValid: true,
-          hasNegativeDuration: false,
-          hasOverlaps: false,
-          overlappingEntries: [],
-        },
-        isPlaceholder: false,
-      }));
-    }
-    return [];
-  }, [queryMode, advancedSearch.data]);
-
-  // Sync processed data to useTimeLogData hook
-  const setAdvancedSearchResultsRef = React.useRef(
-    setAdvancedSearchResultsFromHook,
-  );
-  setAdvancedSearchResultsRef.current = setAdvancedSearchResultsFromHook;
-
-  React.useEffect(() => {
-    setAdvancedSearchResultsRef.current(processedAdvancedSearchData);
-  }, [processedAdvancedSearchData]);
 
   const advancedSearchMetadata =
     queryMode === "advanced" ? advancedSearch.metadata : null;

--- a/web/src/pages/__tests__/PlanningPage.integration.test.tsx
+++ b/web/src/pages/__tests__/PlanningPage.integration.test.tsx
@@ -149,6 +149,30 @@ describe("PlanningPage", () => {
     expect(screen.getByRole("alert")).toHaveTextContent("boom");
   });
 
+  it("keeps the day planning group mounted when there are no tasks", async () => {
+    usePlanningTasksMock.mockReturnValue({
+      tasks: [],
+      query: { isLoading: false, error: null },
+      prefetch: prefetchMock,
+    } satisfies UsePlanningTasksMockResult);
+
+    renderWithProviders(<PlanningPage />);
+
+    await waitFor(() =>
+      expect(calendarAdapter.buildPlanningGroups).toHaveBeenCalledWith(
+        "day",
+        expect.any(Date),
+        [],
+        expect.anything(),
+      ),
+    );
+
+    expect(screen.queryByTestId("empty-state")).not.toBeInTheDocument();
+    expect(screen.getByTestId("planning-task-list")).toHaveTextContent(
+      "tasks:0",
+    );
+  });
+
   it("renders planning content and handles view changes", async () => {
     const user = userEvent.setup();
 

--- a/web/src/pages/__tests__/TimeLogPage.integration.test.tsx
+++ b/web/src/pages/__tests__/TimeLogPage.integration.test.tsx
@@ -325,7 +325,6 @@ const buildDataReturn = (
   cancelBatchDelete: vi.fn(),
   setIsSelectMode: vi.fn(),
   setAdvancedSearchResultsFromHook: vi.fn(),
-  clearAdvancedSearchResultsFromHook: vi.fn(),
   selectionHandlers: {
     handleSelectEntry: vi.fn(),
     handleSelectAll: vi.fn(),


### PR DESCRIPTION
## 背景

本 PR 汇总修复本轮会话中在 visions、timelog、planning 页面确认的边界问题，并清理审查中发现的高确信死代码。当前分支不新增 issue，沿用已关联的问题编号。

## 变更摘要

- 修复 visions tasks tree 在大数据量拖拽排序时的持久化路径和前端重复请求问题。
- 修复 timelog 高级搜索批量编辑后返回单日视图时，选择态和批量操作控件泄漏到单日列表的问题。
- 修复 planning 日视图在没有规划任务但存在 habit actions 时错误显示空态的问题。
- 清理 timelog 高级搜索中已无调用方的纯转发/薄壳状态清理入口，以及页面层重复的数据同步逻辑。
- 补充和调整相关前端、后端测试覆盖。

## 关联问题

Closes #141
Closes #143
Closes #145

本 PR 还包含一次无单独 issue 的高确信死代码清理，范围限定在当前分支已触达的 timelog 高级搜索状态链路。

## 验证

- `npm run typecheck:test`
- `npm run test`
- `bash ./scripts/doctor.sh`
- `uv run vulture src tests --min-confidence 90`

说明：`doctor.sh` 中 PostgreSQL integration tests 因未设置 `LIFEOS_TEST_DATABASE_URL` 按既有规则跳过。

## 风险与回归关注

- visions 拖拽排序现在由父级统一落库，需关注跨父级移动和同级排序是否仍保持一次有效更新。
- timelog 的高级搜索结果同步被收敛到交互 hook，需关注 advanced/single 模式切换时查询结果和选择态是否隔离。
- planning 日视图会在仅有 habit actions 时保留 day group，非日视图仍保持原有空态行为。
