### PR TITLE
docs: Refresh LifeOS feature overview

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,21 +133,21 @@
         "filename": "src/lifeos_cli/locales/en/cli_messages.json",
         "hashed_secret": "49db5cedcbe4d24c102d1c9212c0aeed9d71b528",
         "is_verified": false,
-        "line_number": 841
+        "line_number": 887
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lifeos_cli/locales/en/cli_messages.json",
         "hashed_secret": "d7c832c06c94ed9bfadd601d7a1ca12551261433",
         "is_verified": false,
-        "line_number": 849
+        "line_number": 895
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lifeos_cli/locales/en/cli_messages.json",
         "hashed_secret": "cd6ace16b1f2ff3150b89368ac9df7c86b78ea50",
         "is_verified": false,
-        "line_number": 850
+        "line_number": 896
       }
     ],
     "src/lifeos_cli/locales/zh_Hans/cli_messages.json": [
@@ -156,7 +156,7 @@
         "filename": "src/lifeos_cli/locales/zh_Hans/cli_messages.json",
         "hashed_secret": "5a59e0d7fb6e3aa28246673b01fd19d3e3f3f009",
         "is_verified": false,
-        "line_number": 841
+        "line_number": 887
       }
     ],
     "web/src/features/auth/__tests__/ChangePasswordCard.test.tsx": [
@@ -233,5 +233,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-17T07:12:12Z"
+  "generated_at": "2026-06-29T03:38:15Z"
 }

--- a/README.md
+++ b/README.md
@@ -11,26 +11,69 @@
 ╚══════╝╚═╝╚═╝     ╚══════╝ ╚═════╝ ╚══════╝
 ```
 
-`lifeos-cli` is a terminal-native LifeOS for people who want one structured system for intentions, plans, execution, reflection, and reality.
+`lifeos-cli` is a terminal-native, local-first LifeOS for quantified-self workflows. It gives one structured system for intentions, plans, execution, relationships, money, reflection, and measured reality.
+
+The product surface is already broad and deep: a typed Python CLI as the primary interface, SQLite and PostgreSQL backends, Alembic migrations, a local FastAPI service, and a first-party React Web UI for human browser workflows over the same configured LifeOS database. The CLI is designed to be both human-usable and agent-friendly, with stable command grammar, help-first documentation, identifier-driven flows, and predictable text output.
 
 ## Why It Exists
 
-Most personal systems fragment life into disconnected tools. Tasks live in one place, calendars in another, notes somewhere else, and actual time spent disappears into scattered logs.
-
-That makes it unnecessarily hard to answer practical questions such as:
+Most personal systems fragment life into disconnected tools. Tasks live in one place, calendars in another, notes somewhere else, and actual time spent disappears into scattered logs. That makes it hard to answer practical questions:
 
 - What did I intend to do?
 - What actually happened?
 - What did I spend time on?
 - Which routines are real versus aspirational?
 - Which people, projects, and priorities am I actually serving?
+- How do my plans, time, habits, notes, relationships, and finances connect?
 
-It gives structure to both sides of life:
+`lifeos-cli` treats a personal operating system as both a planning graph and an evidence ledger:
 
-- intention: visions, tasks, habits, and planned events
-- reality: notes, timelogs, completed habit actions, and relationship records
+- intention: areas, visions, tasks, habits, planned events, and finance structures
+- reality: timelogs, habit actions, notes, relationship records, finance snapshots, and aggregate stats
 
-The goal is not just storage, but one CLI interface for self-management, reflection, and automation.
+The goal is not just storage. The goal is a coherent command and API surface that humans and agents can use to capture life as it happens, inspect it later, and automate repeatable self-management workflows.
+
+## Current Capability Map
+
+The implemented system covers the main quantified-self loop from planning to evidence to review.
+
+| Area | Current support |
+| --- | --- |
+| Life structure | `area` records for durable life domains, with display ordering, color/icon metadata, active state, and soft deletion. |
+| Direction | `vision` records with status, area ownership, task trees, stats, experience points, task-effort synchronization, and harvest flow. |
+| Execution | Hierarchical `task` records with parent/child structure, planning-cycle fields, status updates, subtree and hierarchy views, reorder/move support, and aggregate stats. |
+| Calendar intent | Planned `event` records with appointment/timeblock/deadline types, all-day support, recurrence rules, instance-scoped recurring updates/deletes, task/area/person/tag links, and bounded expansion. |
+| Daily schedule | `schedule` day and range views that aggregate planned events, planning-cycle tasks, and habit actions, including overdue unfinished task and habit-action roll-forward behavior. |
+| Routines | `habit` records with daily/weekly/monthly/yearly cadence, weekday/weekend controls, task links, stats, and on-demand `habit-action` materialization. |
+| Time reality | `timelog` records with date and datetime entry modes, quick batch entry, list/search filters, relationship links, batch update/delete, templates, and area-based stats. |
+| Notes and reflection | `note` records with inline/stdin/file capture, search, full-content display, bulk content replacement, soft delete, and associations to tasks, visions, events, people, timelogs, and tags. |
+| Relationships | `people` records with relationship metadata, birthday/anniversary dates, tags, related activities, anniversaries, and links from events, notes, and timelogs. |
+| Taxonomy | `tag` records with category/entity-type metadata and association counts across supported resources. |
+| Finance | Assets, reusable finance trees, nodes, instant and period snapshots, exchange-rate snapshots, default tree bootstrapping, and balance-sheet/cashflow style data modeling. |
+| Data portability | Canonical JSON/JSONL export/import, full bundle backup/restore, dry-run validation, row-level errors, and machine-oriented batch update/delete. |
+| Configuration | Persistent database and preference configuration, including timezone, language, day boundary, week boundary, theme, and default vision experience rate. |
+| Local Web API | FastAPI routers for health, tasks, visions, habits, notes, timelogs, timelog templates, people, areas, finance, planned events, stats, tags, and preferences. |
+| Web UI | A first-party Vite/React workspace for visions, habits, planning, timelog, finance, insights/stats, schedule/calendar, notes, people, and settings. |
+
+## Interfaces
+
+The terminal-native CLI is the primary product interface and command reference:
+
+```bash
+lifeos --help
+lifeos <resource> --help
+lifeos <resource> <action> --help
+```
+
+The command shape is intentionally stable:
+
+```text
+lifeos <resource> <action> [arguments] [options]
+```
+
+This shape is intentionally friendly to both humans and agents. Humans get explicit, discoverable commands; agents get deterministic help, stable identifiers, compact tabular list output, and labeled detail output.
+
+The local Web UI is the human browser interface for the same LifeOS data. It is first-party and intentionally local: the Web API and UI use the same configured database as the CLI and are not a separate hosted service.
 
 ## Getting Started
 
@@ -46,14 +89,13 @@ Install PostgreSQL support only when you need it:
 uv tool install --upgrade "lifeos-cli[postgres]"
 ```
 
-Install the optional local Web API dependencies when you want browser or HTTP access
-backed by the same configured LifeOS database:
+Install the optional local Web API and Web UI runtime dependencies when you want human browser access or HTTP access backed by the same configured LifeOS database:
 
 ```bash
 uv tool install --upgrade "lifeos-cli[web]"
 ```
 
-`lifeos-cli` supports both SQLite and PostgreSQL.
+`lifeos-cli` supports SQLite and PostgreSQL.
 
 - SQLite is the low-friction option for local, single-user setups.
 - PostgreSQL remains the schema-capable backend for managed deployments.
@@ -66,23 +108,43 @@ lifeos init
 
 For local-first use, `lifeos init` can bootstrap SQLite without requiring a separate database service. Use `lifeos init --help` for backend-specific defaults and examples.
 
