### PR TITLE
fix: preserve full stats week buckets

### DIFF
--- a/web/src/features/insights/__tests__/periodBuckets.test.ts
+++ b/web/src/features/insights/__tests__/periodBuckets.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { buildBucketBoundaries } from "@/features/insights/periodBuckets";
+import { GregorianCalendarAdapter } from "@/utils/calendar";
+
+describe("periodBuckets", () => {
+  const mondayFirstAdapter = new GregorianCalendarAdapter(1);
+
+  it("keeps the leading cross-month week complete in month week stats", () => {
+    const buckets = buildBucketBoundaries(
+      "week",
+      "2026-05-01",
+      "2026-05-31",
+      mondayFirstAdapter,
+    );
+
+    expect(buckets[0]).toEqual({
+      start: "2026-04-27",
+      end: "2026-05-03",
+    });
+    expect(buckets).not.toContainEqual({
+      start: "2026-05-01",
+      end: "2026-05-03",
+    });
+  });
+
+  it("keeps the trailing cross-month week complete in month week stats", () => {
+    const buckets = buildBucketBoundaries(
+      "week",
+      "2026-07-01",
+      "2026-07-31",
+      mondayFirstAdapter,
+    );
+
+    expect(buckets.at(-1)).toEqual({
+      start: "2026-07-27",
+      end: "2026-08-02",
+    });
+  });
+
+  it("keeps cross-year weeks complete in year week stats", () => {
+    const buckets = buildBucketBoundaries(
+      "week",
+      "2026-01-01",
+      "2026-12-31",
+      mondayFirstAdapter,
+    );
+
+    expect(buckets[0]).toEqual({
+      start: "2025-12-29",
+      end: "2026-01-04",
+    });
+    expect(buckets.at(-1)).toEqual({
+      start: "2026-12-28",
+      end: "2027-01-03",
+    });
+  });
+});

--- a/web/src/features/insights/periodBuckets.ts
+++ b/web/src/features/insights/periodBuckets.ts
@@ -1,0 +1,101 @@
+import type { AggregationGranularity } from "@/services/api/stats";
+import type { CalendarAdapter, ExtendedPlanningViewType } from "@/utils/calendar";
+
+export interface PeriodBucketBoundary {
+  start: string;
+  end: string;
+}
+
+export const parseLocalDate = (isoDate: string): Date => {
+  const [yearStr, monthStr, dayStr] = isoDate.split("-");
+  const year = Number(yearStr);
+  const month = Number(monthStr) - 1;
+  const day = Number(dayStr);
+  return new Date(year, month, day, 0, 0, 0, 0);
+};
+
+const toIsoDate = (date: Date): string => {
+  const normalized = normalizeDate(date);
+  return normalized.toLocaleDateString("en-CA");
+};
+
+const normalizeDate = (date: Date): Date => {
+  const normalized = new Date(date);
+  normalized.setHours(0, 0, 0, 0);
+  return normalized;
+};
+
+export const buildBucketBoundaries = (
+  granularity: Exclude<AggregationGranularity, "day">,
+  startDate: string,
+  endDate: string,
+  calendarAdapter: CalendarAdapter,
+): PeriodBucketBoundary[] => {
+  if (!startDate || !endDate) return [];
+  const buckets: PeriodBucketBoundary[] = [];
+  const rangeStart = parseLocalDate(startDate);
+  const rangeEnd = parseLocalDate(endDate);
+
+  const appendIntersectingBucket = (start: Date, end: Date) => {
+    const normalizedStart = normalizeDate(start);
+    const normalizedEnd = normalizeDate(end);
+    if (normalizedEnd < rangeStart || normalizedStart > rangeEnd) return;
+    buckets.push({
+      start: toIsoDate(normalizedStart),
+      end: toIsoDate(normalizedEnd),
+    });
+  };
+
+  const viewTypeMap: Record<
+    Exclude<AggregationGranularity, "day">,
+    ExtendedPlanningViewType
+  > = {
+    week: "week",
+    month: "month",
+    year: "year",
+  };
+
+  const viewType = viewTypeMap[granularity];
+  const parseRange = (range: { start: string; end: string }) => ({
+    start: parseLocalDate(range.start),
+    end: parseLocalDate(range.end),
+  });
+
+  let currentRange = calendarAdapter.getPeriodRange(viewType, rangeStart);
+  let { start, end } = parseRange(currentRange);
+  let safety = 0;
+
+  while (end < rangeStart && safety < 500) {
+    const nextRange = calendarAdapter.shiftPeriodRange(
+      viewType,
+      currentRange.start,
+      currentRange.end,
+      1,
+    );
+    currentRange = nextRange;
+    ({ start, end } = parseRange(currentRange));
+    safety += 1;
+  }
+
+  while (start <= rangeEnd && safety < 1500) {
+    appendIntersectingBucket(start, end);
+    if (end >= rangeEnd) break;
+
+    const nextRange = calendarAdapter.shiftPeriodRange(
+      viewType,
+      currentRange.start,
+      currentRange.end,
+      1,
+    );
+    const nextParsed = parseRange(nextRange);
+    if (nextParsed.start.getTime() === start.getTime()) {
+      break;
+    }
+    currentRange = nextRange;
+    start = nextParsed.start;
+    end = nextParsed.end;
+    safety += 1;
+  }
+
+  return buckets;
+};

