### PR TITLE
enhance: Refine finance toolbar tabs

### DIFF
--- a/web/src/features/finance/utils.ts
+++ b/web/src/features/finance/utils.ts
@@ -15,6 +15,15 @@ export type PresetConfig = {
 };
 
 export type FinanceTab = PresetConfig["report"] | "rates" | "trees";
+export type FinanceToolbarTab = FinanceTab | "assets";
+
+export const FINANCE_TOOLBAR_ORDER = [
+  "assets",
+  "trees",
+  "rates",
+  "balance",
+  "cashflow",
+] as const satisfies readonly FinanceToolbarTab[];
 
 export type TreeNodeWithChildren = FinanceTreeNode & {
   children: TreeNodeWithChildren[];

--- a/web/src/features/finance/utils.ts
+++ b/web/src/features/finance/utils.ts
@@ -17,6 +17,8 @@ export type PresetConfig = {
 export type FinanceTab = PresetConfig["report"] | "rates" | "trees";
 export type FinanceToolbarTab = FinanceTab | "assets";
 
+export const DEFAULT_FINANCE_TAB: FinanceTab = "trees";
+
 export const FINANCE_TOOLBAR_ORDER = [
   "assets",
   "trees",

--- a/web/src/pages/FinancePage.tsx
+++ b/web/src/pages/FinancePage.tsx
@@ -40,10 +40,12 @@ import type { UUID } from "@/types/primitive";
 import { SnapshotDetail, SnapshotFormPanel } from "@/features/finance/SnapshotPanels";
 import {
   buildTree,
+  FINANCE_TOOLBAR_ORDER,
   flattenTree,
   snapshotLabel,
   type FinanceNodeFormState,
   type FinanceTab,
+  type FinanceToolbarTab,
   type PresetConfig,
   type TreeNodeWithChildren,
 } from "@/features/finance/utils";
@@ -73,6 +75,10 @@ const PRESETS: PresetConfig[] = [
   },
 ];
 
+const REPORT_TITLE_KEYS = Object.fromEntries(
+  PRESETS.map((item) => [item.report, item.titleKey] as const),
+) as Record<PresetConfig["report"], string>;
+
 function FinancePage() {
   const { t } = useTranslation();
   const { setHeader } = usePageHeader();
@@ -88,44 +94,51 @@ function FinancePage() {
   }, [setHeader, t]);
 
   const preset = PRESETS.find((item) => item.report === activeTab) ?? PRESETS[0];
-  const reportTabs: { id: FinanceTab; label: string }[] = PRESETS.map((item) => ({
-    id: item.report,
-    label: t(item.titleKey),
-  }));
-  const managementTabs: { id: FinanceTab; label: string }[] = [
-    { id: "rates", label: t("finance.rates.tabTitle") },
-    { id: "trees", label: t("finance.tree.tabTitle") },
-  ];
-  const renderTab = (item: { id: FinanceTab; label: string }) => (
+  const toolbarLabel = (tab: FinanceToolbarTab) => {
+    switch (tab) {
+      case "assets":
+        return t("finance.assets.manage");
+      case "trees":
+        return t("finance.tree.tabTitle");
+      case "rates":
+        return t("finance.rates.tabTitle");
+      default:
+        return t(REPORT_TITLE_KEYS[tab]);
+    }
+  };
+  const renderTab = (tab: FinanceTab) => (
     <ActionButton
-      key={item.id}
-      label={item.label}
-      onClick={() => setActiveTab(item.id)}
-      color={activeTab === item.id ? "primary" : "neutral"}
-      variant={activeTab === item.id ? "solid" : "ghost"}
+      key={tab}
+      label={toolbarLabel(tab)}
+      onClick={() => setActiveTab(tab)}
+      color={activeTab === tab ? "primary" : "neutral"}
+      variant={activeTab === tab ? "solid" : "ghost"}
       size="sm"
       className="shrink-0 px-3"
     />
   );
+  const renderToolbarItem = (tab: FinanceToolbarTab) => {
+    if (tab === "assets") {
+      return (
+        <ActionButton
+          key={tab}
+          label={toolbarLabel(tab)}
+          iconName="settings"
+          onClick={() => setAssetManagerOpen(true)}
+          size="sm"
+          variant="outline"
+          className="shrink-0 px-3"
+        />
+      );
+    }
+    return renderTab(tab);
+  };
 
   return (
     <PageLayout>
       <ToolbarContainer className="mb-6" variant="compact" padding="sm">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div className="flex flex-wrap items-center gap-2">
-            {reportTabs.map(renderTab)}
-          </div>
-          <div className="flex flex-wrap items-center justify-end gap-2">
-            {managementTabs.map(renderTab)}
-            <ActionButton
-              label={t("finance.assets.manage")}
-              iconName="settings"
-              onClick={() => setAssetManagerOpen(true)}
-              size="sm"
-              variant="outline"
-              className="shrink-0 px-3"
-            />
-          </div>
+        <div className="flex flex-wrap items-center gap-2">
+          {FINANCE_TOOLBAR_ORDER.map(renderToolbarItem)}
         </div>
       </ToolbarContainer>
 

--- a/web/src/pages/FinancePage.tsx
+++ b/web/src/pages/FinancePage.tsx
@@ -40,6 +40,7 @@ import type { UUID } from "@/types/primitive";
 import { SnapshotDetail, SnapshotFormPanel } from "@/features/finance/SnapshotPanels";
 import {
   buildTree,
+  DEFAULT_FINANCE_TAB,
   FINANCE_TOOLBAR_ORDER,
   flattenTree,
   snapshotLabel,
@@ -82,7 +83,7 @@ const REPORT_TITLE_KEYS = Object.fromEntries(
 function FinancePage() {
   const { t } = useTranslation();
   const { setHeader } = usePageHeader();
-  const [activeTab, setActiveTab] = useState<FinanceTab>("balance");
+  const [activeTab, setActiveTab] = useState<FinanceTab>(DEFAULT_FINANCE_TAB);
   const [assetManagerOpen, setAssetManagerOpen] = useState(false);
 
   useEffect(() => {

--- a/web/src/pages/__tests__/FinancePage.test.ts
+++ b/web/src/pages/__tests__/FinancePage.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { FINANCE_TOOLBAR_ORDER } from "@/features/finance/utils";
+
+describe("FinancePage", () => {
+  it("keeps finance toolbar tabs in the product order", () => {
+    expect(FINANCE_TOOLBAR_ORDER).toEqual([
+      "assets",
+      "trees",
+      "rates",
+      "balance",
+      "cashflow",
+    ]);
+  });
+});

--- a/web/src/pages/__tests__/FinancePage.test.ts
+++ b/web/src/pages/__tests__/FinancePage.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { FINANCE_TOOLBAR_ORDER } from "@/features/finance/utils";
+import { DEFAULT_FINANCE_TAB, FINANCE_TOOLBAR_ORDER } from "@/features/finance/utils";
 
 describe("FinancePage", () => {
+  it("opens the finance tree tab by default", () => {
+    expect(DEFAULT_FINANCE_TAB).toBe("trees");
+  });
+
   it("keeps finance toolbar tabs in the product order", () => {
     expect(FINANCE_TOOLBAR_ORDER).toEqual([
       "assets",


### PR DESCRIPTION
## 背景

finance web 页面顶部 toolbar 的展示顺序仍沿用旧顺序：资产负债表、现金流、汇率快照、财务树、资产管理。当前需求希望将管理入口提前，让常用的资产管理、财务树与汇率快照先于报表入口展示。

同时，资产负债表默认加载可能较慢；默认进入财务树可以更快展示管理入口并降低首次进入页面的等待感。

## 变更

- 将 finance toolbar 顺序调整为：资产管理、财务树、汇率快照、资产负债表、现金流。
- 将 finance 页默认 active tab 改为财务树。
- 将 toolbar 顺序和默认 tab 抽为页面使用的配置常量。
- 清理本次变更中可避免的中间数组薄层，避免重复维护 tab label 事实源。
- 增加前端回归测试，锁定 toolbar 展示顺序和默认 tab。
- 合并最新 `main`。

## 自审结论

- 本 PR 与 #176 是完整修复关系，并额外纳入默认打开财务树的产品调整；`Closes #176` 仍准确。
- 当前测试不多余：现有仓库没有其它覆盖 finance toolbar 产品顺序或默认 tab 的前端测试；该轻量测试覆盖了本 PR 的核心回归点。
- 未发现当前分支引入的高置信死代码、兼容旧实现逻辑或纯转发冗余。

## 验证

- `npm test -- FinancePage.test.ts`
- `npm run typecheck:test`
- `npm run lint`
- `bash ./scripts/web_validate.sh`
- `bash ./scripts/doctor.sh`

说明：`doctor.sh` 中 PostgreSQL CLI 集成测试因未设置 `LIFEOS_TEST_DATABASE_URL` 按脚本规则跳过。

Closes #176
