### PR TITLE
feat: Add stats coverage and fix range boundary

### DIFF
--- a/src/lifeos_cli/application/time_preferences.py
+++ b/src/lifeos_cli/application/time_preferences.py
@@ -73,6 +73,16 @@ def get_utc_window_for_local_date_range(
     return range_start, range_end_exclusive - timedelta(microseconds=1)
 
 
+def get_utc_half_open_window_for_local_date_range(
+    start_date: date,
+    end_date: date,
+) -> tuple[datetime, datetime]:
+    """Return the half-open UTC datetime window for an inclusive local-date range."""
+    range_start, _ = get_utc_window_for_local_date(start_date)
+    _, range_end_exclusive = get_utc_window_for_local_date(end_date)
+    return range_start, range_end_exclusive
+
+
 def get_week_bounds(reference_date: date) -> tuple[date, date]:
     """Return the configured week start and end dates for one local date."""
     week_starts_on = get_preferences_settings().week_starts_on

--- a/src/lifeos_cli/db/services/timelog_stats.py
+++ b/src/lifeos_cli/db/services/timelog_stats.py
@@ -14,8 +14,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from lifeos_cli.application.datetime_utils import normalize_storage_datetime
 from lifeos_cli.application.time_preferences import (
     get_operational_date,
+    get_utc_half_open_window_for_local_date_range,
     get_utc_window_for_local_date,
-    get_utc_window_for_local_date_range,
     get_week_bounds,
 )
 from lifeos_cli.config import get_preferences_settings
@@ -352,7 +352,10 @@ async def _recompute_aggregated_period(
     end_date: date,
 ) -> None:
     timezone_name = get_preferences_settings().timezone
-    window_start, window_end = get_utc_window_for_local_date_range(start_date, end_date)
+    window_start, window_end = get_utc_half_open_window_for_local_date_range(
+        start_date,
+        end_date,
+    )
     report = await _collect_area_stats_for_window(
         session,
         window_start=window_start,
@@ -476,7 +479,7 @@ async def get_timelog_stats_groupby_area_for_range(
         start_date=start_date,
         end_date=end_date,
     )
-    window_start, window_end = get_utc_window_for_local_date_range(
+    window_start, window_end = get_utc_half_open_window_for_local_date_range(
         normalized_start_date,
         normalized_end_date,
     )
@@ -521,7 +524,10 @@ async def get_timelog_stats_groupby_area_for_period(
             end_date=end_date,
             rows=rows,
         )
-    window_start, window_end = get_utc_window_for_local_date_range(start_date, end_date)
+    window_start, window_end = get_utc_half_open_window_for_local_date_range(
+        start_date,
+        end_date,
+    )
     return await _collect_area_stats_for_window(
         session,
         window_start=window_start,

--- a/tests/test_time_preferences.py
+++ b/tests/test_time_preferences.py
@@ -5,6 +5,7 @@ from datetime import date, datetime, timezone
 from lifeos_cli.application.time_preferences import (
     apply_preferred_timezone,
     get_operational_date,
+    get_utc_half_open_window_for_local_date_range,
     get_utc_window_for_local_date,
     get_week_bounds,
     to_preferred_timezone,
@@ -59,6 +60,22 @@ def test_get_utc_window_for_local_date_respects_day_start_boundary(monkeypatch, 
 
     assert window_start.isoformat() == "2026-04-10T08:00:00+00:00"
     assert window_end.isoformat() == "2026-04-11T08:00:00+00:00"
+    clear_config_cache()
+
+
+def test_get_utc_half_open_window_for_local_date_range_keeps_exclusive_end(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    install_test_config(monkeypatch=monkeypatch, tmp_path=tmp_path, include_preferences=True)
+
+    window_start, window_end = get_utc_half_open_window_for_local_date_range(
+        date(2026, 4, 10),
+        date(2026, 4, 11),
+    )
+
+    assert window_start.isoformat() == "2026-04-10T08:00:00+00:00"
+    assert window_end.isoformat() == "2026-04-12T08:00:00+00:00"
     clear_config_cache()
 
 

--- a/tests/test_timelog_stats.py
+++ b/tests/test_timelog_stats.py
@@ -56,6 +56,17 @@ def test_overlap_minutes_for_window_treats_naive_storage_values_as_utc() -> None
     assert minutes == 30
 
 
+def test_overlap_minutes_for_window_keeps_final_boundary_minute() -> None:
+    minutes = timelog_stats.overlap_minutes_for_window(
+        start_time=datetime(2026, 3, 22, 15, 10, tzinfo=timezone.utc),
+        end_time=datetime(2026, 3, 22, 22, 10, tzinfo=timezone.utc),
+        window_start=datetime(2026, 3, 15, 16, 0, tzinfo=timezone.utc),
+        window_end=datetime(2026, 3, 22, 16, 0, tzinfo=timezone.utc),
+    )
+
+    assert minutes == 50
+
+
 @pytest.mark.usefixtures("configured_time_preferences")
 def test_resolve_stats_period_uses_configured_week_boundary() -> None:
     start_date, end_date = timelog_stats.resolve_stats_period(

--- a/web/src/components/InlineQuickTimeEntry.tsx
+++ b/web/src/components/InlineQuickTimeEntry.tsx
@@ -401,8 +401,11 @@ export default function InlineQuickTimeEntry({
   } = useTimelogTemplates();
   const sortedTemplates = useMemo(() => sortTemplates(templates), [templates]);
 
-  const hhmmToISO = (baseDate: Date, hhmm: string): string =>
-    hhmmOnDateToISO(baseDate, hhmm, timezone);
+  const hhmmToISO = useCallback(
+    (baseDate: Date, hhmm: string): string =>
+      hhmmOnDateToISO(baseDate, hhmm, timezone),
+    [timezone],
+  );
 
   // Human readable duration label
   const formStartTime = formData.start_time;
@@ -448,6 +451,7 @@ export default function InlineQuickTimeEntry({
     initialEndTime,
     shouldInitializeFromProps,
     setFormDataWithSync,
+    hhmmToISO,
   ]);
 
   // Focus title input when component mounts

--- a/web/src/components/notes/NoteItem.tsx
+++ b/web/src/components/notes/NoteItem.tsx
@@ -373,7 +373,7 @@ const NoteItem = React.memo<NoteItemProps>(
         default:
           return null;
       }
-    }, [associationTooltip, areaMap]);
+    }, [associationTooltip, areaMap, timezone]);
 
     // 复制笔记内容到剪贴板
     const handleCopy = async () => {

--- a/web/src/features/insights/__tests__/periodCoverage.test.ts
+++ b/web/src/features/insights/__tests__/periodCoverage.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { buildPeriodCoverage } from "@/features/insights/periodCoverage";
+
+describe("periodCoverage", () => {
+  it("formats whole-hour coverage without decimals", () => {
+    expect(buildPeriodCoverage(24 * 60, 144 * 60).label).toBe("24/144");
+  });
+
+  it("keeps partial-hour coverage visible", () => {
+    expect(buildPeriodCoverage(23 * 60 + 30, 24 * 60).label).toBe("23.5/24");
+    expect(buildPeriodCoverage(23 * 60 + 59, 24 * 60).label).toBe("23.98/24");
+  });
+
+  it("marks coverage complete only when actual minutes match capacity minutes", () => {
+    expect(buildPeriodCoverage(24 * 60, 24 * 60)).toEqual({
+      label: "24/24",
+      isComplete: true,
+    });
+    expect(buildPeriodCoverage(143 * 60, 144 * 60)).toMatchObject({
+      label: "143/144",
+      isComplete: false,
+    });
+  });
+});

--- a/web/src/features/insights/periodCoverage.ts
+++ b/web/src/features/insights/periodCoverage.ts
@@ -1,0 +1,29 @@
+export interface PeriodCoverage {
+  label: string;
+  isComplete: boolean;
+}
+
+function normalizeMinutes(minutes: number): number {
+  if (!Number.isFinite(minutes)) return 0;
+  return Math.max(0, Math.round(minutes));
+}
+
+function formatCoverageHourValue(minutes: number): string {
+  const normalizedMinutes = normalizeMinutes(minutes);
+  const hours = normalizedMinutes / 60;
+  if (Number.isInteger(hours)) return String(hours);
+  return hours.toFixed(2).replace(/\.?0+$/, "");
+}
+
+export function buildPeriodCoverage(
+  actualMinutes: number,
+  capacityMinutes: number,
+): PeriodCoverage {
+  const normalizedActualMinutes = normalizeMinutes(actualMinutes);
+  const normalizedCapacityMinutes = normalizeMinutes(capacityMinutes);
+
+  return {
+    label: `${formatCoverageHourValue(normalizedActualMinutes)}/${formatCoverageHourValue(normalizedCapacityMinutes)}`,
+    isComplete: normalizedActualMinutes === normalizedCapacityMinutes,
+  };
+}

--- a/web/src/pages/InsightsPage.tsx
+++ b/web/src/pages/InsightsPage.tsx
@@ -36,6 +36,10 @@ import {
   type InsightViewType,
 } from "@/features/insights/useInsightsViewState";
 import { useInsightsStatsController } from "@/features/insights/controller/useInsightsStatsController";
+import {
+  buildPeriodCoverage,
+  type PeriodCoverage,
+} from "@/features/insights/periodCoverage";
 
 type AreaBucket = {
   areaId: UUID;
@@ -224,6 +228,7 @@ interface StatisticItemProps {
   label?: string;
   labelTitle?: string;
   totalMinutesOverride?: number;
+  coverage: PeriodCoverage;
 }
 
 const StatisticItem: React.FC<StatisticItemProps> = ({
@@ -235,18 +240,28 @@ const StatisticItem: React.FC<StatisticItemProps> = ({
   label,
   labelTitle,
   totalMinutesOverride,
+  coverage,
 }) => {
   const displayLabel = label ?? formatDate(day);
-  const labelTooltip = labelTitle ?? displayLabel;
   const denominator = totalMinutesOverride ?? 1440;
+  const coverageColorClass = coverage.isComplete
+    ? "text-base-content/80"
+    : "text-warning";
   return (
     <div className="flex items-center gap-3">
       {/* 日期 - 使用常规大小 */}
       <div
         className="w-32 text-base font-medium text-base-content/80 flex-shrink-0 flex items-center justify-center"
-        title={labelTooltip}
+        title={labelTitle ?? displayLabel}
       >
         {displayLabel}
+      </div>
+
+      <div
+        className={`w-16 text-sm font-semibold tabular-nums ${coverageColorClass} flex-shrink-0 flex items-center justify-center`}
+        title={coverage.label}
+      >
+        {coverage.label}
       </div>
 
       {/* 条带图 - 改进样式 */}
@@ -432,7 +447,7 @@ function InsightsPage() {
         labelTitle: string;
         rows: DailyAreaRow[];
         capacityMinutes: number;
-        totalSelectedMinutes: number;
+        totalLoggedMinutes: number;
       }>;
 
     const boundaries = buildBucketBoundaries(
@@ -466,7 +481,7 @@ function InsightsPage() {
           areaOrder.indexOf(a.area_id) -
           areaOrder.indexOf(b.area_id),
       );
-      const totalSelectedMinutes = convertedRows.reduce(
+      const totalLoggedMinutes = rawRows.reduce(
         (sum, current) => sum + current.minutes,
         0,
       );
@@ -478,7 +493,7 @@ function InsightsPage() {
         labelTitle: formatBucketTitle(granularity, start, end),
         rows: convertedRows,
         capacityMinutes: calculateBucketCapacityMinutes(start, end),
-        totalSelectedMinutes,
+        totalLoggedMinutes,
       };
     });
   }, [
@@ -494,6 +509,7 @@ function InsightsPage() {
   const displayBuckets = useMemo(() => {
     if (granularity === "day") {
       return dayRange.map((day) => {
+        const rawRows = dailyStats.filter((row) => row.date === day);
         const rows = (curByDay.get(day) || [])
           .slice()
           .sort(
@@ -501,7 +517,7 @@ function InsightsPage() {
               areaOrder.indexOf(a.area_id) -
               areaOrder.indexOf(b.area_id),
           );
-        const totalSelectedMinutes = rows.reduce(
+        const totalLoggedMinutes = rawRows.reduce(
           (sum, current) => sum + current.minutes,
           0,
         );
@@ -513,13 +529,20 @@ function InsightsPage() {
           labelTitle: formatDate(day),
           rows,
           capacityMinutes: 24 * 60,
-          totalSelectedMinutes,
+          totalLoggedMinutes,
         };
       });
     }
 
     return aggregatedBuckets;
-  }, [granularity, dayRange, curByDay, areaOrder, aggregatedBuckets]);
+  }, [
+    granularity,
+    dayRange,
+    dailyStats,
+    curByDay,
+    areaOrder,
+    aggregatedBuckets,
+  ]);
 
   const totalPeriodDayCount = useMemo(() => {
     if (!startDate || !endDate) return 0;
@@ -1134,6 +1157,10 @@ function InsightsPage() {
                     label={bucket.label}
                     labelTitle={bucket.labelTitle}
                     totalMinutesOverride={bucket.capacityMinutes}
+                    coverage={buildPeriodCoverage(
+                      bucket.totalLoggedMinutes,
+                      bucket.capacityMinutes,
+                    )}
                   />
                 </div>
               ))}


### PR DESCRIPTION
## 变更内容

- 在 /stats 数据洞察页的日志统计行中新增独立的周期覆盖率列，显示实际小时/理论小时。
- 覆盖率基于当前 stats API 返回的已有统计行加和，不从原始 timelog 重新演算。
- 覆盖率不受前端 area 筛选影响，避免隐藏某个 area 后误报周期缺口。
- 当实际值与理论值不一致时，仅覆盖率列使用 warning 文本颜色。
- 修复两个 React hook 依赖 lint warning。
- 自审清理了覆盖率 helper 中未消费的返回字段、不必要的公共导出，以及局部组件的可选 fallback。
- 修复 timelog stats 聚合/范围统计的时间边界：统计路径现在使用半开 UTC 窗口，避免区间末尾 1 微秒被扣除后按整分钟取整少 1 分钟。

## 审查结论

- PR 与 #151 是直接实现关系，使用 Closes #151 准确。
- 需求仍然有效：覆盖率列可以暴露周期内 persisted stats 的缺口；本次补充修复确认旧的 167.98/168、719.98/720 类偏差来自聚合统计边界精度，而不是前端显示误差。
- 后端修复只收敛在 timelog stats 聚合/范围统计路径，没有改变事件、日志列表等仍依赖闭区间 helper 的查询语义。
- 未发现当前分支引入的未收敛问题；已执行高确信死代码清理。

## 数据重建与抽查

- 已执行 `uv run lifeos timelog stats rebuild --all`。
- 重建范围：2016-06-30 到 2026-06-17，共 3640 个日期。
- 抽查 `2026-03-16 ~ 2026-03-22` 周统计：聚合分钟数为 10080，即 168/168；该周每日仍为 24/24。
- 全库抽查未再发现理论值少 1 到 3 分钟的近似满额聚合记录。

## 验证

- `uv run pytest tests/test_time_preferences.py tests/test_timelog_stats.py`
- `npm --prefix web run lint`
- `npm --prefix web test -- periodCoverage`
- `npm --prefix web run typecheck:test`
- `bash ./scripts/web_validate.sh`
- `bash ./scripts/doctor.sh`（PostgreSQL 集成测试因未设置 LIFEOS_TEST_DATABASE_URL 按脚本规则跳过）

Closes #151