-You can run that step yourself, or ask an agent that can run terminal commands to do it for you.
-
-See the available command surface:
+Inspect and adjust runtime preferences:
 
 ```bash
-lifeos --help
+lifeos config show
+lifeos config set preferences.timezone America/Toronto
+lifeos config set preferences.language zh-Hans
+lifeos config set preferences.day_starts_at 04:00
+lifeos config set preferences.week_starts_on monday
 ```
 
-Start the local Web API server:
+## Common CLI Workflows
+
+```bash
+lifeos area add "Health" --color "#16A34A" --icon heart
+lifeos vision add "Build a stronger health baseline" --area-id <area-id>
+lifeos task add "Train three times this week" --vision-id <vision-id> --planning-cycle-type week --planning-cycle-days 7 --planning-cycle-start-date 2026-04-13
+lifeos event add "Strength training" --start-time 2026-04-13T18:00:00 --end-time 2026-04-13T19:00:00 --task-id <task-id>
+lifeos schedule show --date 2026-04-13
+lifeos timelog add "Workout" --start-time 2026-04-13T18:00:00 --end-time 2026-04-13T19:00:00 --task-id <task-id>
+lifeos habit add "Morning mobility" --start-date 2026-04-01 --duration-days 100 --cadence-frequency daily
+lifeos habit-action log --habit-id <habit-id> --date 2026-04-13 --status done
+lifeos note add "Energy was higher after sleeping earlier." --task-id <task-id>
+lifeos finance tree-ensure-default
+lifeos data export all --output lifeos-bundle.zip
+```
+
+For complete CLI usage, workflows, and output conventions, see [docs/cli.md](docs/cli.md). Command-specific facts belong in CLI help, not in repository-level docs.
+
+## Local Web UI
+
+Start the local Web API server for browser access:
 
 ```bash
 lifeos web serve
 ```
 
-`lifeos web serve` does not install, build, or bundle the frontend workspace from
-PyPI. To serve a built checkout UI from the same process, build `web/` and pass
-its output directory explicitly:
+`lifeos web serve` does not install, build, or bundle the frontend workspace from PyPI. To serve the human Web UI from the same process in a source checkout, build `web/` and pass its output directory explicitly:
 
 ```bash
 lifeos web serve --static-dir web/dist
@@ -94,8 +156,7 @@ If your configured database URL uses PostgreSQL, install or run with both option
 uv run --extra web --extra postgres lifeos web serve
 ```
 
-During frontend development, run the Vite app in `web/` and proxy API requests to
-the local Web API:
+During frontend development, run the human-facing Vite app in `web/` and proxy API requests to the local Web API:
 
 ```bash
 cd web
@@ -103,27 +164,9 @@ npm install
 npm run dev
 ```
 
-Inspect and adjust runtime preferences:
+See [web/README.md](web/README.md) for frontend workspace details.
 
-```bash
-lifeos config show
-lifeos config set preferences.timezone America/Toronto
-lifeos config set preferences.language zh-Hans
-```
-
-Common commands:
-
-```bash
-lifeos schedule show --date 2026-04-13
-lifeos task list
-lifeos note add "Capture today's key decisions"
-lifeos timelog list --date 2026-04-13
-lifeos finance tree-ensure-default --purpose balance
-```
-
-For complete CLI usage, workflows, and output conventions, see [docs/cli.md](docs/cli.md).
-
-## Agent Use (Recommended)
+## Agent Use
 
 Any agent runtime that can execute terminal commands and inspect command output can operate the same CLI. That includes Codex, OpenCode, Swival, Claude Code, Cursor, Gemini CLI, OpenClaw, or your own setup.
 
@@ -132,30 +175,22 @@ Any agent runtime that can execute terminal commands and inspect command output 
 - identifier-driven discovery flows built around `list` and `show`
 - compact summary output for lists and labeled output for record detail views
 - entity-specific primary-key headers such as `task_id`, `vision_id`, and `event_id`
+- persisted language preference so agents can match human-authored payload language
+- data import/export commands for machine-generated cleanup, migration, and backup flows
 
-## Current Scope
+## Development Validation
 
-The current system already covers the core building blocks of a practical LifeOS:
+For repository changes, run the primary validation entrypoint:
 
-- notes
-- areas
-- tags
-- people
-- visions
-- tasks
-- habits and habit actions
-- events
-- timelogs
-- finance trees and snapshots
+```bash
+bash ./scripts/doctor.sh
+```
 
-Cross-cutting capabilities:
+For CLI documentation review, the help audit script executes the parser tree and renders a Markdown report:
 
