### PR TITLE
feat: Persist Web UI theme preference

### DIFF
--- a/src/lifeos_cli/application/configuration.py
+++ b/src/lifeos_cli/application/configuration.py
@@ -10,11 +10,13 @@ from lifeos_cli.cli_support.runtime_utils import refresh_runtime_configuration
 from lifeos_cli.config import (
     DEFAULT_DATABASE_SCHEMA,
     DEFAULT_DAY_STARTS_AT,
+    DEFAULT_THEME,
     DEFAULT_VISION_EXPERIENCE_RATE_PER_HOUR,
     DEFAULT_WEEK_STARTS_ON,
     ConfigurationError,
     DatabaseSettings,
     PreferencesSettings,
+    clear_config_cache,
     database_policy,
     default_sqlite_database_url,
     detect_default_language,
@@ -26,6 +28,7 @@ from lifeos_cli.config import (
     validate_database_url,
     validate_day_starts_at,
     validate_language,
+    validate_theme,
     validate_timezone_name,
     validate_vision_experience_rate_per_hour,
     validate_week_starts_on,
@@ -68,6 +71,7 @@ SUPPORTED_CONFIG_KEYS = (
     "preferences.day_starts_at",
     "preferences.week_starts_on",
     "preferences.vision_experience_rate_per_hour",
+    "preferences.theme",
 )
 
 
@@ -150,6 +154,7 @@ def build_preferences_settings(request: InitializationRequest) -> PreferencesSet
             week_starts_on=DEFAULT_WEEK_STARTS_ON,
             vision_experience_rate_per_hour=DEFAULT_VISION_EXPERIENCE_RATE_PER_HOUR,
             config_file=config_path,
+            theme=DEFAULT_THEME,
         )
 
     timezone_value = request.timezone or current.timezone
@@ -178,6 +183,7 @@ def build_preferences_settings(request: InitializationRequest) -> PreferencesSet
             vision_experience_rate_value
         ),
         config_file=config_path,
+        theme=validate_theme(current.theme),
     )
 
 
@@ -194,7 +200,12 @@ def persist_runtime_settings(
     return config_path
 
 
-def set_runtime_config_value(*, key: str, value: str) -> ConfigSetResult:
+def set_runtime_config_value(
+    *,
+    key: str,
+    value: str,
+    refresh_runtime: bool = True,
+) -> ConfigSetResult:
     """Persist one supported runtime config key and refresh caches."""
     normalized_key = key.strip()
     if normalized_key == "database.schema":
@@ -261,12 +272,20 @@ def set_runtime_config_value(*, key: str, value: str) -> ConfigSetResult:
             preferences_settings,
             vision_experience_rate_per_hour=validate_vision_experience_rate_per_hour(value),
         )
+    elif normalized_key == "preferences.theme":
+        preferences_settings = replace(
+            preferences_settings,
+            theme=validate_theme(value),
+        )
 
     written_path = write_database_settings(
         database_settings,
         preferences=preferences_settings,
     )
