### PR TITLE
fix(web): declare esbuild build dependency

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -46,6 +46,7 @@
         "@vitest/coverage-v8": "^4.1.8",
         "autoprefixer": "^10.4.21",
         "daisyui": "3.9.4",
+        "esbuild": "^0.28.1",
         "eslint": "^9.30.1",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",

--- a/web/package.json
+++ b/web/package.json
@@ -56,6 +56,7 @@
     "@vitest/coverage-v8": "^4.1.8",
     "autoprefixer": "^10.4.21",
     "daisyui": "3.9.4",
+    "esbuild": "^0.28.1",
     "eslint": "^9.30.1",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",


### PR DESCRIPTION
## 背景

#146 的 `Validate Frontend` 在 Vite build 阶段失败，错误指向 `transformWithEsbuild` 需要独立安装 `esbuild`。当前 `web/vite.config.ts` 使用 `minify: "esbuild"`，但 `web/package.json` 没有显式声明 `esbuild`，实际依赖了锁文件中的传递依赖。

## 变更

- 在 `web/package.json` 中把 `esbuild` 声明为直接 devDependency。
- 同步 `web/package-lock.json` 的根依赖声明。
- 不包含 #146 或 #147 的依赖升级内容。

## 验证

- `bash ./scripts/web_dependency_health.sh`
- `bash ./scripts/web_validate.sh`
- `bash ./scripts/doctor.sh`

Closes #149