-- a `schedule` read model that aggregates tasks, habit actions, and planned events into day and range views
-- recurring event expansion and recurring habit cadence support, including on-demand habit-action materialization
-- generic note associations across tasks, visions, events, people, timelogs, and tags
-- a unified finance tree and snapshot model for balance-sheet, cashflow, and custom financial records
-- persisted runtime configuration for database access plus preferences such as timezone, language, day boundary, week boundary, and vision experience defaults
-- localized CLI help and stable summary-table output for direct human use and agent consumption
+```bash
+uv run python scripts/audit_cli_help.py
+```
 
 ## Project Policies
 

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -11,26 +11,69 @@ English: [README.md](README.md)
 ╚══════╝╚═╝╚═╝     ╚══════╝ ╚═════╝ ╚══════╝
 ```
 
-`lifeos-cli` 是一个终端原生的 LifeOS，面向希望用同一个结构化系统管理意图、计划、执行、复盘与现实的人。
+`lifeos-cli` 是一个 terminal-native、local-first 的 LifeOS，用于量化自我工作流。它用同一套结构化系统管理意图、计划、执行、人际关系、金钱、反思和被测量的现实。
+
+当前产品面已经很完整：以 typed Python CLI 作为主接口，支持 SQLite 和 PostgreSQL 后端、Alembic 迁移、本地 FastAPI 服务，并提供一方 React Web UI，让人类可以通过浏览器操作同一份已配置的 LifeOS 数据库。CLI 同时面向人类和 agent 设计，具备稳定命令语法、help-first 文档、identifier-driven 流程和可预测的文本输出。
 
 ## 为什么做它
 
-大多数个人系统会把生活拆散到多个互不相通的工具里。任务在一个地方，日程在另一个地方，笔记在别处，实际投入的时间又散落在各种零碎记录里。
-
-这会让一些本来很实际的问题变得很难回答：
+大多数个人系统会把生活拆散到多个互不相通的工具里。任务在一个地方，日程在另一个地方，笔记在别处，实际投入的时间又散落在各种零碎记录里。这会让一些实际问题变得很难回答：
 
 - 我原本打算做什么？
 - 实际上发生了什么？
 - 我的时间到底花在了哪里？
 - 哪些习惯是真正活出来的，哪些只是停留在愿望里？
 - 我真正服务的是哪些人、哪些项目、哪些优先级？
+- 计划、时间、习惯、笔记、人际关系和财务之间到底如何连接？
 
-它同时为生活的两侧提供结构：
+`lifeos-cli` 把个人操作系统同时视为 planning graph 和 evidence ledger：
 
-- intention：visions、tasks、habits、planned events
-- reality：notes、timelogs、completed habit actions、relationship records
+- intention：areas、visions、tasks、habits、planned events、finance structures
+- reality：timelogs、habit actions、notes、relationship records、finance snapshots、aggregate stats
 
-目标不只是存储数据，而是为自我管理、复盘反思和自动化提供同一套 CLI 接口。
+目标不只是存储数据，而是提供一套人类和 agent 都能使用的命令与 API 表面，用来记录正在发生的生活、事后审视它，并自动化可重复的自我管理流程。
+
+## 当前能力地图
+
+已实现系统覆盖了从计划到证据再到复盘的主要量化自我闭环。
+
+| Area | Current support |
+| --- | --- |
+| Life structure | `area` 记录用于稳定生活领域，支持显示顺序、颜色/图标元数据、active 状态和软删除。 |
+| Direction | `vision` 记录支持状态、area 归属、task tree、stats、experience points、task-effort 同步和 harvest 流程。 |
+| Execution | 分层 `task` 记录支持父子结构、planning-cycle 字段、状态更新、subtree/hierarchy 视图、reorder/move 和聚合 stats。 |
+| Calendar intent | 计划型 `event` 支持 appointment/timeblock/deadline 类型、all-day、recurrence rules、单实例范围的 recurring update/delete、task/area/person/tag 链接和有界展开。 |
+| Daily schedule | `schedule` day/range 视图聚合 planned events、planning-cycle tasks 和 habit actions，并支持 overdue unfinished task / habit-action roll-forward。 |
+| Routines | `habit` 支持 daily/weekly/monthly/yearly cadence、weekday/weekend 控制、task 链接、stats 和按需 `habit-action` 物化。 |
+| Time reality | `timelog` 支持日期与日期时间录入、quick batch entry、list/search 过滤、关系链接、batch update/delete、templates 和按 area 分组的 stats。 |
+| Notes and reflection | `note` 支持 inline/stdin/file capture、search、完整内容展示、批量内容替换、软删除，并可关联 tasks、visions、events、people、timelogs 和 tags。 |
+| Relationships | `people` 支持关系元数据、生日/纪念日、tags、相关活动、anniversaries，以及来自 events、notes、timelogs 的链接。 |
+| Taxonomy | `tag` 支持 category/entity-type 元数据，以及跨资源 association counts。 |
+| Finance | 支持 assets、可复用 finance trees、nodes、instant/period snapshots、exchange-rate snapshots、default tree bootstrap，以及资产负债表/现金流风格的数据建模。 |
+| Data portability | 支持规范 JSON/JSONL export/import、完整 bundle backup/restore、dry-run validation、row-level errors 和面向机器的 batch update/delete。 |
+| Configuration | 持久化 database 与 preference 配置，包括 timezone、language、day boundary、week boundary、theme 和默认 vision experience rate。 |
+| Local Web API | FastAPI routers 覆盖 health、tasks、visions、habits、notes、timelogs、timelog templates、people、areas、finance、planned events、stats、tags 和 preferences。 |
+| Web UI | 一方 Vite/React workspace 覆盖 visions、habits、planning、timelog、finance、insights/stats、schedule/calendar、notes、people 和 settings。 |
+
+## Interfaces
+
+terminal-native CLI 是主要产品接口，也是命令参考的来源：
+
+```bash
+lifeos --help
+lifeos <resource> --help
+lifeos <resource> <action> --help
+```
+
+命令形状刻意保持稳定：
+
+```text
+lifeos <resource> <action> [arguments] [options]
+```
+
+这种形状刻意对人类和 agent 都友好。人类可以使用显式、可发现的命令；agent 可以依赖确定性的 help、稳定标识符、紧凑的 tabular list 输出和带标签的 detail 输出。
+
+本地 Web UI 是面向人类的浏览器界面，用来操作同一份 LifeOS 数据。它是一方、本地化的产品面：Web API 和 UI 使用与 CLI 相同的已配置数据库，而不是单独的托管服务。
 
 ## 快速开始
 
@@ -46,13 +89,13 @@ uv tool install --upgrade lifeos-cli
 uv tool install --upgrade "lifeos-cli[postgres]"
 ```
 
-如果需要浏览器或 HTTP 访问，可以安装可选的本地 Web API 依赖。它会使用同一份 LifeOS 数据库配置：
+如果需要人类浏览器访问或 HTTP 访问，可以安装可选的本地 Web API 与 Web UI 运行时依赖。它会使用同一份 LifeOS 数据库配置：
 
 ```bash
 uv tool install --upgrade "lifeos-cli[web]"
 ```
 
-`lifeos-cli` 当前正式支持 SQLite 和 PostgreSQL。
+`lifeos-cli` 支持 SQLite 和 PostgreSQL。
 
 - SQLite 适合本地、单用户、低门槛使用场景。
 - PostgreSQL 仍然是支持 schema 的部署型后端。
@@ -65,22 +108,43 @@ lifeos init
 
 对于本地优先的单机使用，`lifeos init` 可以直接引导 SQLite，无需额外启动数据库服务。后端默认值和示例以 `lifeos init --help` 为准。
 
-这一步既可以由人类自己执行，也可以交给能执行终端命令的 agent 来代为完成。
-
-查看 CLI 命令面：
+查看并调整运行时偏好：
 
 ```bash
-lifeos --help
+lifeos config show
+lifeos config set preferences.timezone America/Toronto
+lifeos config set preferences.language zh-Hans
+lifeos config set preferences.day_starts_at 04:00
+lifeos config set preferences.week_starts_on monday
 ```
 
-启动本地 Web API 服务：
+## 常见 CLI 工作流
+
+```bash
+lifeos area add "Health" --color "#16A34A" --icon heart
+lifeos vision add "Build a stronger health baseline" --area-id <area-id>
+lifeos task add "Train three times this week" --vision-id <vision-id> --planning-cycle-type week --planning-cycle-days 7 --planning-cycle-start-date 2026-04-13
+lifeos event add "Strength training" --start-time 2026-04-13T18:00:00 --end-time 2026-04-13T19:00:00 --task-id <task-id>
+lifeos schedule show --date 2026-04-13
+lifeos timelog add "Workout" --start-time 2026-04-13T18:00:00 --end-time 2026-04-13T19:00:00 --task-id <task-id>
+lifeos habit add "Morning mobility" --start-date 2026-04-01 --duration-days 100 --cadence-frequency daily
+lifeos habit-action log --habit-id <habit-id> --date 2026-04-13 --status done
+lifeos note add "Energy was higher after sleeping earlier." --task-id <task-id>
+lifeos finance tree-ensure-default
+lifeos data export all --output lifeos-bundle.zip
+```
+
+完整的 CLI 用法、工作流和输出约定，请参考 [docs/cli.md](docs/cli.md)。命令级事实应以 CLI help 为准，而不是放在仓库级文档中维护第二份来源。
+
+## Local Web UI
+
+启动本地 Web API 服务以支持浏览器访问：
 
 ```bash
 lifeos web serve
 ```
 
-`lifeos web serve` 不会从 PyPI 安装、构建或内置前端工作区。如果要让同一个进程服务当前
-checkout 中已构建的 UI，需要先构建 `web/`，再显式传入输出目录：
+`lifeos web serve` 不会从 PyPI 安装、构建或内置前端工作区。如果要在源码 checkout 中让同一个进程服务面向人类的 Web UI，需要先构建 `web/`，再显式传入输出目录：
 
 ```bash
 lifeos web serve --static-dir web/dist
@@ -92,7 +156,7 @@ lifeos web serve --static-dir web/dist
 uv run --extra web --extra postgres lifeos web serve
 ```
 
-前端开发时，可以在 `web/` 目录启动 Vite，并把 API 请求代理到本地 Web API：
+前端开发时，可以在 `web/` 目录启动面向人类的 Vite app，并把 API 请求代理到本地 Web API：
 
 ```bash
 cd web
@@ -100,27 +164,9 @@ npm install
 npm run dev
 ```
 
-查看并调整运行时偏好：
+前端 workspace 详情见 [web/README.md](web/README.md)。
 