-    refresh_runtime_configuration()
+    if refresh_runtime:
+        refresh_runtime_configuration()
+    else:
+        clear_config_cache()
     return ConfigSetResult(
         key=normalized_key,
         config_path=written_path,

--- a/src/lifeos_cli/cli_support/runtime_utils.py
+++ b/src/lifeos_cli/cli_support/runtime_utils.py
@@ -68,6 +68,7 @@ def format_config_summary(
         f"Preference week starts on: {preferences_settings.week_starts_on}",
         "Preference vision experience rate per hour: "
         f"{preferences_settings.vision_experience_rate_per_hour}",
+        f"Preference theme: {preferences_settings.theme}",
         "Agent payload rule: use the preference language for human-authored titles, "
         "descriptions, and note content unless the human explicitly asks for another language.",
     ]

--- a/src/lifeos_cli/cli_support/system/config_commands.py
+++ b/src/lifeos_cli/cli_support/system/config_commands.py
@@ -33,6 +33,7 @@ def build_config_parser(subparsers: argparse._SubParsersAction[argparse.Argument
                 "lifeos config show",
                 "lifeos config show --show-secrets",
                 "lifeos config set preferences.timezone America/Toronto",
+                "lifeos config set preferences.theme night",
             ),
             notes=(
                 _(
@@ -109,6 +110,7 @@ def build_config_parser(subparsers: argparse._SubParsersAction[argparse.Argument
                 "sqlite+aiosqlite:///$HOME/.lifeos/work.db "
                 "--show-secrets",
                 "lifeos config set preferences.vision_experience_rate_per_hour 120",
+                "lifeos config set preferences.theme night",
             ),
             notes=(
                 _(

--- a/src/lifeos_cli/config.py
+++ b/src/lifeos_cli/config.py
@@ -35,7 +35,38 @@ DEFAULT_LANGUAGE = "en"
 DEFAULT_DAY_STARTS_AT = "00:00"
 DEFAULT_WEEK_STARTS_ON = "monday"
 DEFAULT_VISION_EXPERIENCE_RATE_PER_HOUR = 60
+DEFAULT_THEME = "system"
 MAX_VISION_EXPERIENCE_RATE_PER_HOUR = 3600
+SUPPORTED_THEMES = (
+    "system",
+    "fresh",
+    "cupcake",
+    "bumblebee",
+    "emerald",
+    "corporate",
+    "synthwave",
+    "retro",
+    "cyberpunk",
+    "valentine",
+    "halloween",
+    "garden",
+    "forest",
+    "aqua",
+    "lofi",
+    "pastel",
+    "fantasy",
+    "wireframe",
+    "luxury",
+    "dracula",
+    "cmyk",
+    "autumn",
+    "business",
+    "acid",
+    "lemonade",
+    "night",
+    "coffee",
+    "winter",
+)
 _SCHEMA_NAME_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _LANGUAGE_TAG_PATTERN = re.compile(r"^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$")
 _DAY_STARTS_AT_PATTERN = re.compile(r"^(?P<hour>[01]\d|2[0-3]):(?P<minute>[0-5]\d)$")
@@ -258,6 +289,15 @@ def validate_vision_experience_rate_per_hour(value: int | str) -> int:
     return normalized
 
 
+def validate_theme(value: str) -> str:
+    """Validate the preferred Web UI theme."""
+    normalized = value.strip()
+    if normalized not in SUPPORTED_THEMES:
+        supported = ", ".join(SUPPORTED_THEMES)
+        raise ConfigurationError(f"Preference `theme` must be one of: {supported}.")
+    return normalized
+
+
 def _parse_bool(value: str) -> bool:
     normalized = value.strip().lower()
     return normalized in {"1", "true", "yes", "on"}
@@ -299,6 +339,7 @@ def _render_preferences_table(settings: PreferencesSettings) -> str:
             f"day_starts_at = {_serialize_toml_string(settings.day_starts_at)}",
             f"week_starts_on = {_serialize_toml_string(settings.week_starts_on)}",
             f"vision_experience_rate_per_hour = {settings.vision_experience_rate_per_hour}",
+            f"theme = {_serialize_toml_string(settings.theme)}",
         )
     )
 
@@ -482,6 +523,7 @@ class PreferencesSettings:
     week_starts_on: str
     vision_experience_rate_per_hour: int
     config_file: Path
+    theme: str = DEFAULT_THEME
 
     @classmethod
     def from_env(
@@ -505,6 +547,7 @@ class PreferencesSettings:
         file_day_starts_at = preference_values.get("day_starts_at")
         file_week_starts_on = preference_values.get("week_starts_on")
         file_vision_experience_rate = preference_values.get("vision_experience_rate_per_hour")
+        file_theme = preference_values.get("theme")
 
         timezone_value = source.get("LIFEOS_TIMEZONE") if include_overrides else None
         if timezone_value is None and isinstance(file_timezone, str):
@@ -539,6 +582,9 @@ class PreferencesSettings:
             vision_experience_rate_value
         )
 
+        theme_value = file_theme if isinstance(file_theme, str) else DEFAULT_THEME
+        theme = validate_theme(theme_value)
+
         return cls(
             timezone=timezone_value,
             language=language_value,
@@ -546,6 +592,7 @@ class PreferencesSettings:
             week_starts_on=week_starts_on_value,
             vision_experience_rate_per_hour=vision_experience_rate,
             config_file=config_path,
+            theme=theme,
         )
 
 

--- a/src/lifeos_cli/db/session.py
+++ b/src/lifeos_cli/db/session.py
@@ -104,8 +104,8 @@ def clear_session_cache() -> None:
     if engine is None:
         return
     try:
-        asyncio.get_running_loop()
+        loop = asyncio.get_running_loop()
     except RuntimeError:
         asyncio.run(engine.dispose())
         return
-    raise RuntimeError("clear_session_cache() cannot run inside an active event loop.")
+    loop.create_task(engine.dispose())

--- a/src/lifeos_web/routers/preferences.py
+++ b/src/lifeos_web/routers/preferences.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel
 
 from lifeos_cli.application.configuration import set_runtime_config_value
 from lifeos_cli.config import (
+    SUPPORTED_THEMES,
     ConfigurationError,
     PreferencesSettings,
     clear_config_cache,
@@ -31,38 +32,8 @@ _VISIBLE_MODULES = [
     "settings",
 ]
 
-_THEMES = [
-    "system",
-    "fresh",
-    "cupcake",
-    "bumblebee",
-    "emerald",
-    "corporate",
-    "synthwave",
-    "retro",
-    "cyberpunk",
-    "valentine",
-    "halloween",
-    "garden",
-    "forest",
-    "aqua",
-    "lofi",
-    "pastel",
-    "fantasy",
-    "wireframe",
-    "luxury",
-    "dracula",
-    "cmyk",
-    "autumn",
-    "business",
-    "acid",
-    "lemonade",
-    "night",
-    "coffee",
-    "winter",
-]
-
 _CONFIG_KEY_MAP = {
+    "appearance.theme": "preferences.theme",
     "system.timezone": "preferences.timezone",
     "visions.experience_rate_per_hour": "preferences.vision_experience_rate_per_hour",
 }
@@ -73,7 +44,6 @@ _CONFIG_ENV_KEY_MAP = {
 }
 
 _STATIC_DEFAULTS: dict[str, Any] = {
-    "appearance.theme": "system",
     "calendar.first_day_of_week": 1,
     "calendar.system": "gregorian",
     "dashboard.area_order": [],
@@ -88,7 +58,7 @@ _STATIC_DEFAULTS: dict[str, Any] = {
 
 _META: dict[str, dict[str, Any]] = {
     "appearance.theme": {
-        "allowed_values": _THEMES,
+        "allowed_values": list(SUPPORTED_THEMES),
         "description": "LifeOS Web UI theme.",
         "module": "appearance",
     },
@@ -120,6 +90,8 @@ class PreferenceUpdate(BaseModel):
 
 
 def _extract_config_preference_value(preferences: PreferencesSettings, key: str) -> Any:
+    if key == "appearance.theme":
+        return preferences.theme
     if key == "system.timezone":
         return preferences.timezone
     if key == "visions.experience_rate_per_hour":
@@ -136,7 +108,11 @@ def _sync_effective_config_preference_to_file(key: str) -> Any:
         key,
     )
     if effective_value != file_value:
-        set_runtime_config_value(key=config_key, value=str(effective_value))
+        set_runtime_config_value(
+            key=config_key,
+            value=str(effective_value),
+            refresh_runtime=False,
+        )
         effective_value = _extract_config_preference_value(get_preferences_settings(), key)
     return effective_value
 
@@ -187,7 +163,11 @@ async def set_preference(key: str, payload: PreferenceUpdate) -> dict[str, Any]:
     config_key = _CONFIG_KEY_MAP.get(key)
     if config_key is not None:
         try:
-            set_runtime_config_value(key=config_key, value=str(payload.value))
+            set_runtime_config_value(
+                key=config_key,
+                value=str(payload.value),
+                refresh_runtime=False,
+            )
         except ConfigurationError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
         _set_process_config_override(key, payload.value)

--- a/tests/config_support.py
+++ b/tests/config_support.py
@@ -18,6 +18,7 @@ def write_test_config(
     day_starts_at: str = "04:00",
     week_starts_on: str = "monday",
     vision_experience_rate_per_hour: int | None = None,
+    theme: str | None = None,
 ) -> Path:
     lines: list[str] = []
     if include_database:
@@ -37,6 +38,8 @@ def write_test_config(
         )
         if vision_experience_rate_per_hour is not None:
             lines.append(f"vision_experience_rate_per_hour = {vision_experience_rate_per_hour}")
+        if theme is not None:
+            lines.append(f'theme = "{theme}"')
         lines.append("")
     config_path.write_text("\n".join(lines), encoding="utf-8")
     return config_path
@@ -56,6 +59,7 @@ def install_test_config(
     day_starts_at: str = "04:00",
     week_starts_on: str = "monday",
     vision_experience_rate_per_hour: int | None = None,
+    theme: str | None = None,
 ) -> Path:
     config_path = write_test_config(
         tmp_path / "config.toml",
@@ -69,6 +73,7 @@ def install_test_config(
         day_starts_at=day_starts_at,
         week_starts_on=week_starts_on,
         vision_experience_rate_per_hour=vision_experience_rate_per_hour,
+        theme=theme,
     )
     clear_config_cache()
     monkeypatch.setenv("LIFEOS_CONFIG_FILE", str(config_path))

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -566,6 +566,43 @@ def test_main_config_set_ignores_runtime_env_overrides_when_persisting(
     clear_config_cache()
 
 
+def test_main_config_set_updates_theme(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        "\n".join(
+            (
+                "[database]",
+                'schema = "lifeos"',
+                "echo = false",
+                "",
+                "[preferences]",
+                'timezone = "America/Toronto"',
+                'language = "zh-Hans"',
+                'day_starts_at = "04:00"',
+                'week_starts_on = "sunday"',
+                "vision_experience_rate_per_hour = 90",
+                "",
+            )
+        ),
+        encoding="utf-8",
+    )
+    clear_config_cache()
+    monkeypatch.setenv("LIFEOS_CONFIG_FILE", str(config_path))
+
+    exit_code = cli.main(["config", "set", "preferences.theme", "night"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "Updated key: preferences.theme" in captured.out
+    assert "Preference theme: night" in captured.out
+    assert 'theme = "night"' in config_path.read_text(encoding="utf-8")
+    clear_config_cache()
+
+
 def test_main_init_can_repair_invalid_existing_config(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,6 +24,7 @@ from lifeos_cli.config import (
     validate_database_url,
     validate_day_starts_at,
     validate_language,
+    validate_theme,
     validate_timezone_name,
     validate_vision_experience_rate_per_hour,
     validate_week_starts_on,
@@ -159,6 +160,7 @@ def test_preferences_settings_read_config_file(tmp_path: Path) -> None:
                 'day_starts_at = "04:00"',
                 'week_starts_on = "sunday"',
                 "vision_experience_rate_per_hour = 90",
+                'theme = "night"',
                 "",
             )
         ),
@@ -172,6 +174,7 @@ def test_preferences_settings_read_config_file(tmp_path: Path) -> None:
     assert settings.day_starts_at == "04:00"
     assert settings.week_starts_on == "sunday"
     assert settings.vision_experience_rate_per_hour == 90
+    assert settings.theme == "night"
 
 
 def test_preferences_settings_can_ignore_env_overrides(tmp_path: Path) -> None:
@@ -208,6 +211,7 @@ def test_preferences_settings_can_ignore_env_overrides(tmp_path: Path) -> None:
     assert settings.day_starts_at == "04:00"
     assert settings.week_starts_on == "sunday"
     assert settings.vision_experience_rate_per_hour == 90
+    assert settings.theme == "system"
 
 
 def test_preferences_settings_rejects_invalid_vision_experience_rate(tmp_path: Path) -> None:
@@ -485,6 +489,18 @@ def test_validate_vision_experience_rate_per_hour_rejects_invalid_values() -> No
         raise AssertionError("invalid vision experience rate should fail")
 
 
+def test_validate_theme_rejects_invalid_values() -> None:
+    assert validate_theme("night") == "night"
+
+    try:
+        validate_theme("unknown")
+    except ConfigurationError as exc:
+        assert "Preference `theme`" in str(exc)
+        assert "system" in str(exc)
+    else:
+        raise AssertionError("invalid theme should fail")
+
+
 def test_parse_boolean_value_rejects_invalid_values() -> None:
     assert parse_boolean_value("true", field_name="Config key `database.echo`") is True
     assert parse_boolean_value("0", field_name="Config key `database.echo`") is False
@@ -522,6 +538,7 @@ def test_write_database_settings_can_write_preferences_without_database_url(tmp_
     assert "url =" not in content
     assert 'schema = "lifeos"' in content
     assert 'timezone = "America/Toronto"' in content
+    assert 'theme = "system"' in content
 
 
 def test_write_database_settings_persists_toml(tmp_path: Path) -> None:
@@ -550,6 +567,7 @@ def test_write_database_settings_persists_toml(tmp_path: Path) -> None:
     assert 'url = "postgresql+psycopg://db-user:<db-password>@localhost:5432/lifeos"' in content
     assert 'timezone = "America/Toronto"' in content
     assert "vision_experience_rate_per_hour = 90" in content
+    assert 'theme = "system"' in content
 
 
 def test_write_database_settings_preserves_other_top_level_sections(tmp_path: Path) -> None:
@@ -689,6 +707,38 @@ def test_set_runtime_config_value_updates_sqlite_url_within_same_backend(
     content = config_path.read_text(encoding="utf-8")
     assert 'url = "sqlite+aiosqlite:///tmp/new-lifeos.db"' in content
     assert "schema =" not in content
+
+
+def test_set_runtime_config_value_updates_theme_preference(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "lifeos" / "config.toml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("LIFEOS_CONFIG_FILE", str(config_path))
+    config_path.write_text(
+        "\n".join(
+            (
+                "[database]",
+                'schema = "lifeos"',
+                "echo = false",
+                "",
+                "[preferences]",
+                'timezone = "UTC"',
+                'language = "en"',
+                'day_starts_at = "00:00"',
+                'week_starts_on = "monday"',
+                "vision_experience_rate_per_hour = 60",
+                "",
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    result = set_runtime_config_value(key="preferences.theme", value="night")
+
+    assert result.preferences_settings.theme == "night"
+    assert 'theme = "night"' in config_path.read_text(encoding="utf-8")
 
 
 def test_build_database_settings_uses_injected_prompts(

--- a/tests/test_db_session.py
+++ b/tests/test_db_session.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from typing import cast
 from unittest.mock import AsyncMock
@@ -19,6 +20,24 @@ def test_clear_session_cache_disposes_cached_engine(
     monkeypatch.setattr(db_session, "_CACHED_ENGINE", fake_engine)
 
     db_session.clear_session_cache()
+
+    dispose.assert_awaited_once()
+    assert db_session._CACHED_ENGINE is None
+
+
+def test_clear_session_cache_disposes_cached_engine_inside_active_event_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dispose = AsyncMock()
+    fake_engine = SimpleNamespace(dispose=dispose)
+
+    async def run_clear() -> None:
+        monkeypatch.setattr(db_session, "_CACHED_ENGINE", fake_engine)
+
+        db_session.clear_session_cache()
+        await asyncio.sleep(0)
+
+    asyncio.run(run_clear())
 
     dispose.assert_awaited_once()
     assert db_session._CACHED_ENGINE is None

--- a/tests/test_repository_contracts.py
+++ b/tests/test_repository_contracts.py
@@ -1,8 +1,11 @@
 import json
+import re
 from pathlib import Path
 from typing import Any, cast
 
 import yaml  # type: ignore[import-untyped]
+
+from lifeos_cli.config import SUPPORTED_THEMES
 
 GITIGNORE_TEXT = Path(".gitignore").read_text()
 DEPENDABOT_CONFIG = yaml.safe_load(Path(".github/dependabot.yml").read_text())
@@ -20,6 +23,7 @@ FRONTEND_DEPENDENCY_AUDIT_WORKFLOW = yaml.safe_load(
 VALIDATE_WORKFLOW = yaml.safe_load(Path(".github/workflows/validate.yml").read_text())
 VULTURE_WHITELIST_TEXT = Path("scripts/vulture_whitelist.py").read_text()
 LOAD_LOCAL_ENV_TEXT = Path("scripts/load_local_env.sh").read_text()
+WEB_THEME_TEXT = Path("web/src/theme.ts").read_text()
 
 
 def _non_comment_shell_lines(text: str) -> list[str]:
@@ -51,6 +55,16 @@ def _flatten_json_catalog_keys(catalog: dict[str, Any]) -> dict[str, str]:
     return flattened
 
 
+def _extract_frontend_available_themes() -> tuple[str, ...]:
+    match = re.search(
+        r"export const AVAILABLE_THEMES: AppTheme\[] = \[(?P<body>.*?)\];",
+        WEB_THEME_TEXT,
+        flags=re.DOTALL,
+    )
+    assert match is not None
+    return tuple(re.findall(r'"([^"]+)"', match.group("body")))
+
+
 DOCTOR_COMMANDS = _non_comment_shell_lines(DOCTOR_TEXT)
 DEPENDENCY_HEALTH_COMMANDS = _non_comment_shell_lines(DEPENDENCY_HEALTH_TEXT)
 WEB_DEPENDENCY_HEALTH_COMMANDS = _non_comment_shell_lines(WEB_DEPENDENCY_HEALTH_TEXT)
@@ -79,6 +93,10 @@ def test_dependabot_configuration_keeps_backend_and_frontend_updates_separate() 
     assert npm_entry["groups"]["web-runtime"]["patterns"] == ["*"]
     assert npm_entry["groups"]["web-tooling"]["dependency-type"] == "development"
     assert npm_entry["groups"]["web-tooling"]["patterns"] == ["*"]
+
+
+def test_backend_theme_preferences_match_frontend_theme_options() -> None:
+    assert SUPPORTED_THEMES == _extract_frontend_available_themes()
 
 
 def test_dependency_scripts_keep_separate_scopes() -> None:

--- a/tests/test_web_cli.py
+++ b/tests/test_web_cli.py
@@ -32,6 +32,11 @@ from lifeos_cli.db.services.timelog_support import (
 from tests.config_support import install_test_config
 
 
+class CachedEngineSentinel:
+    async def dispose(self) -> None:
+        raise AssertionError("Web preference writes must not dispose the cached database engine")
+
+
 def test_web_command_is_registered() -> None:
     parser = build_parser()
 
@@ -1348,6 +1353,7 @@ def test_web_timezone_preference_converges_env_override_to_cli_config(
 ) -> None:
     pytest.importorskip("fastapi")
 
+    from lifeos_cli.db import session as db_session
     from lifeos_web.routers.preferences import get_preference
 
     config_path = install_test_config(
@@ -1357,6 +1363,7 @@ def test_web_timezone_preference_converges_env_override_to_cli_config(
         timezone="UTC",
     )
     monkeypatch.setenv("LIFEOS_TIMEZONE", "America/New_York")
+    monkeypatch.setattr(db_session, "_CACHED_ENGINE", CachedEngineSentinel())
     clear_config_cache()
 
     current = asyncio.run(get_preference("system.timezone"))
@@ -1423,3 +1430,35 @@ def test_web_vision_experience_preference_persists_to_cli_config(
     assert reloaded["value"] == 120
 
     assert "vision_experience_rate_per_hour = 120" in config_path.read_text(encoding="utf-8")
+
+
+def test_web_theme_preference_persists_to_cli_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    pytest.importorskip("fastapi")
+
+    from lifeos_cli.db import session as db_session
+    from lifeos_web.routers.preferences import PreferenceUpdate, get_preference, set_preference
+
+    config_path = install_test_config(
+        monkeypatch=monkeypatch,
+        tmp_path=tmp_path,
+        include_preferences=True,
+        theme="system",
+    )
+    monkeypatch.setattr(db_session, "_CACHED_ENGINE", CachedEngineSentinel())
+
+    updated = asyncio.run(
+        set_preference(
+            "appearance.theme",
+            PreferenceUpdate(value="night", module="appearance"),
+        )
+    )
+    assert updated["value"] == "night"
+
+    clear_config_cache()
+    reloaded = asyncio.run(get_preference("appearance.theme"))
+    assert reloaded["value"] == "night"
+
+    assert 'theme = "night"' in config_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## 背景

Web UI 的 `/config` 页面会通过 `appearance.theme` 保存视觉主题，但后端此前只把该偏好写入 Web 进程内存，重启 Web UI 后会回到默认值。

本次审查还定位到一个相关运行时问题：Web 写入 config-backed 偏好时，如果进程内已经缓存过数据库 engine，完整 runtime refresh 会尝试在 ASGI active event loop 内同步清理 session cache，从而触发 500。

## 变更

- 将 CLI 本地配置扩展为支持 `[preferences] theme`，并复用主题白名单做校验。
- 将 Web `appearance.theme` 映射到 `preferences.theme`，让主题偏好通过现有 config 文件持久化。
- Web 写 config-backed 偏好时只刷新 config cache，不触发数据库 session cache 清理。
- 收敛底层 `clear_session_cache()`：在 active event loop 内调用时调度 engine disposal，不再抛出运行时异常，避免未来异步接入层误触相同问题。
- 支持 `lifeos config set preferences.theme <theme>`，并在 `config show` 输出中展示当前主题。
- 移除 Web 进程内 `appearance.theme` 默认值残留，避免 config-backed 偏好继续保留冗余内存默认项。
- 增加前后端主题选项契约测试，避免 Python 后端校验列表与 Web 前端主题列表漂移。
- 补充配置读写、CLI config set、Web preferences endpoint 回归测试，并覆盖已缓存数据库 engine 后的 Web 写配置场景与 active event loop 下的 session cache 清理。

## 验证

- `uv run pytest tests/test_config.py tests/test_cli_init.py tests/test_web_cli.py -q`
- `uv run pytest tests/test_repository_contracts.py tests/test_config.py tests/test_web_cli.py -q`
- `uv run pytest tests/test_web_cli.py::test_web_timezone_preference_converges_env_override_to_cli_config tests/test_web_cli.py::test_web_theme_preference_persists_to_cli_config tests/test_config.py -q`
- `uv run pytest tests/test_db_session.py tests/test_web_cli.py::test_web_timezone_preference_converges_env_override_to_cli_config tests/test_web_cli.py::test_web_theme_preference_persists_to_cli_config -q`
- `npm test -- --run src/hooks/queries/__tests__/usePreferenceWithBootstrap.test.tsx`
- `bash ./scripts/dead_code_check.sh`
- `bash ./scripts/doctor.sh`

Closes #175