--- a/web/src/pages/InsightsPage.tsx
+++ b/web/src/pages/InsightsPage.tsx
@@ -17,10 +17,6 @@ import { usePageHeader } from "@/contexts/PageHeaderContext";
 import PageLayout from "@/layouts/PageLayout";
 import { formatDate, formatDuration } from "@/utils/datetime";
 import { Icon } from "@/components/icons";
-import type {
-  CalendarAdapter,
-  ExtendedPlanningViewType,
-} from "@/utils/calendar";
 import type { Area } from "@/services/api/areas";
 import ActionButton from "@/components/ActionButton";
 import { RadioGroup, SegmentedControl, TextInput } from "@/components/forms";
@@ -40,6 +36,10 @@ import {
   buildPeriodCoverage,
   type PeriodCoverage,
 } from "@/features/insights/periodCoverage";
+import {
+  buildBucketBoundaries,
+  parseLocalDate,
+} from "@/features/insights/periodBuckets";
 
 type AreaBucket = {
   areaId: UUID;
@@ -62,26 +62,6 @@ const INSIGHT_VIEW_CONFIG: InsightViewConfig = {
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
-const parseLocalDate = (isoDate: string): Date => {
-  const [yearStr, monthStr, dayStr] = isoDate.split("-");
-  const year = Number(yearStr);
-  const month = Number(monthStr) - 1;
-  const day = Number(dayStr);
-  return new Date(year, month, day, 0, 0, 0, 0);
-};
-
-const toIsoDate = (date: Date): string => {
-  const normalized = new Date(date);
-  normalized.setHours(0, 0, 0, 0);
-  return normalized.toLocaleDateString("en-CA");
-};
-
-const normalizeDate = (date: Date): Date => {
-  const normalized = new Date(date);
-  normalized.setHours(0, 0, 0, 0);
-  return normalized;
-};
-
 const calculateInclusiveDays = (start: string, end?: string | null): number => {
   if (!start) return 0;
   const startDate = parseLocalDate(start);
@@ -92,97 +72,6 @@ const calculateInclusiveDays = (start: string, end?: string | null): number => {
   const upper = Math.max(startTime, endTime);
   const diff = upper - lower;
   return Math.max(1, Math.floor(diff / MS_PER_DAY) + 1);
-};
-
-const buildBucketBoundaries = (
-  granularity: AggregationGranularity,
-  startDate: string,
-  endDate: string,
-  calendarAdapter: CalendarAdapter,
-): Array<{ start: string; end: string }> => {
-  if (!startDate || !endDate) return [];
-  const buckets: Array<{ start: string; end: string }> = [];
-  const rangeStart = parseLocalDate(startDate);
-  const rangeEnd = parseLocalDate(endDate);
-  const toIso = (d: Date) => toIsoDate(normalizeDate(d));
-
-  const appendBucket = (start: Date, end: Date) => {
-    const normalizedStart = normalizeDate(start);
-    const normalizedEnd = normalizeDate(end);
-    if (normalizedStart > rangeEnd) return;
-    const clampedStart =
-      normalizedStart < rangeStart ? rangeStart : normalizedStart;
-    const clampedEnd = normalizedEnd > rangeEnd ? rangeEnd : normalizedEnd;
-    if (clampedStart > clampedEnd) return;
-    buckets.push({ start: toIso(clampedStart), end: toIso(clampedEnd) });
-  };
-
-  if (granularity === "day") {
-    for (
-      let cursor = new Date(rangeStart);
-      cursor <= rangeEnd;
-      cursor.setDate(cursor.getDate() + 1)
-    ) {
-      const iso = toIsoDate(cursor);
-      buckets.push({ start: iso, end: iso });
-    }
-    return buckets;
-  }
-
-  const viewTypeMap: Record<
-    Exclude<AggregationGranularity, "day">,
-    ExtendedPlanningViewType
-  > = {
-    week: "week",
-    month: "month",
-    year: "year",
-  };
-
-  const viewType =
-    viewTypeMap[granularity as Exclude<AggregationGranularity, "day">];
-  const parseRange = (range: { start: string; end: string }) => ({
-    start: parseLocalDate(range.start),
-    end: parseLocalDate(range.end),
-  });
-
-  let currentRange = calendarAdapter.getPeriodRange(viewType, rangeStart);
-  let { start, end } = parseRange(currentRange);
-  let safety = 0;
-
-  while (end < rangeStart && safety < 500) {
-    const nextRange = calendarAdapter.shiftPeriodRange(
-      viewType,
-      currentRange.start,
-      currentRange.end,
-      1,
-    );
-    currentRange = nextRange;
-    ({ start, end } = parseRange(currentRange));
-    safety += 1;
-  }
-
-  while (start <= rangeEnd && safety < 1500) {
-    appendBucket(start, end);
-    if (end >= rangeEnd) break;
-
-    const nextRange = calendarAdapter.shiftPeriodRange(
-      viewType,
-      currentRange.start,
-      currentRange.end,
-      1,
-    );
-    const nextParsed = parseRange(nextRange);
-    if (nextParsed.start.getTime() === start.getTime()) {
-      // Prevent infinite loops if adapter returns the same range
-      break;
-    }
-    currentRange = nextRange;
-    start = nextParsed.start;
-    end = nextParsed.end;
-    safety += 1;
-  }
-
-  return buckets;
 };
 
 const calculateBucketCapacityMinutes = (start: string, end: string): number => {


### PR DESCRIPTION
## 背景

`/stats` 在月视图或年视图按周展示时，跨月或跨年的自然周不应被裁剪为当前视图内的片段。完整自然周应在它跨到的每个月或每个年视图中出现。

Closes #153

## 变更

- 将 stats 周期分桶逻辑从 `InsightsPage` 抽出到 `periodBuckets` 纯函数模块，便于独立测试日期边界。
- 周统计分桶改为保留与当前视图范围相交的完整自然周，不再生成 `2026-05-01 ~ 2026-05-03` 这类被裁剪的周片段。
- 清理本分支引入的不可达 day 分支和不必要导出，收窄函数公开表面。
- 新增前端单测覆盖月初跨月周、月末跨月周、年初/年末跨年周。

## 审查结论

- `Closes #153` 关系准确：该 PR 直接修复 issue 中描述的 `/stats` 周统计跨月/跨年自然周截断问题。
- 未发现本 PR 引入的未接线历史残留；已清理本分支迁移过程中产生的高确信冗余。

## 验证

- `bash ./scripts/web_validate.sh`
- `bash ./scripts/doctor.sh`