-```bash
-lifeos config show
-lifeos config set preferences.timezone America/Toronto
-lifeos config set preferences.language zh-Hans
-```
-
-常用命令：
-
-```bash
-lifeos schedule show --date 2026-04-13
-lifeos task list
-lifeos note add "Capture today's key decisions"
-lifeos timelog list --date 2026-04-13
-lifeos finance tree-ensure-default --purpose balance
-```
-
-完整的 CLI 用法、工作流和输出约定，请参考 [docs/cli.md](docs/cli.md)。
-
-## Agent 使用（推荐）
+## Agent 使用
 
 任意能够执行终端命令并读取命令输出的 agent runtime 都可以操作同一套 CLI。这包括但不限于 Codex、OpenCode、Swival、Claude Code、Cursor、Gemini CLI、OpenClaw，以及你自己的自定义 agent runtime。
 
@@ -129,30 +175,22 @@ lifeos finance tree-ensure-default --purpose balance
 - 围绕 `list` 和 `show` 构建的 identifier-driven 发现流程
 - 面向列表的紧凑摘要输出，以及面向详情的标注字段输出
 - 使用 `task_id`、`vision_id`、`event_id` 等实体化主键列表头
+- 持久化语言偏好，便于 agent 匹配面向人类 payload 的语言
+- 数据 import/export 命令支持机器生成的清理、迁移和备份流程
 
-## 当前范围
+## 开发验证
 
-当前系统已经覆盖一个实用 LifeOS 的核心积木：
+仓库改动应运行主验证入口：
 
-- notes
-- areas
-- tags
-- people
-- visions
-- tasks
-- habits and habit actions
-- events
-- timelogs
-- finance trees and snapshots
+```bash
+bash ./scripts/doctor.sh
+```
 
-当前还具备这些跨模块能力：
+CLI 文档审查可以运行 help audit 脚本。它会遍历 parser tree，执行发现到的全部 `--help` 命令，并生成 Markdown 报告：
 
-- 一个 `schedule` 读模型，可把 tasks、habit actions 和 planned events 聚合成按天或按区间查看的视图
-- recurring events 的展开能力，以及 recurring habits 的 cadence 支持，包括按需生成的 habit-action
-- 跨 tasks、visions、events、people、timelogs、tags 的通用 note associations
-- 一套统一的 finance tree 与 snapshot 模型，可用于 balance-sheet、cashflow 与自定义财务记录
-- 持久化的运行时配置，既覆盖 database 连接，也覆盖 timezone、language、day boundary、week boundary 和 vision experience defaults 等偏好
-- 本地化的 CLI help，以及适合人类直用和 agent 消费的稳定摘要表输出
+```bash
+uv run python scripts/audit_cli_help.py
+```
 
 ## 项目策略
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -94,9 +94,25 @@ The current command tree is organized around a few stable families:
 - planning resources such as `area`, `vision`, `task`, `note`, `people`, and `tag`
 - scheduling and tracking resources such as `event`, `schedule`, `timelog`, `habit`, and `habit-action`
 - financial reality resources such as `finance`
-- system and portability commands such as `init`, `config`, `db`, and `data`
+- system, Web, and portability commands such as `init`, `config`, `db`, `web`, and `data`
 
 Use `lifeos <resource> --help` to enter one family and then follow the resource-level help into the action or namespace you need.
+
+## Help Review
+
+The CLI help tree is broad enough that manual spot checks are not sufficient for release review. Use the help audit script when reviewing command documentation:
+
+```bash
+uv run python scripts/audit_cli_help.py
+```
+
+The script walks the parser tree, executes every discovered `--help` invocation, and renders a Markdown report with command output and failures. Use `--path-prefix` for focused reviews such as:
+
+```bash
+uv run python scripts/audit_cli_help.py --path-prefix "timelog stats"
+```
+
+Localized help should be reviewed through the same command surface by setting the runtime language preference or `LIFEOS_LANGUAGE`.
 
 ## Safety Model
 

--- a/src/lifeos_cli/cli_support/resources/finance/parser.py
+++ b/src/lifeos_cli/cli_support/resources/finance/parser.py
@@ -37,6 +37,7 @@ from lifeos_cli.cli_support.resources.finance.handlers import (
 )
 from lifeos_cli.cli_support.runtime_utils import make_sync_handler
 from lifeos_cli.cli_support.time_args import parse_user_datetime_value
+from lifeos_cli.i18n import cli_message as _
 
 
 def build_finance_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
@@ -45,11 +46,8 @@ def build_finance_parser(subparsers: argparse._SubParsersAction[argparse.Argumen
         subparsers,
         "finance",
         help_content=HelpContent(
-            summary="Manage unified finance trees and snapshots.",
-            description=(
-                "Create finance trees, nodes, and snapshots for balance-sheet and cashflow "
-                "views. Finance trees are reusable structures and are not tied to a report type."
-            ),
+            summary=_("resources.finance.parser.manage_unified_finance_trees_and_snapshots"),
+            description=(_("resources.finance.parser.create_finance_trees_nodes_and_snapshots")),
             examples=(
                 "lifeos finance asset-list",
                 "lifeos finance tree-add --help",
@@ -58,27 +56,29 @@ def build_finance_parser(subparsers: argparse._SubParsersAction[argparse.Argumen
                 "lifeos finance snapshot-add --help",
             ),
             notes=(
-                "Instant snapshots appear in the balance-sheet view.",
-                "Period snapshots appear in the cashflow view.",
+                _("resources.finance.parser.instant_snapshots_appear_in_balance_sheet_view"),
+                _("resources.finance.parser.period_snapshots_appear_in_cashflow_view"),
             ),
         ),
     )
     finance_subparsers = finance_parser.add_subparsers(
         dest="finance_command",
-        title="actions",
-        metavar="action",
+        title=_("common.messages.actions"),
+        metavar=_("common.messages.action"),
     )
 
     asset_list = add_documented_parser(
         finance_subparsers,
         "asset-list",
         help_content=HelpContent(
-            summary="List finance assets.",
-            description="List active finance assets and their display/input precision.",
+            summary=_("resources.finance.parser.list_finance_assets"),
+            description=_(
+                "resources.finance.parser.list_active_finance_assets_and_their_precision"
+            ),
             examples=("lifeos finance asset-list",),
         ),
     )
-    add_include_deleted_argument(asset_list, noun="finance assets")
+    add_include_deleted_argument(asset_list, noun=_("resources.finance.parser.finance_assets"))
     add_limit_offset_arguments(asset_list)
     asset_list.set_defaults(handler=make_sync_handler(handle_finance_asset_list_async))
 
@@ -86,11 +86,8 @@ def build_finance_parser(subparsers: argparse._SubParsersAction[argparse.Argumen
         finance_subparsers,
         "asset-add",
         help_content=HelpContent(
-            summary="Create a finance asset.",
-            description=(
-                "Create a selectable asset code. Decimal places control amount input "
-                "validation and display formatting, from 0 to 8 places."
-            ),
+            summary=_("resources.finance.parser.create_finance_asset"),
+            description=(_("resources.finance.parser.create_selectable_asset_code")),
             examples=(
                 'lifeos finance asset-add BTC --name "Bitcoin" --decimal-places 8',
                 'lifeos finance asset-add CNY --name "Chinese Yuan"',
@@ -107,8 +104,8 @@ def build_finance_parser(subparsers: argparse._SubParsersAction[argparse.Argumen
         finance_subparsers,
         "asset-update",
         help_content=HelpContent(
-            summary="Update a finance asset.",
-            description="Update mutable finance asset fields, including decimal-place precision.",
+            summary=_("resources.finance.parser.update_finance_asset"),
+            description=_("resources.finance.parser.update_mutable_finance_asset_fields"),
             examples=("lifeos finance asset-update <asset-id> --decimal-places 8",),
         ),
     )
@@ -123,8 +120,8 @@ def build_finance_parser(subparsers: argparse._SubParsersAction[argparse.Argumen
         finance_subparsers,
         "asset-delete",
         help_content=HelpContent(
-            summary="Delete a finance asset.",
-            description="Soft-delete a finance asset.",
+            summary=_("resources.finance.parser.delete_finance_asset"),
+            description=_("resources.finance.parser.soft_delete_finance_asset"),
             examples=("lifeos finance asset-delete 11111111-1111-1111-1111-111111111111",),
         ),
     )
@@ -135,8 +132,8 @@ def build_finance_parser(subparsers: argparse._SubParsersAction[argparse.Argumen
         finance_subparsers,
         "tree-add",
         help_content=HelpContent(
-            summary="Create a finance tree.",
-            description="Create one reusable finance tree for any finance snapshot view.",
+            summary=_("resources.finance.parser.create_finance_tree"),
+            description=_("resources.finance.parser.create_reusable_finance_tree"),
             examples=(
                 'lifeos finance tree-add "Personal Finance" --primary-currency USD',
                 'lifeos finance tree-add "Investments" --primary-currency BTC --default',
@@ -153,12 +150,12 @@ def build_finance_parser(subparsers: argparse._SubParsersAction[argparse.Argumen
         finance_subparsers,
         "tree-list",
         help_content=HelpContent(
-            summary="List finance trees.",
-            description="List active finance trees.",
+            summary=_("resources.finance.parser.list_finance_trees"),
+            description=_("resources.finance.parser.list_active_finance_trees"),
             examples=("lifeos finance tree-list",),
         ),
     )
-    add_include_deleted_argument(tree_list, noun="finance trees")
+    add_include_deleted_argument(tree_list, noun=_("resources.finance.parser.finance_trees"))
     add_limit_offset_arguments(tree_list)
     tree_list.set_defaults(handler=make_sync_handler(handle_finance_tree_list_async))
 
@@ -166,21 +163,21 @@ def build_finance_parser(subparsers: argparse._SubParsersAction[argparse.Argumen
         finance_subparsers,
         "tree-show",
         help_content=HelpContent(
-            summary="Show a finance tree.",
-            description="Show one finance tree and its node hierarchy.",
+            summary=_("resources.finance.parser.show_finance_tree"),
+            description=_("resources.finance.parser.show_one_finance_tree_and_node_hierarchy"),
             examples=("lifeos finance tree-show 11111111-1111-1111-1111-111111111111",),
         ),
     )
     tree_show.add_argument("tree_id", type=UUID)
-    add_include_deleted_argument(tree_show, noun="finance trees")
+    add_include_deleted_argument(tree_show, noun=_("resources.finance.parser.finance_trees"))
     tree_show.set_defaults(handler=make_sync_handler(handle_finance_tree_show_async))
 
     ensure_default = add_documented_parser(
         finance_subparsers,
         "tree-ensure-default",
         help_content=HelpContent(
-            summary="Ensure a default finance tree exists.",
-            description="Create the global default finance tree if it does not exist.",
+            summary=_("resources.finance.parser.ensure_default_finance_tree_exists"),
+            description=_("resources.finance.parser.create_global_default_finance_tree_if_missing"),
             examples=("lifeos finance tree-ensure-default",),
         ),
     )
@@ -191,11 +188,8 @@ def build_finance_parser(subparsers: argparse._SubParsersAction[argparse.Argumen
         finance_subparsers,
         "node-add",
         help_content=HelpContent(
-            summary="Add a finance tree node.",
-            description=(
-                "Add a node to a finance tree. Nodes with children are rolled up "
-                "automatically when snapshots are saved."
-            ),
+            summary=_("resources.finance.parser.add_finance_tree_node"),
+            description=(_("resources.finance.parser.add_node_to_finance_tree")),
             examples=(
                 'lifeos finance node-add <tree-id> "Checking" --parent-id <assets-id>',
                 'lifeos finance node-add <tree-id> "Cash"',
@@ -213,8 +207,8 @@ def build_finance_parser(subparsers: argparse._SubParsersAction[argparse.Argumen
         finance_subparsers,
         "node-update",
         help_content=HelpContent(
-            summary="Update a finance node.",
-            description="Update mutable node fields without changing tree membership.",
+            summary=_("resources.finance.parser.update_finance_node"),
+            description=_("resources.finance.parser.update_mutable_node_fields"),
             examples=('lifeos finance node-update <node-id> --name "Brokerage"',),
         ),
     )
@@ -228,8 +222,8 @@ def build_finance_parser(subparsers: argparse._SubParsersAction[argparse.Argumen
         finance_subparsers,
         "node-delete",
         help_content=HelpContent(
-            summary="Delete a finance node.",
-            description="Soft-delete a finance node.",
+            summary=_("resources.finance.parser.delete_finance_node"),
+            description=_("resources.finance.parser.soft_delete_finance_node"),
             examples=("lifeos finance node-delete 11111111-1111-1111-1111-111111111111",),
         ),
     )
@@ -240,13 +234,8 @@ def build_finance_parser(subparsers: argparse._SubParsersAction[argparse.Argumen
         finance_subparsers,
         "snapshot-add",
         help_content=HelpContent(
-            summary="Create a finance snapshot.",
-            description=(
-                "Create an instant or period snapshot. Repeat --entry with "
-                "node-id:amount[:currency]. Select --rate-snapshot-id when "
-                "non-primary currencies should be converted into the primary currency. "
-                "Use --title for an optional display label."
-            ),
+            summary=_("resources.finance.parser.create_finance_snapshot"),
+            description=(_("resources.finance.parser.create_instant_or_period_snapshot")),
             examples=(
                 'lifeos finance snapshot-add <tree-id> --title "June net worth" '
                 "--entry <node-id>:1000:USD",
@@ -276,12 +265,8 @@ def build_finance_parser(subparsers: argparse._SubParsersAction[argparse.Argumen
         finance_subparsers,
         "rate-snapshot-add",
         help_content=HelpContent(
-            summary="Create a finance exchange-rate snapshot.",
-            description=(
-                "Capture point-in-time exchange-rate pairs. Repeat --rate with "
-                "base-currency:rate:quote-currency, meaning 1 base-currency equals "
-                "rate quote-currency."
-            ),
+            summary=_("resources.finance.parser.create_exchange_rate_snapshot"),
+            description=(_("resources.finance.parser.capture_point_in_time_exchange_rate_pairs")),
             examples=(
                 "lifeos finance rate-snapshot-add --rate BTC:67000:USDT",
                 "lifeos finance rate-snapshot-add --rate EUR:1.08:USD --rate CNY:0.14:USD",
@@ -306,12 +291,15 @@ def build_finance_parser(subparsers: argparse._SubParsersAction[argparse.Argumen
         finance_subparsers,
         "rate-snapshot-list",
         help_content=HelpContent(
-            summary="List finance exchange-rate snapshots.",
-            description="List stored exchange-rate snapshots.",
+            summary=_("resources.finance.parser.list_exchange_rate_snapshots"),
+            description=_("resources.finance.parser.list_stored_exchange_rate_snapshots"),
             examples=("lifeos finance rate-snapshot-list",),
         ),
     )
-    add_include_deleted_argument(rate_snapshot_list, noun="finance rate snapshots")
+    add_include_deleted_argument(
+        rate_snapshot_list,
+        noun=_("resources.finance.parser.finance_rate_snapshots"),
+    )
     add_limit_offset_arguments(rate_snapshot_list)
     rate_snapshot_list.set_defaults(
         handler=make_sync_handler(handle_finance_rate_snapshot_list_async)
@@ -321,13 +309,16 @@ def build_finance_parser(subparsers: argparse._SubParsersAction[argparse.Argumen
         finance_subparsers,
         "rate-snapshot-show",
         help_content=HelpContent(
-            summary="Show a finance exchange-rate snapshot.",
-            description="Show one rate snapshot and its exchange-rate entries.",
+            summary=_("resources.finance.parser.show_exchange_rate_snapshot"),
+            description=_("resources.finance.parser.show_one_rate_snapshot_and_entries"),
             examples=("lifeos finance rate-snapshot-show 11111111-1111-1111-1111-111111111111",),
         ),
     )
     rate_snapshot_show.add_argument("rate_snapshot_id", type=UUID)
-    add_include_deleted_argument(rate_snapshot_show, noun="finance rate snapshots")
+    add_include_deleted_argument(
+        rate_snapshot_show,
+        noun=_("resources.finance.parser.finance_rate_snapshots"),
+    )
     rate_snapshot_show.set_defaults(
         handler=make_sync_handler(handle_finance_rate_snapshot_show_async)
     )
@@ -336,8 +327,8 @@ def build_finance_parser(subparsers: argparse._SubParsersAction[argparse.Argumen
         finance_subparsers,
         "snapshot-list",
         help_content=HelpContent(
-            summary="List finance snapshots.",
-            description="List finance snapshots across all trees or for one tree.",
+            summary=_("resources.finance.parser.list_finance_snapshots"),
+            description=_("resources.finance.parser.list_finance_snapshots_across_trees"),
             examples=(
                 "lifeos finance snapshot-list",
                 "lifeos finance snapshot-list --tree-id <tree-id>",
@@ -352,11 +343,14 @@ def build_finance_parser(subparsers: argparse._SubParsersAction[argparse.Argumen
         finance_subparsers,
         "snapshot-show",
         help_content=HelpContent(
-            summary="Show a finance snapshot.",
-            description="Show one finance snapshot with all entry amounts.",
+            summary=_("resources.finance.parser.show_finance_snapshot"),
+            description=_("resources.finance.parser.show_one_finance_snapshot_with_entries"),
             examples=("lifeos finance snapshot-show 11111111-1111-1111-1111-111111111111",),
         ),
     )
     snapshot_show.add_argument("snapshot_id", type=UUID)
-    add_include_deleted_argument(snapshot_show, noun="finance snapshots")
+    add_include_deleted_argument(
+        snapshot_show,
+        noun=_("resources.finance.parser.finance_snapshots"),
+    )
     snapshot_show.set_defaults(handler=make_sync_handler(handle_finance_snapshot_show_async))

--- a/src/lifeos_cli/cli_support/system/web_commands.py
+++ b/src/lifeos_cli/cli_support/system/web_commands.py
@@ -10,6 +10,7 @@ from lifeos_cli.cli_support.help_utils import (
     add_documented_help_parser,
     add_documented_parser,
 )
+from lifeos_cli.i18n import cli_message as _
 
 
 def run_web_serve(args: argparse.Namespace) -> int:
@@ -31,47 +32,49 @@ def build_web_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentPar
         subparsers,
         "web",
         help_content=HelpContent(
-            summary="Run the optional local Web API.",
-            description=(
-                "Run the local LifeOS Web service against the database configured by "
-                "`lifeos init` and `lifeos config`."
-            ),
+            summary=_("system.web_commands.run_optional_local_web_api"),
+            description=(_("system.web_commands.run_local_lifeos_web_service")),
             examples=("lifeos web serve", "lifeos web serve --port 8765"),
-            notes=(
-                "Install the optional Web dependencies with `lifeos-cli[web]`. "
-                "If your configured database is PostgreSQL, install both extras with "
-                "`lifeos-cli[web,postgres]`.",
-            ),
+            notes=(_("system.web_commands.install_optional_web_dependencies"),),
         ),
     )
     web_subparsers = web_parser.add_subparsers(
         dest="web_command",
-        title="actions",
-        metavar="action",
+        title=_("common.messages.actions"),
+        metavar=_("common.messages.action"),
     )
     serve_parser = add_documented_parser(
         web_subparsers,
         "serve",
         help_content=HelpContent(
-            summary="Serve the local Web API, optionally with built frontend assets.",
-            description="Start a FastAPI server bound to localhost by default.",
+            summary=_("system.web_commands.serve_local_web_api"),
+            description=_("system.web_commands.start_fastapi_server_bound_to_localhost"),
             examples=(
                 "lifeos web serve",
                 "lifeos web serve --host 127.0.0.1 --port 8765",
                 "lifeos web serve --static-dir web/dist",
             ),
-            notes=(
-                "Use `web/` with Vite during frontend development. "
-                "Pass `--static-dir web/dist` to serve a built checkout UI. "
-                "With uv and a PostgreSQL database, run with `--extra web --extra postgres`.",
-            ),
+            notes=(_("system.web_commands.use_vite_during_frontend_development"),),
         ),
     )
-    serve_parser.add_argument("--host", default="127.0.0.1", help="Bind host.")
-    serve_parser.add_argument("--port", type=int, default=8765, help="Bind port.")
-    serve_parser.add_argument("--reload", action="store_true", help="Enable uvicorn reload.")
+    serve_parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help=_("system.web_commands.bind_host"),
+    )
+    serve_parser.add_argument(
+        "--port",
+        type=int,
+        default=8765,
+        help=_("system.web_commands.bind_port"),
+    )
+    serve_parser.add_argument(
+        "--reload",
+        action="store_true",
+        help=_("system.web_commands.enable_uvicorn_reload"),
+    )
     serve_parser.add_argument(
         "--static-dir",
-        help="Serve a built frontend directory such as web/dist.",
+        help=_("system.web_commands.serve_built_frontend_directory"),
     )
     serve_parser.set_defaults(handler=run_web_serve)

--- a/src/lifeos_cli/locales/en/cli_messages.json
+++ b/src/lifeos_cli/locales/en/cli_messages.json
@@ -246,6 +246,52 @@
         "when_both_start_time_and_end_time_are_given_overlapping_events_are": "`--start-time/--end-time` define an overlap window, not exact event field matches; use `--start-date/--end-date` for local-date ranges."
       }
     },
+    "finance": {
+      "parser": {
+        "add_finance_tree_node": "Add a finance tree node.",
+        "add_node_to_finance_tree": "Add a node to a finance tree. Nodes with children are rolled up automatically when snapshots are saved.",
+        "capture_point_in_time_exchange_rate_pairs": "Capture point-in-time exchange-rate pairs. Repeat --rate with base-currency:rate:quote-currency, meaning 1 base-currency equals rate quote-currency.",
+        "create_exchange_rate_snapshot": "Create a finance exchange-rate snapshot.",
+        "create_finance_asset": "Create a finance asset.",
+        "create_finance_snapshot": "Create a finance snapshot.",
+        "create_finance_tree": "Create a finance tree.",
+        "create_finance_trees_nodes_and_snapshots": "Create finance trees, nodes, and snapshots for balance-sheet and cashflow views. Finance trees are reusable structures and are not tied to a report type.",
+        "create_global_default_finance_tree_if_missing": "Create the global default finance tree if it does not exist.",
+        "create_instant_or_period_snapshot": "Create an instant or period snapshot. Repeat --entry with node-id:amount[:currency]. Select --rate-snapshot-id when non-primary currencies should be converted into the primary currency. Use --title for an optional display label.",
+        "create_reusable_finance_tree": "Create one reusable finance tree for any finance snapshot view.",
+        "create_selectable_asset_code": "Create a selectable asset code. Decimal places control amount input validation and display formatting, from 0 to 8 places.",
+        "delete_finance_asset": "Delete a finance asset.",
+        "delete_finance_node": "Delete a finance node.",
+        "ensure_default_finance_tree_exists": "Ensure a default finance tree exists.",
+        "finance_assets": "finance assets",
+        "finance_rate_snapshots": "finance rate snapshots",
+        "finance_snapshots": "finance snapshots",
+        "finance_trees": "finance trees",
+        "instant_snapshots_appear_in_balance_sheet_view": "Instant snapshots appear in the balance-sheet view.",
+        "list_active_finance_assets_and_their_precision": "List active finance assets and their display/input precision.",
+        "list_active_finance_trees": "List active finance trees.",
+        "list_exchange_rate_snapshots": "List finance exchange-rate snapshots.",
+        "list_finance_assets": "List finance assets.",
+        "list_finance_snapshots": "List finance snapshots.",
+        "list_finance_snapshots_across_trees": "List finance snapshots across all trees or for one tree.",
+        "list_finance_trees": "List finance trees.",
+        "list_stored_exchange_rate_snapshots": "List stored exchange-rate snapshots.",
+        "manage_unified_finance_trees_and_snapshots": "Manage unified finance trees and snapshots.",
+        "period_snapshots_appear_in_cashflow_view": "Period snapshots appear in the cashflow view.",
+        "show_exchange_rate_snapshot": "Show a finance exchange-rate snapshot.",
+        "show_finance_snapshot": "Show a finance snapshot.",
+        "show_finance_tree": "Show a finance tree.",
+        "show_one_finance_snapshot_with_entries": "Show one finance snapshot with all entry amounts.",
+        "show_one_finance_tree_and_node_hierarchy": "Show one finance tree and its node hierarchy.",
+        "show_one_rate_snapshot_and_entries": "Show one rate snapshot and its exchange-rate entries.",
+        "soft_delete_finance_asset": "Soft-delete a finance asset.",
+        "soft_delete_finance_node": "Soft-delete a finance node.",
+        "update_finance_asset": "Update a finance asset.",
+        "update_finance_node": "Update a finance node.",
+        "update_mutable_finance_asset_fields": "Update mutable finance asset fields, including decimal-place precision.",
+        "update_mutable_node_fields": "Update mutable node fields without changing tree membership."
+      }
+    },
     "habit": {
       "parser": {
         "cadence_cycles_can_be_daily_weekly_monthly_or_yearly_while_habit_action": "Cadence cycles can be daily, weekly, monthly, or yearly, while habit-action occurrences remain date-based.",
@@ -877,6 +923,18 @@
       "use_ping_to_validate_current_connection_settings_without_changing_schema": "Use `ping` to validate the current connection settings without changing schema.",
       "use_this_before_db_upgrade_when_you_first_need_to_confirm_target": "Use this before `db upgrade` when you first need to confirm the target database.",
       "use_upgrade_when_configured_database_schema_needs_to_catch_up_with_code": "Use `upgrade` when the configured database schema needs to catch up with the code."
+    },
+    "web_commands": {
+      "bind_host": "Bind host.",
+      "bind_port": "Bind port.",
+      "enable_uvicorn_reload": "Enable uvicorn reload.",
+      "install_optional_web_dependencies": "Install the optional Web dependencies with `lifeos-cli[web]`. If your configured database is PostgreSQL, install both extras with `lifeos-cli[web,postgres]`.",
+      "run_local_lifeos_web_service": "Run the local LifeOS Web service against the database configured by `lifeos init` and `lifeos config`.",
+      "run_optional_local_web_api": "Run the optional local Web API.",
+      "serve_built_frontend_directory": "Serve a built frontend directory such as web/dist.",
+      "serve_local_web_api": "Serve the local Web API, optionally with built frontend assets.",
+      "start_fastapi_server_bound_to_localhost": "Start a FastAPI server bound to localhost by default.",
+      "use_vite_during_frontend_development": "Use `web/` with Vite during frontend development. Pass `--static-dir web/dist` to serve a built checkout UI. With uv and a PostgreSQL database, run with `--extra web --extra postgres`."
     },
     "init_commands": {
       "configuration_is_written_to_config_lifeos_config_toml_by_default": "Configuration is written to ~/.lifeos/config.toml by default.",

--- a/src/lifeos_cli/locales/zh_Hans/cli_messages.json
+++ b/src/lifeos_cli/locales/zh_Hans/cli_messages.json
@@ -246,6 +246,52 @@
         "when_both_start_time_and_end_time_are_given_overlapping_events_are": "`--start-time/--end-time` 定义重叠时间窗口，不是精确匹配 `event` 字段；本地日期范围请使用 `--start-date/--end-date`。"
       }
     },
+    "finance": {
+      "parser": {
+        "add_finance_tree_node": "添加 `finance tree` 节点。",
+        "add_node_to_finance_tree": "向 `finance tree` 添加节点。保存 snapshot 时，含子节点的节点会自动汇总。",
+        "capture_point_in_time_exchange_rate_pairs": "记录某一时点的汇率对。重复使用 --rate，格式为 base-currency:rate:quote-currency，表示 1 个 base-currency 等于 rate 个 quote-currency。",
+        "create_exchange_rate_snapshot": "创建 finance 汇率 snapshot。",
+        "create_finance_asset": "创建 `finance asset`。",
+        "create_finance_snapshot": "创建 `finance snapshot`。",
+        "create_finance_tree": "创建 `finance tree`。",
+        "create_finance_trees_nodes_and_snapshots": "创建用于资产负债表和现金流视图的 `finance tree`、node 和 snapshot。`finance tree` 是可复用结构，不绑定到某一种报表类型。",
+        "create_global_default_finance_tree_if_missing": "当全局默认 `finance tree` 不存在时创建它。",
+        "create_instant_or_period_snapshot": "创建即时或区间 snapshot。重复使用 --entry，格式为 node-id:amount[:currency]。当非主币种需要换算到主币种时，选择 --rate-snapshot-id。使用 --title 设置可选展示标题。",
+        "create_reusable_finance_tree": "创建一个可用于任意 `finance snapshot` 视图的可复用 `finance tree`。",
+        "create_selectable_asset_code": "创建一个可选择的 `asset code`。`decimal places` 控制金额输入校验和显示格式，范围为 0 到 8 位。",
+        "delete_finance_asset": "删除 `finance asset`。",
+        "delete_finance_node": "删除 `finance node`。",
+        "ensure_default_finance_tree_exists": "确保默认 `finance tree` 存在。",
+        "finance_assets": "`finance asset`",
+        "finance_rate_snapshots": "finance 汇率 snapshot",
+        "finance_snapshots": "`finance snapshot`",
+        "finance_trees": "`finance tree`",
+        "instant_snapshots_appear_in_balance_sheet_view": "即时 snapshot 会出现在资产负债表视图中。",
+        "list_active_finance_assets_and_their_precision": "列出活动 `finance asset` 及其显示/输入精度。",
+        "list_active_finance_trees": "列出活动 `finance tree`。",
+        "list_exchange_rate_snapshots": "列出 finance 汇率 snapshot。",
+        "list_finance_assets": "列出 `finance asset`。",
+        "list_finance_snapshots": "列出 `finance snapshot`。",
+        "list_finance_snapshots_across_trees": "列出所有 tree 或某个 tree 下的 `finance snapshot`。",
+        "list_finance_trees": "列出 `finance tree`。",
+        "list_stored_exchange_rate_snapshots": "列出已存储的汇率 snapshot。",
+        "manage_unified_finance_trees_and_snapshots": "管理统一 `finance tree` 和 snapshot。",
+        "period_snapshots_appear_in_cashflow_view": "区间 snapshot 会出现在现金流视图中。",
+        "show_exchange_rate_snapshot": "显示 finance 汇率 snapshot。",
+        "show_finance_snapshot": "显示 `finance snapshot`。",
+        "show_finance_tree": "显示 `finance tree`。",
+        "show_one_finance_snapshot_with_entries": "显示一个 `finance snapshot` 及其所有 entry 金额。",
+        "show_one_finance_tree_and_node_hierarchy": "显示一个 `finance tree` 及其 node 层级。",
+        "show_one_rate_snapshot_and_entries": "显示一个汇率 snapshot 及其汇率 entry。",
+        "soft_delete_finance_asset": "软删除 `finance asset`。",
+        "soft_delete_finance_node": "软删除 `finance node`。",
+        "update_finance_asset": "更新 `finance asset`。",
+        "update_finance_node": "更新 `finance node`。",
+        "update_mutable_finance_asset_fields": "更新可变的 `finance asset` 字段，包括 decimal-place 精度。",
+        "update_mutable_node_fields": "更新可变 node 字段，不改变 tree 归属。"
+      }
+    },
     "habit": {
       "parser": {
         "cadence_cycles_can_be_daily_weekly_monthly_or_yearly_while_habit_action": "cadence 周期可以是 daily、weekly、monthly 或 yearly，而 `habit-action` 实例仍然按日期记录。",
@@ -877,6 +923,18 @@
       "use_ping_to_validate_current_connection_settings_without_changing_schema": "使用 `ping` 验证当前连接设置，不改变 schema。",
       "use_this_before_db_upgrade_when_you_first_need_to_confirm_target": "当你需要先确认目标数据库时，请在 `db upgrade` 前使用此命令。",
       "use_upgrade_when_configured_database_schema_needs_to_catch_up_with_code": "当已配置数据库的 schema 需要追上当前代码时，请使用 `upgrade`。"
+    },
+    "web_commands": {
+      "bind_host": "绑定 host。",
+      "bind_port": "绑定 port。",
+      "enable_uvicorn_reload": "启用 `uvicorn` reload。",
+      "install_optional_web_dependencies": "使用 `lifeos-cli[web]` 安装可选 Web 依赖。如果已配置数据库是 PostgreSQL，请同时安装 `lifeos-cli[web,postgres]`。",
+      "run_local_lifeos_web_service": "基于 `lifeos init` 和 `lifeos config` 配置的数据库运行本地 LifeOS Web 服务。",
+      "run_optional_local_web_api": "运行可选的本地 Web API。",
+      "serve_built_frontend_directory": "服务已构建的前端目录，例如 `web/dist`。",
+      "serve_local_web_api": "服务本地 Web API，可选挂载已构建的前端资源。",
+      "start_fastapi_server_bound_to_localhost": "启动默认绑定到 localhost 的 FastAPI 服务。",
+      "use_vite_during_frontend_development": "前端开发时使用 `web/` 下的 Vite。传入 `--static-dir web/dist` 可以服务已构建的 `checkout UI`。使用 uv 且数据库为 PostgreSQL 时，请搭配 `--extra web --extra postgres` 运行。"
     },
     "init_commands": {
       "configuration_is_written_to_config_lifeos_config_toml_by_default": "默认情况下，配置写入 ~/.lifeos/config.toml。",

--- a/web/README.md
+++ b/web/README.md
@@ -1,12 +1,27 @@
 # LifeOS Web UI
 
-This frontend is ported from the reference web frontend and adapted to the local
-LifeOS Web API.
+This frontend is the first-party human Web UI for LifeOS. It is a Vite/React workspace for browser workflows over the same database configured by the terminal-native `lifeos` CLI. The frontend is not Python package payload; published PyPI installs do not build or bundle this workspace automatically.
 
-The intent is to preserve the source frontend page structure, density, layout,
-and interaction behavior while keeping the implementation aligned with the
-current local LifeOS API. The frontend lives as a first-party repository
-workspace; it is not Python package payload.
+The UI currently focuses on dense personal operating-system workflows rather than a marketing shell. It exposes the implemented LifeOS surfaces for planning, execution, reflection, finance, people, and settings.
+
+## Current Scope
+
+Default navigation keeps LifeOS-backed surfaces visible:
+
+- Visions
+- Habits
+- Planning
+- Timelog
+- Finance
+- Insights / Stats
+- Schedule / Calendar
+- Notes
+- People
+- Settings / Config
+
+The Web API backing these surfaces lives in `src/lifeos_web`. New frontend features should land with the corresponding API surface and tests when they need server-backed data.
+
+Unsupported reference-product modules such as food diary, cloud auth, invitations, agent sessions, cardbox, notifications, export APIs, and sage maxims are intentionally absent until LifeOS exposes matching local capabilities.
 
 ## Run With Built Assets
 
@@ -16,8 +31,7 @@ From the repository root:
 uv run --extra web --extra postgres lifeos web serve --host 127.0.0.1 --port 8765 --static-dir web/dist
 ```
 
-Use `--extra postgres` when the configured LifeOS database URL uses
-`postgresql+psycopg://`. For SQLite-only local setups, `--extra web` is enough.
+Use `--extra postgres` when the configured LifeOS database URL uses `postgresql+psycopg://`. For SQLite-only local setups, `--extra web` is enough.
 
 ## Development
 
@@ -44,23 +58,3 @@ cd web
 npm ci
 npm run build
 ```
-
-## Current Scope
-
-Default navigation keeps LifeOS-backed surfaces visible:
-
-- Vision
-- Habit
-- Planning
-- Timelog
-- Stats
-- Schedule
-- Note
-- People
-- Config
-
-Unsupported modules such as finance, food diary, cloud auth, invitations, agent
-sessions, cardbox, notifications, export APIs, and sage maxims are not present in
-this frontend until LifeOS exposes matching Web API capabilities. New Web
-features should land with the corresponding `src/lifeos_web` API surface and
-tests.


### PR DESCRIPTION
## 变更概览

- 重写 canonical `README.md`，突出 LifeOS 的量化自我定位、当前能力地图、CLI/Web API/Web UI 范围和常见工作流。
- 修正产品定位：强调 `lifeos-cli` 是 terminal-native、local-first 的成熟 LifeOS 产品面，CLI 是主接口且 agent-friendly，同时 Web UI 是面向人类的本地浏览器界面。
- 同步 `README.zh-Hans.md`，避免已链接的本地化 companion 与英文 README 脱节。
- 更新 `docs/cli.md`，补充 CLI help audit 作为命令文档审查入口。
- 更新 `web/README.md`，移除 finance 不在前端的过期表述，并同步当前导航范围和人类 Web UI 定位。
- 将 `finance` 与 `web` CLI help 改为 i18n catalog 文案，补齐中文 help 中的英文硬编码片段。
- 更新 `.secrets.baseline` 中因 catalog 行号变化产生的 line number 和 generated_at。

## 自审结论

- 已移除错误的 alpha/pre-alpha 弱化表述。
- 已扫描并移除旧的无效 finance 示例 `tree-ensure-default --purpose balance`。
- 已根据实际 CLI help 修正 README 中新增的 `task add`、`timelog add`、`habit add` 示例。
- 已确认 `web/README.md` 与当前 Web UI navigation 中的 finance/insights/schedule 等模块不再冲突。
- `README.md` 继续作为英文 canonical 入口，中文 README 仅作为已存在的本地化 companion 保持对齐。
- 已将本次涉及的 Markdown prose 调整为自然段单行，避免把同一句硬换成多行。

## 验证

- `uv run python scripts/audit_cli_help.py --output /tmp/lifeos-cli-help-audit.md`
- `bash ./scripts/doctor.sh`

`doctor.sh` 已完成 PostgreSQL CLI integration coverage：主测试 641 passed，集成测试 13 passed。
