### PR TITLE
feat: Support multi-asset finance snapshots

### DIFF
--- a/src/lifeos_cli/alembic/versions/20260629_0900_allow_multi_asset_finance_entries.py
+++ b/src/lifeos_cli/alembic/versions/20260629_0900_allow_multi_asset_finance_entries.py
@@ -1,0 +1,59 @@
+"""Allow multi-asset finance snapshot entries per node.
+
+Revision ID: 20260629_0900
+Revises: 20260626_1100
+Create Date: 2026-06-29 09:00:00.000000
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260629_0900"
+down_revision: str | Sequence[str] | None = "20260626_1100"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _schema_name() -> str | None:
+    context = op.get_context()
+    return context.version_table_schema
+
+
+def upgrade() -> None:
+    schema_name = _schema_name()
+    op.drop_index(
+        "uq_finance_snapshot_entries_snapshot_node_active",
+        table_name="finance_snapshot_entries",
+        schema=schema_name,
+    )
+    op.create_index(
+        "uq_finance_snapshot_entries_snapshot_node_currency_auto_active",
+        "finance_snapshot_entries",
+        ["snapshot_id", "node_id", "currency_code", "is_auto_generated"],
+        unique=True,
+        schema=schema_name,
+        postgresql_where=sa.text("deleted_at IS NULL"),
+        sqlite_where=sa.text("deleted_at IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    schema_name = _schema_name()
+    op.drop_index(
+        "uq_finance_snapshot_entries_snapshot_node_currency_auto_active",
+        table_name="finance_snapshot_entries",
+        schema=schema_name,
+    )
+    op.create_index(
+        "uq_finance_snapshot_entries_snapshot_node_active",
+        "finance_snapshot_entries",
+        ["snapshot_id", "node_id"],
+        unique=True,
+        schema=schema_name,
+        postgresql_where=sa.text("deleted_at IS NULL"),
+        sqlite_where=sa.text("deleted_at IS NULL"),
+    )

--- a/src/lifeos_cli/alembic/versions/20260629_1000_drop_stale_finance_tree_legacy_columns.py
+++ b/src/lifeos_cli/alembic/versions/20260629_1000_drop_stale_finance_tree_legacy_columns.py
@@ -1,0 +1,65 @@
+"""Drop stale legacy finance tree columns.
+
+Revision ID: 20260629_1000
+Revises: 20260629_0900
+Create Date: 2026-06-29 10:00:00.000000
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260629_1000"
+down_revision: str | Sequence[str] | None = "20260629_0900"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _schema_name() -> str | None:
+    context = op.get_context()
+    return context.version_table_schema
+
+
+def _finance_tree_columns() -> set[str]:
+    bind = op.get_bind()
+    return {
+        column["name"]
+        for column in sa.inspect(bind).get_columns("finance_trees", schema=_schema_name())
+    }
+
+
+def upgrade() -> None:
+    stale_columns = _finance_tree_columns().intersection({"purpose", "time_mode"})
+    if not stale_columns:
+        return
+
+    with op.batch_alter_table("finance_trees", schema=_schema_name()) as batch_op:
+        for column_name in ("purpose", "time_mode"):
+            if column_name in stale_columns:
+                batch_op.drop_column(column_name)
+
+
+def downgrade() -> None:
+    existing_columns = _finance_tree_columns()
+    with op.batch_alter_table("finance_trees", schema=_schema_name()) as batch_op:
+        if "purpose" not in existing_columns:
+            batch_op.add_column(
+                sa.Column("purpose", sa.String(length=20), nullable=False, server_default="custom")
+            )
+        if "time_mode" not in existing_columns:
+            batch_op.add_column(
+                sa.Column(
+                    "time_mode",
+                    sa.String(length=20),
+                    nullable=False,
+                    server_default="instant",
+                )
+            )
+    with op.batch_alter_table("finance_trees", schema=_schema_name()) as batch_op:
+        if "purpose" not in existing_columns:
+            batch_op.alter_column("purpose", server_default=None)
+        if "time_mode" not in existing_columns:
+            batch_op.alter_column("time_mode", server_default=None)

--- a/src/lifeos_cli/db/models/finance.py
+++ b/src/lifeos_cli/db/models/finance.py
@@ -185,9 +185,11 @@ class FinanceSnapshotEntry(UUIDPrimaryKeyMixin, TimestampedMixin, SoftDeleteMixi
     __tablename__ = "finance_snapshot_entries"
     __table_args__ = (
         Index(
-            "uq_finance_snapshot_entries_snapshot_node_active",
+            "uq_finance_snapshot_entries_snapshot_node_currency_auto_active",
             "snapshot_id",
             "node_id",
+            "currency_code",
+            "is_auto_generated",
             unique=True,
             postgresql_where=text("deleted_at IS NULL"),
             sqlite_where=text("deleted_at IS NULL"),

--- a/src/lifeos_cli/db/services/finance.py
+++ b/src/lifeos_cli/db/services/finance.py
@@ -712,10 +712,8 @@ async def _load_entry_nodes(
     if not entries:
         raise FinanceValidationError("Finance snapshot requires at least one entry")
     node_ids = [entry.node_id for entry in entries]
-    if len(set(node_ids)) != len(node_ids):
-        raise FinanceValidationError("Finance snapshot entries must reference unique nodes")
     stmt = select(FinanceTreeNode).where(
-        FinanceTreeNode.id.in_(node_ids),
+        FinanceTreeNode.id.in_(set(node_ids)),
         FinanceTreeNode.tree_id == tree_id,
         FinanceTreeNode.deleted_at.is_(None),
     )
@@ -1343,12 +1341,21 @@ async def _rebuild_finance_snapshot_entries(
         amount = _decimal(entry_input.amount)
         normalized_inputs.append((entry_input, node, amount, currency_code))
         entry_currency_codes.add(currency_code)
+    seen_entry_keys: set[tuple[UUID, str]] = set()
+    for _, node, _, currency_code in normalized_inputs:
+        entry_key = (node.id, currency_code)
+        if entry_key in seen_entry_keys:
+            raise FinanceValidationError(
+                f"Finance snapshot entries must reference unique assets per node: "
+                f"{node.name} {currency_code}"
+            )
+        seen_entry_keys.add(entry_key)
     decimal_places_by_code = await _load_asset_decimal_places(
         session,
         currency_codes=entry_currency_codes,
     )
     snapshot_entries: list[FinanceSnapshotEntry] = []
-    entry_by_node_id: dict[UUID, FinanceSnapshotEntry] = {}
+    manual_entries_by_node_id: dict[UUID, list[FinanceSnapshotEntry]] = {}
     used_rates: dict[str, RateResolution] = {}
     missing_rate_currencies: set[str] = set()
     for entry_input, node, amount, currency_code in normalized_inputs:
@@ -1388,53 +1395,59 @@ async def _rebuild_finance_snapshot_entries(
         )
         session.add(entry)
         snapshot_entries.append(entry)
-        entry_by_node_id[node.id] = entry
+        manual_entries_by_node_id.setdefault(node.id, []).append(entry)
 
     rollup_nodes = await _load_rollup_nodes(session, tree_id=tree.id)
     all_nodes = {node.id: node for node in await list_finance_nodes(session, tree_id=tree.id)}
     for rollup_node in rollup_nodes:
-        if rollup_node.id in entry_by_node_id:
-            continue
         descendant_entries = [
             entry
-            for node_id, entry in entry_by_node_id.items()
+            for node_id, node_entries in manual_entries_by_node_id.items()
+            for entry in node_entries
             if all_nodes.get(node_id) is not None
-            and all_nodes[node_id].path.startswith(f"{rollup_node.path}/")
+            and (
+                all_nodes[node_id].id == rollup_node.id
+                or all_nodes[node_id].path.startswith(f"{rollup_node.path}/")
+            )
         ]
         if not descendant_entries:
             continue
         use_converted_rollups = rate_snapshot is not None and not missing_rate_currencies
         if not use_converted_rollups:
-            descendant_currencies = {entry.currency_code for entry in descendant_entries}
-            if len(descendant_currencies) != 1:
-                continue
-            rollup_currency = next(iter(descendant_currencies))
-            amount = _quantize_amount(
-                sum((entry.amount for entry in descendant_entries), Decimal("0"))
-            )
-            entry = FinanceSnapshotEntry(
-                snapshot_id=snapshot.id,
-                node_id=rollup_node.id,
-                amount=amount,
-                currency_code=rollup_currency,
-                amount_converted=amount,
-                is_auto_generated=True,
-            )
-        else:
-            amount_converted = _quantize_amount(
-                sum((entry.amount_converted for entry in descendant_entries), Decimal("0"))
-            )
-            entry = FinanceSnapshotEntry(
-                snapshot_id=snapshot.id,
-                node_id=rollup_node.id,
-                amount=amount_converted,
-                currency_code=snapshot.primary_currency,
-                amount_converted=amount_converted,
-                is_auto_generated=True,
-            )
+            entries_by_currency: dict[str, list[FinanceSnapshotEntry]] = {}
+            for descendant_entry in descendant_entries:
+                entries_by_currency.setdefault(
+                    descendant_entry.currency_code,
+                    [],
+                ).append(descendant_entry)
+            for rollup_currency, currency_entries in sorted(entries_by_currency.items()):
+                amount = _quantize_amount(
+                    sum((entry.amount for entry in currency_entries), Decimal("0"))
+                )
+                entry = FinanceSnapshotEntry(
+                    snapshot_id=snapshot.id,
+                    node_id=rollup_node.id,
+                    amount=amount,
+                    currency_code=rollup_currency,
+                    amount_converted=amount,
+                    is_auto_generated=True,
+                )
+                session.add(entry)
+                snapshot_entries.append(entry)
+            continue
+        amount_converted = _quantize_amount(
+            sum((entry.amount_converted for entry in descendant_entries), Decimal("0"))
+        )
+        entry = FinanceSnapshotEntry(
+            snapshot_id=snapshot.id,
+            node_id=rollup_node.id,
+            amount=amount_converted,
+            currency_code=snapshot.primary_currency,
+            amount_converted=amount_converted,
+            is_auto_generated=True,
+        )
         session.add(entry)
         snapshot_entries.append(entry)
-        entry_by_node_id[rollup_node.id] = entry
 
     manual_entries = [entry for entry in snapshot_entries if not entry.is_auto_generated]
     aggregation_mode = (

--- a/tests/test_finance_services.py
+++ b/tests/test_finance_services.py
@@ -358,6 +358,116 @@ def test_finance_snapshot_amount_precision_follows_asset() -> None:
     asyncio.run(run())
 
 
+def test_finance_snapshot_supports_multiple_assets_under_one_account() -> None:
+    async def run() -> None:
+        engine, session_factory = await _create_sqlite_session_factory()
+        try:
+            async with session_factory() as session:
+                tree = await finance.ensure_default_finance_tree(
+                    session,
+                    primary_currency="USD",
+                )
+                nodes = await finance.list_finance_nodes(session, tree_id=tree.id)
+                assets = next(node for node in nodes if node.name == "Assets")
+                exin = await finance.create_finance_node(
+                    session,
+                    tree_id=tree.id,
+                    parent_id=assets.id,
+                    name="EXIN savings",
+                    currency_code="CNY",
+                )
+
+                snapshot = await finance.create_finance_snapshot(
+                    session,
+                    tree_id=tree.id,
+                    entries=[
+                        finance.FinanceSnapshotEntryInput(
+                            node_id=exin.id,
+                            amount=Decimal("1000"),
+                            currency_code="CNY",
+                        ),
+                        finance.FinanceSnapshotEntryInput(
+                            node_id=exin.id,
+                            amount=Decimal("50"),
+                            currency_code="USDT",
+                        ),
+                    ],
+                )
+
+                manual_entries = [
+                    entry for entry in snapshot.entries if not entry.is_auto_generated
+                ]
+                assert {(entry.node_id, entry.currency_code) for entry in manual_entries} == {
+                    (exin.id, "CNY"),
+                    (exin.id, "USDT"),
+                }
+                asset_rollups = [
+                    entry
+                    for entry in snapshot.entries
+                    if entry.node_id == assets.id and entry.is_auto_generated
+                ]
+                assert {(entry.currency_code, entry.amount) for entry in asset_rollups} == {
+                    ("CNY", Decimal("1000.00000000")),
+                    ("USDT", Decimal("50.00000000")),
+                }
+                assert snapshot.summary is not None
+                assert snapshot.summary["amounts_by_currency"]["CNY"]["net_amount"] == (
+                    "1000.00000000"
+                )
+                assert snapshot.summary["amounts_by_currency"]["USDT"]["net_amount"] == (
+                    "50.00000000"
+                )
+        finally:
+            await engine.dispose()
+
+    asyncio.run(run())
+
+
+def test_finance_snapshot_rejects_duplicate_asset_entries_for_one_account() -> None:
+    async def run() -> None:
+        engine, session_factory = await _create_sqlite_session_factory()
+        try:
+            async with session_factory() as session:
+                tree = await finance.ensure_default_finance_tree(
+                    session,
+                    primary_currency="USD",
+                )
+                assets = next(
+                    node
+                    for node in await finance.list_finance_nodes(session, tree_id=tree.id)
+                    if node.name == "Assets"
+                )
+                account = await finance.create_finance_node(
+                    session,
+                    tree_id=tree.id,
+                    parent_id=assets.id,
+                    name="Brokerage",
+                    currency_code="USD",
+                )
+
+                with pytest.raises(finance.FinanceValidationError):
+                    await finance.create_finance_snapshot(
+                        session,
+                        tree_id=tree.id,
+                        entries=[
+                            finance.FinanceSnapshotEntryInput(
+                                node_id=account.id,
+                                amount=Decimal("10"),
+                                currency_code="USD",
+                            ),
+                            finance.FinanceSnapshotEntryInput(
+                                node_id=account.id,
+                                amount=Decimal("20"),
+                                currency_code="usd",
+                            ),
+                        ],
+                    )
+        finally:
+            await engine.dispose()
+
+    asyncio.run(run())
+
+
 def test_finance_snapshot_without_rate_snapshot_keeps_native_currency_totals() -> None:
     async def run() -> None:
         engine, session_factory = await _create_sqlite_session_factory()

--- a/web/src/features/finance/SnapshotPanels.tsx
+++ b/web/src/features/finance/SnapshotPanels.tsx
@@ -23,7 +23,6 @@ import {
   formatAmountForAsset,
   formatMoney,
   formatNumberForAsset,
-  getRequiredRateCurrencies,
   isoToDateInput,
   isoToDateTimeLocal,
   localDateTimeToIso,
@@ -32,7 +31,6 @@ import {
   todayDate,
   type PresetConfig,
   type SnapshotAmountState,
-  type SnapshotNoteState,
   type TreeNodeWithChildren,
 } from "./utils";
 
@@ -83,17 +81,16 @@ export function SnapshotFormPanel({
   const [periodEnd, setPeriodEnd] = useState(todayDate());
   const [title, setTitle] = useState("");
   const [amounts, setAmounts] = useState<SnapshotAmountState>({});
-  const [notes, setNotes] = useState<SnapshotNoteState>({});
   const [snapshotNote, setSnapshotNote] = useState("");
   const [selectedRateSnapshotId, setSelectedRateSnapshotId] = useState<UUID | "">("");
   const [settlementCurrency, setSettlementCurrency] = useState(tree.primary_currency);
-  const leafNodes = useMemo(
-    () => flattenTree(treeNodes).filter((node) => node.children.length === 0),
+  const flatNodes = useMemo(
+    () => flattenTree(treeNodes),
     [treeNodes],
   );
   const requiredSettlementCurrencies = useMemo(
-    () => getRequiredRateCurrencies(leafNodes, settlementCurrency),
-    [leafNodes, settlementCurrency],
+    () => getRequiredHoldingRateCurrencies(amounts, settlementCurrency),
+    [amounts, settlementCurrency],
   );
   const selectedRateSnapshot = useMemo(
     () => rateSnapshots.find((snapshot) => snapshot.id === selectedRateSnapshotId) ?? null,
@@ -139,7 +136,6 @@ export function SnapshotFormPanel({
       setPeriodEnd(todayDate());
       setTitle("");
       setAmounts({});
-      setNotes({});
       setSnapshotNote("");
       setSelectedRateSnapshotId("");
       setSettlementCurrency(tree.primary_currency);
@@ -154,15 +150,20 @@ export function SnapshotFormPanel({
     setSelectedRateSnapshotId(initialSnapshot.rate_snapshot_id ?? "");
     setSettlementCurrency(initialSnapshot.primary_currency || tree.primary_currency);
     const nextAmounts: SnapshotAmountState = {};
-    const nextNotes: SnapshotNoteState = {};
     (initialSnapshot.entries ?? [])
       .filter((entry) => !entry.is_auto_generated)
       .forEach((entry) => {
-        nextAmounts[entry.node_id] = entry.amount;
-        nextNotes[entry.node_id] = entry.note ?? "";
+        nextAmounts[entry.node_id] = [
+          ...(nextAmounts[entry.node_id] ?? []),
+          {
+            id: entry.id,
+            currencyCode: entry.currency_code,
+            amount: entry.amount,
+            note: entry.note ?? "",
+          },
+        ];
       });
     setAmounts(nextAmounts);
-    setNotes(nextNotes);
   }, [initialSnapshot, mode, tree.primary_currency]);
 
   useEffect(() => {
@@ -173,20 +174,35 @@ export function SnapshotFormPanel({
 
   const handleSubmit = (event: React.FormEvent) => {
     event.preventDefault();
-    const entries = leafNodes.reduce<FinanceSnapshotEntryCreate[]>((acc, node) => {
-      const amount = amounts[node.id]?.trim();
-      if (!amount) {
-        return acc;
-      }
-      acc.push({
-        node_id: node.id,
-        amount: amount.replace(",", "."),
-        currency_code: node.currency_code || tree.primary_currency,
-        note: notes[node.id]?.trim() || null,
+    let hasHoldingWithoutAsset = false;
+    const entryNodes = flatNodes.filter(
+      (node) => !node.children.length || (amounts[node.id] ?? []).length > 0,
+    );
+    const entries = entryNodes.reduce<FinanceSnapshotEntryCreate[]>((acc, node) => {
+      (amounts[node.id] ?? []).forEach((holding) => {
+        const amount = holding.amount.trim();
+        if (!amount) {
+          return;
+        }
+        const currencyCode = normalizeHoldingCurrency(holding.currencyCode);
+        if (!currencyCode) {
+          hasHoldingWithoutAsset = true;
+          return;
+        }
+        acc.push({
+          node_id: node.id,
+          amount: amount.replace(",", "."),
+          currency_code: currencyCode,
+          note: holding.note.trim() || null,
+        });
       });
       return acc;
     }, []);
 
+    if (hasHoldingWithoutAsset) {
+      toast.showWarning(t("finance.messages.holdingAssetRequired"));
+      return;
+    }
     if (!entries.length) {
       toast.showWarning(t("finance.messages.noEntries"));
       return;
@@ -204,7 +220,6 @@ export function SnapshotFormPanel({
     if (mode === "create") {
       setTitle("");
       setAmounts({});
-      setNotes({});
       setSnapshotNote("");
       setSelectedRateSnapshotId("");
     }
@@ -237,7 +252,7 @@ export function SnapshotFormPanel({
             color="primary"
             variant="solid"
             iconName="check"
-            disabled={submitting || !leafNodes.length}
+            disabled={submitting || !flatNodes.length}
           />
         </div>
       </div>
@@ -331,19 +346,22 @@ export function SnapshotFormPanel({
         <SnapshotEntryTreeTable
           treeNodes={treeNodes}
           amounts={amounts}
-          notes={notes}
           aggregatedAmounts={hasCompleteRateSnapshot ? aggregatedAmounts : {}}
           nativeAggregatedAmounts={nativeAggregatedAmounts}
           primaryCurrency={settlementCurrency}
           conversionRates={conversionRates}
           assets={assets}
+          onCreateAsset={onCreateAsset}
           hasRateSnapshot={hasCompleteRateSnapshot}
           submitting={submitting}
-          onChangeAmount={(nodeId, value) =>
-            setAmounts((prev) => ({ ...prev, [nodeId]: value }))
+          onAddHolding={(node) =>
+            setAmounts((prev) => addExtraHoldingToNode(prev, node, settlementCurrency, assets))
           }
-          onChangeNote={(nodeId, value) =>
-            setNotes((prev) => ({ ...prev, [nodeId]: value }))
+          onChangeHolding={(nodeId, holdingId, patch) =>
+            setAmounts((prev) => updateHoldingInNode(prev, nodeId, holdingId, patch))
+          }
+          onRemoveHolding={(nodeId, holdingId) =>
+            setAmounts((prev) => removeHoldingFromNode(prev, nodeId, holdingId))
           }
         />
       </div>
@@ -413,29 +431,35 @@ function RateSnapshotSelectPanel({
 function SnapshotEntryTreeTable({
   treeNodes,
   amounts,
-  notes,
   aggregatedAmounts,
   nativeAggregatedAmounts,
   primaryCurrency,
   conversionRates,
   assets,
+  onCreateAsset,
   hasRateSnapshot,
   submitting,
-  onChangeAmount,
-  onChangeNote,
+  onAddHolding,
+  onChangeHolding,
+  onRemoveHolding,
 }: {
   treeNodes: TreeNodeWithChildren[];
   amounts: SnapshotAmountState;
-  notes: SnapshotNoteState;
   aggregatedAmounts: Record<UUID, string>;
   nativeAggregatedAmounts: Record<UUID, string>;
   primaryCurrency: string;
   conversionRates: Record<string, number>;
   assets: FinanceAsset[];
+  onCreateAsset: (code: string) => Promise<FinanceAsset>;
   hasRateSnapshot: boolean;
   submitting: boolean;
-  onChangeAmount: (nodeId: UUID, value: string) => void;
-  onChangeNote: (nodeId: UUID, value: string) => void;
+  onAddHolding: (node: TreeNodeWithChildren) => void;
+  onChangeHolding: (
+    nodeId: UUID,
+    holdingId: string,
+    patch: { currencyCode?: string; amount?: string; note?: string },
+  ) => void;
+  onRemoveHolding: (nodeId: UUID, holdingId: string) => void;
 }) {
   const { t } = useTranslation();
   const [expandedIds, setExpandedIds] = useState<Set<UUID>>(new Set());
@@ -462,27 +486,39 @@ function SnapshotEntryTreeTable({
     nodes.flatMap((node) => {
       const hasChildren = node.children.length > 0;
       const isExpanded = expandedIds.has(node.id);
-      const amount = amounts[node.id] ?? "";
-      const nodeCurrency = node.currency_code || primaryCurrency;
-      const aggregatedAmount = aggregatedAmounts[node.id] ?? "";
+      const holdings = amounts[node.id] ?? [];
+      const defaultCurrency = normalizeHoldingCurrency(node.currency_code || primaryCurrency);
+      const defaultHolding = holdings.find(
+        (holding) => normalizeHoldingCurrency(holding.currencyCode) === defaultCurrency,
+      );
+      const extraHoldings = holdings.filter((holding) => holding.id !== defaultHolding?.id);
       const nativeAggregatedAmount = nativeAggregatedAmounts[node.id] ?? "";
-      const convertedAmount = hasRateSnapshot
-        ? hasChildren
-          ? aggregatedAmount
-          : convertSnapshotAmount(
-              amount,
-              nodeCurrency,
-              primaryCurrency,
-              conversionRates,
-              assets,
-            )
-        : nativeAggregatedAmounts[node.id] ?? "";
-      const amountNegative = isNegativeAmount(amount);
-      const convertedNegative = isNegativeAmount(convertedAmount);
+      const aggregatedAmount = aggregatedAmounts[node.id] ?? "";
+      const defaultAmount = defaultHolding?.amount ?? "";
+      const defaultConvertedAmount = hasRateSnapshot
+        ? convertSnapshotAmount(
+            defaultAmount,
+            defaultCurrency,
+            primaryCurrency,
+            conversionRates,
+            assets,
+          )
+        : "";
+      const displayConvertedAmount = hasChildren ? aggregatedAmount : defaultConvertedAmount;
+      const defaultAmountNegative = isNegativeAmount(defaultAmount);
       const nativeAggregatedNegative = isNegativeAmount(nativeAggregatedAmount);
+      const displayConvertedNegative = isNegativeAmount(displayConvertedAmount);
 
       const rows: React.ReactNode[] = [
-        <tr key={node.id} className="border-base-200">
+        <tr
+          key={node.id}
+          className={[
+            "border-base-200",
+            hasChildren ? "border-l-4 border-l-base-content/30 bg-base-200/60" : "",
+          ]
+            .filter(Boolean)
+            .join(" ")}
+        >
           <td className="align-top">
             <div
               className="flex items-start gap-3"
@@ -512,45 +548,82 @@ function SnapshotEntryTreeTable({
             </div>
           </td>
           <td className="align-top text-center">
-            <span className="text-base-content/70">{nodeCurrency.toUpperCase()}</span>
+            <span className="inline-flex min-h-[2.25rem] items-center text-base-content/70">
+              {defaultCurrency}
+            </span>
           </td>
           <td className="align-top">
             {hasChildren ? (
-              <div
-                className={[
-                  "min-h-[2.25rem] rounded-md border border-dashed border-base-200 px-3 py-2 text-sm",
-                  nativeAggregatedNegative ? "text-error" : "text-base-content/80",
-                ]
-                  .filter(Boolean)
-                  .join(" ")}
-              >
-                {nativeAggregatedAmount || "-"}
+              <div className="flex min-w-[12rem] items-start gap-2">
+                <div
+                  className={[
+                    "min-h-[2.25rem] flex-1 rounded-md border border-dashed border-base-200 px-3 py-2 text-sm",
+                    nativeAggregatedNegative ? "text-error" : "text-base-content/80",
+                  ]
+                    .filter(Boolean)
+                    .join(" ")}
+                >
+                  {nativeAggregatedAmount || "-"}
+                </div>
+                <ActionButton
+                  label=""
+                  iconName="plus"
+                  iconOnly
+                  size="xs"
+                  variant="ghost"
+                  ariaLabel={t("finance.snapshot.addHolding")}
+                  disabled={submitting}
+                  onClick={() => {
+                    onAddHolding(node);
+                    setExpandedIds((current) => new Set(current).add(node.id));
+                  }}
+                />
               </div>
             ) : (
-              <TextInput
-                type="text"
-                inputMode="decimal"
-                pattern={amountInputPattern(assetDecimalPlaces(assets, nodeCurrency))}
-                size="sm"
-                className={amountNegative ? "text-error" : "text-base-content"}
-                value={amount}
-                onChange={(event) => onChangeAmount(node.id, event.target.value)}
-                placeholder={t("finance.snapshot.balancePlaceholder")}
-                disabled={submitting}
-              />
+              <div className="flex min-w-[12rem] items-start gap-2">
+                <TextInput
+                  type="text"
+                  inputMode="decimal"
+                  pattern={amountInputPattern(assetDecimalPlaces(assets, defaultCurrency))}
+                  size="sm"
+                  className={defaultAmountNegative ? "text-error" : "text-base-content"}
+                  value={defaultAmount}
+                  onChange={(event) =>
+                    onChangeHolding(node.id, defaultHolding?.id ?? "", {
+                      currencyCode: defaultCurrency,
+                      amount: event.target.value,
+                    })
+                  }
+                  placeholder={t("finance.snapshot.balancePlaceholder")}
+                  disabled={submitting}
+                />
+                <ActionButton
+                  label=""
+                  iconName="plus"
+                  iconOnly
+                  size="xs"
+                  variant="ghost"
+                  ariaLabel={t("finance.snapshot.addHolding")}
+                  disabled={submitting}
+                  onClick={() => {
+                    onAddHolding(node);
+                    setExpandedIds((current) => new Set(current).add(node.id));
+                  }}
+                />
+              </div>
             )}
           </td>
           <td className="align-top">
-            {convertedAmount ? (
+            {displayConvertedAmount ? (
               <span
                 className={[
                   "inline-flex min-h-[2.25rem] items-center rounded-md border border-dashed border-base-200 px-3 text-sm",
-                  convertedNegative ? "text-error" : "text-base-content/80",
+                  displayConvertedNegative ? "text-error" : "text-base-content/80",
                 ]
                   .filter(Boolean)
                   .join(" ")}
               >
-                {convertedAmount}
+                {displayConvertedAmount}
               </span>
             ) : (
               <span className="inline-flex min-h-[2.25rem] items-center rounded-md border border-dashed border-base-200 px-3 text-sm text-base-content/40">
@@ -567,8 +640,13 @@ function SnapshotEntryTreeTable({
               <TextInput
                 type="text"
                 size="sm"
-                value={notes[node.id] ?? ""}
-                onChange={(event) => onChangeNote(node.id, event.target.value)}
+                value={defaultHolding?.note ?? ""}
+                onChange={(event) =>
+                  onChangeHolding(node.id, defaultHolding?.id ?? "", {
+                    currencyCode: defaultCurrency,
+                    note: event.target.value,
+                  })
+                }
                 placeholder={t("finance.snapshot.notePlaceholder")}
                 disabled={submitting}
               />
@@ -576,6 +654,112 @@ function SnapshotEntryTreeTable({
           </td>
         </tr>,
       ];
+
+      if (isExpanded) {
+        (hasChildren ? holdings : extraHoldings).forEach((holding) => {
+          const holdingCurrency = normalizeHoldingCurrency(holding.currencyCode);
+          const holdingPrecisionCurrency = holdingCurrency || primaryCurrency;
+          const convertedHoldingAmount = hasRateSnapshot
+            ? holdingCurrency
+              ? convertSnapshotAmount(
+                  holding.amount,
+                  holdingCurrency,
+                  primaryCurrency,
+                  conversionRates,
+                  assets,
+                )
+              : ""
+            : "";
+          const amountNegative = isNegativeAmount(holding.amount);
+          const holdingConvertedNegative = isNegativeAmount(convertedHoldingAmount);
+          rows.push(
+            <tr
+              key={`${node.id}:${holding.id}`}
+              className="border-base-200 border-l-4 border-l-transparent bg-base-100"
+            >
+              <td className="align-top">
+                <div
+                  className="flex items-start gap-3"
+                  style={{ paddingLeft: `${(depth + 1) * 1.25}rem` }}
+                />
+              </td>
+              <td className="align-top">
+                <AssetSelect
+                  assets={assets}
+                  value={holdingCurrency}
+                  onChange={(currencyCode) =>
+                    onChangeHolding(node.id, holding.id, { currencyCode })
+                  }
+                  onCreateAsset={onCreateAsset}
+                  disabled={submitting}
+                  size="sm"
+                  className="min-w-[8rem]"
+                />
+              </td>
+              <td className="align-top">
+                <div className="flex min-w-[12rem] items-start gap-2">
+                  <TextInput
+                    type="text"
+                    inputMode="decimal"
+                    pattern={amountInputPattern(
+                      assetDecimalPlaces(assets, holdingPrecisionCurrency),
+                    )}
+                    size="sm"
+                    className={amountNegative ? "text-error" : "text-base-content"}
+                    value={holding.amount}
+                    onChange={(event) =>
+                      onChangeHolding(node.id, holding.id, { amount: event.target.value })
+                    }
+                    placeholder={t("finance.snapshot.balancePlaceholder")}
+                    disabled={submitting}
+                  />
+                  <ActionButton
+                    label=""
+                    iconName="trash"
+                    iconOnly
+                    size="xs"
+                    variant="ghost"
+                    color="error"
+                    ariaLabel={t("finance.snapshot.removeHolding")}
+                    disabled={submitting}
+                    onClick={() => onRemoveHolding(node.id, holding.id)}
+                  />
+                </div>
+              </td>
+              <td className="align-top">
+                {convertedHoldingAmount ? (
+                  <span
+                    className={[
+                      "inline-flex min-h-[2.25rem] items-center rounded-md border border-dashed border-base-200 px-3 text-sm",
+                      holdingConvertedNegative ? "text-error" : "text-base-content/80",
+                    ]
+                      .filter(Boolean)
+                      .join(" ")}
+                  >
+                    {convertedHoldingAmount}
+                  </span>
+                ) : (
+                  <span className="inline-flex min-h-[2.25rem] items-center rounded-md border border-dashed border-base-200 px-3 text-sm text-base-content/40">
+                    -
+                  </span>
+                )}
+              </td>
+              <td className="align-top">
+                <TextInput
+                  type="text"
+                  size="sm"
+                  value={holding.note}
+                  onChange={(event) =>
+                    onChangeHolding(node.id, holding.id, { note: event.target.value })
+                  }
+                  placeholder={t("finance.snapshot.notePlaceholder")}
+                  disabled={submitting}
+                />
+              </td>
+            </tr>,
+          );
+        });
+      }
 
       if (hasChildren && isExpanded) {
         rows.push(...renderRows(node.children, depth + 1));
@@ -598,7 +782,7 @@ function SnapshotEntryTreeTable({
                   {t("finance.snapshot.node")}
                 </th>
                 <th className="w-20 px-4 py-2 text-center">
-                  {t("finance.snapshot.originalCurrency")}
+                  {t("finance.snapshot.asset")}
                 </th>
                 <th className="min-w-[10rem] px-4 py-2">
                   {t("finance.snapshot.originalAmount")}
@@ -692,6 +876,13 @@ function AssetSummaryPanel({
   const totalValue = canShowTotal
     ? convertedRows.reduce((sum, row) => sum + (row.convertedValue ?? 0), 0)
     : null;
+  const rowsWithShare = convertedRows.map((row) => ({
+    ...row,
+    share:
+      totalValue !== null && totalValue !== 0 && row.convertedValue !== null
+        ? formatSharePercentage(row.convertedValue / totalValue)
+        : "",
+  }));
 
   return (
     <div className="rounded-lg border border-base-300 bg-base-100">
@@ -715,10 +906,11 @@ function AssetSummaryPanel({
               <th className="text-right">
                 {t("finance.metrics.convertTo", { currency: primaryCurrency })}
               </th>
+              <th className="text-right">{t("finance.metrics.share")}</th>
             </tr>
           </thead>
           <tbody>
-            {convertedRows.map((row) => (
+            {rowsWithShare.map((row) => (
               <tr key={row.currency}>
                 <td className="font-medium">{row.currency}</td>
                 <td className="text-right tabular-nums">{row.amount}</td>
@@ -741,6 +933,9 @@ function AssetSummaryPanel({
                   ) : (
                     <span className="text-base-content/40">-</span>
                   )}
+                </td>
+                <td className="text-right tabular-nums">
+                  {row.share || <span className="text-base-content/40">-</span>}
                 </td>
               </tr>
             ))}
@@ -799,15 +994,15 @@ export function SnapshotDetail({
     [snapshot.exchange_rates],
   );
 
-  const [expandedIds, setExpandedIds] = useState<Set<UUID>>(new Set());
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
 
   useEffect(() => {
-    const expandableIds = new Set<UUID>();
+    const expandableIds = new Set<string>();
     collectExpandableSnapshotNodeIds(displayTree, expandableIds);
     setExpandedIds(expandableIds);
   }, [displayTree]);
 
-  const toggleNode = (nodeId: UUID) => {
+  const toggleNode = (nodeId: string) => {
     setExpandedIds((current) => {
       const next = new Set(current);
       if (next.has(nodeId)) {
@@ -852,7 +1047,7 @@ export function SnapshotDetail({
                   {t("finance.snapshot.node")}
                 </th>
                 <th className="w-20 px-4 py-2 text-center">
-                  {t("finance.snapshot.originalCurrency")}
+                  {t("finance.snapshot.asset")}
                 </th>
                 <th className="min-w-[10rem] px-4 py-2">
                   {t("finance.snapshot.originalAmount")}
@@ -867,6 +1062,8 @@ export function SnapshotDetail({
               {visibleNodes.map((node) => {
                 const hasChildren = node.children.length > 0;
                 const isExpanded = expandedIds.has(node.id);
+                const hasNodeLabel = node.name.trim().length > 0;
+                const isAggregateRow = hasChildren || node.isAutoGenerated;
                 const originalAmount = parseDisplayAmount(node.amount);
                 const convertedAmount = parseDisplayAmount(node.amountConverted);
                 const originalAmountClass =
@@ -883,7 +1080,15 @@ export function SnapshotDetail({
                       : "text-base-content";
 
                 return (
-                  <tr key={node.id} className="border-base-200">
+                  <tr
+                    key={node.id}
+                    className={[
+                      "border-base-200",
+                      isAggregateRow
+                        ? "border-l-4 border-l-base-content/30 bg-base-200/60"
+                        : "border-l-4 border-l-transparent",
+                    ].join(" ")}
+                  >
                     <td className="align-top">
                       <div
                         className="flex items-start gap-2"
@@ -901,13 +1106,17 @@ export function SnapshotDetail({
                             ariaExpanded={isExpanded}
                             onClick={() => toggleNode(node.id)}
                           />
-                        ) : (
+                        ) : hasNodeLabel ? (
                           <span className="mt-1 inline-flex h-5 w-5 flex-shrink-0 items-center justify-center text-base-content/30">
                             •
                           </span>
+                        ) : (
+                          <span className="inline-flex h-5 w-5 flex-shrink-0" />
                         )}
                         <div className="min-w-0 space-y-1">
-                          <span className="font-medium text-base-content">{node.name}</span>
+                          {hasNodeLabel ? (
+                            <span className="font-medium text-base-content">{node.name}</span>
+                          ) : null}
                         </div>
                       </div>
                     </td>
@@ -920,7 +1129,7 @@ export function SnapshotDetail({
                       </span>
                     </td>
                     <td className="align-top">
-                      {usesConvertedAggregation ? (
+                      {usesConvertedAggregation && node.amountConverted ? (
                         <span className={`tabular-nums ${convertedAmountClass}`}>
                           {formatMoney(node.amountConverted, snapshot.primary_currency, assets)}
                         </span>
@@ -965,7 +1174,7 @@ export function SnapshotDetail({
 type SnapshotEntry = NonNullable<FinanceSnapshot["entries"]>[number];
 
 type SnapshotDisplayNode = {
-  id: UUID;
+  id: string;
   name: string;
   depth: number;
   amount: string;
@@ -983,36 +1192,76 @@ function buildSnapshotDisplayTree(
   primaryCurrency: string,
   assets: FinanceAsset[],
 ): SnapshotDisplayNode[] {
-  const entryByNodeId = new Map<UUID, SnapshotEntry>();
+  const manualEntriesByNodeId = new Map<UUID, SnapshotEntry[]>();
+  const rollupEntriesByNodeId = new Map<UUID, SnapshotEntry[]>();
   entries.forEach((entry) => {
-    entryByNodeId.set(entry.node_id, entry);
+    const target = entry.is_auto_generated ? rollupEntriesByNodeId : manualEntriesByNodeId;
+    target.set(entry.node_id, [...(target.get(entry.node_id) ?? []), entry]);
   });
-  const usedNodeIds = new Set<UUID>();
+  const usedEntryIds = new Set<string>();
 
   const buildNodes = (nodes: TreeNodeWithChildren[], depth: number): SnapshotDisplayNode[] =>
     nodes
       .map((node) => {
-        const children = buildNodes(node.children, depth + 1);
-        const entry = entryByNodeId.get(node.id);
-        if (entry) {
-          usedNodeIds.add(node.id);
+        const childNodes = buildNodes(node.children, depth + 1);
+        const manualEntries = manualEntriesByNodeId.get(node.id) ?? [];
+        const rollupEntries = rollupEntriesByNodeId.get(node.id) ?? [];
+        const inlineSingleHolding = !childNodes.length && manualEntries.length === 1;
+        const sortedManualEntries = [...manualEntries].sort((left, right) =>
+          left.currency_code.localeCompare(right.currency_code),
+        );
+        const sortedRollupEntries = [...rollupEntries].sort((left, right) =>
+          left.currency_code.localeCompare(right.currency_code),
+        );
+        const holdingChildren = sortedManualEntries
+          .filter(() => !inlineSingleHolding)
+          .map((entry) => {
+            usedEntryIds.add(entry.id);
+            return {
+              id: `${node.id}:${entry.id}`,
+              name: "",
+              depth: depth + 1,
+              amount: entry.amount,
+              amountConverted: entry.amount_converted,
+              currencyCode: entry.currency_code,
+              note: entry.note ?? null,
+              isAutoGenerated: false,
+              children: [],
+            } satisfies SnapshotDisplayNode;
+          });
+        if (inlineSingleHolding) {
+          usedEntryIds.add(manualEntries[0].id);
         }
-        if (!entry && !children.length) {
+        const children = [...holdingChildren, ...childNodes];
+        if (!rollupEntries.length && !manualEntries.length && !children.length) {
           return null;
         }
-        const amountConverted =
-          entry?.amount_converted ??
-          (useConvertedRollups ? sumSnapshotNodeAmounts(children, primaryCurrency, assets) : "");
-        const currencyCode = entry?.currency_code ?? node.currency_code ?? primaryCurrency;
+        rollupEntries.forEach((entry) => usedEntryIds.add(entry.id));
+        const inlineEntry = inlineSingleHolding ? manualEntries[0] : null;
+        const amountConverted = useConvertedRollups
+          ? (rollupEntries[0]?.amount_converted ??
+            inlineEntry?.amount_converted ??
+            sumSnapshotNodeAmounts(children, primaryCurrency, assets))
+          : "";
+        const amount = useConvertedRollups
+          ? formatAmountForAsset(amountConverted, primaryCurrency, assets)
+          : (sortedRollupEntries.length ? sortedRollupEntries : inlineEntry ? [inlineEntry] : [])
+              .map((entry) => `${entry.amount} ${entry.currency_code}`)
+              .join(", ");
+        const currencyCode = useConvertedRollups
+          ? primaryCurrency
+          : rollupEntries.length === 1 || inlineEntry
+            ? (rollupEntries[0] ?? inlineEntry)?.currency_code ?? ""
+            : "";
         return {
           id: node.id,
           name: node.name,
           depth,
-          amount: entry?.amount ?? formatAmountForAsset(amountConverted, currencyCode, assets),
+          amount,
           amountConverted,
           currencyCode,
-          note: entry?.note ?? null,
-          isAutoGenerated: entry?.is_auto_generated ?? false,
+          note: inlineEntry?.note ?? null,
+          isAutoGenerated: rollupEntries.length > 0,
           children,
         } satisfies SnapshotDisplayNode;
       })
@@ -1020,11 +1269,11 @@ function buildSnapshotDisplayTree(
 
   const roots = buildNodes(treeNodes, 0);
   const orphanEntries = entries
-    .filter((entry) => !usedNodeIds.has(entry.node_id))
+    .filter((entry) => !usedEntryIds.has(entry.id))
     .map(
       (entry) =>
         ({
-          id: entry.node_id,
+          id: entry.id,
           name: entry.node_name ?? entry.node_id,
           depth: 0,
           amount: entry.amount,
@@ -1081,39 +1330,6 @@ function buildSummaryRowsFromAmountsByCurrency(
       numericAmount: 0,
     },
   ];
-}
-
-function buildNativeCurrencySummaryRows(
-  nodes: TreeNodeWithChildren[],
-  amounts: SnapshotAmountState,
-  primaryCurrency: string,
-  assets: FinanceAsset[],
-): AssetSummaryRow[] {
-  const totals = new Map<string, number>();
-  const visit = (node: TreeNodeWithChildren) => {
-    if (!node.children.length) {
-      const amount = amounts[node.id]?.trim() ?? "";
-      if (!amount) {
-        return;
-      }
-      const parsed = parseDisplayAmount(amount);
-      if (!Number.isFinite(parsed)) {
-        return;
-      }
-      const currency = (node.currency_code || primaryCurrency).toUpperCase();
-      totals.set(currency, (totals.get(currency) ?? 0) + parsed);
-      return;
-    }
-    node.children.forEach(visit);
-  };
-  nodes.forEach(visit);
-  return Array.from(totals.entries())
-    .sort(([left], [right]) => left.localeCompare(right))
-    .map(([currency, value]) => ({
-      currency,
-      amount: formatNumberForAsset(value, currency, assets),
-      numericAmount: value,
-    }));
 }
 
 function getSummaryAggregationMode(summary?: Record<string, unknown> | null): string {
@@ -1202,6 +1418,13 @@ function rateInfoTooltip(rateInfo: RateInfo, assets: FinanceAsset[]): string {
   return [primaryLine, ...sourceLines, pathLine].filter(Boolean).join("\n");
 }
 
+function formatSharePercentage(value: number): string {
+  if (!Number.isFinite(value)) {
+    return "";
+  }
+  return `${(value * 100).toFixed(2)}%`;
+}
+
 function rateSnapshotTooltip(snapshot: FinanceRateSnapshot, assets: FinanceAsset[]): string {
   const lines = (snapshot.entries ?? []).map((entry) => {
     const baseAmount = formatAmountForAsset("1", entry.base_currency, assets);
@@ -1220,6 +1443,126 @@ function includeFinanceNodeIds(nodes: TreeNodeWithChildren[], target: Set<UUID>)
   });
 }
 
+function createHoldingId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `holding-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+function normalizeHoldingCurrency(currency: string): string {
+  return currency.trim().toUpperCase();
+}
+
+function nextExtraHoldingCurrency(
+  existingCurrencies: string[],
+  defaultCurrency: string,
+  assets: FinanceAsset[],
+): string {
+  const used = new Set(existingCurrencies.map(normalizeHoldingCurrency));
+  const normalizedDefault = normalizeHoldingCurrency(defaultCurrency);
+  const available = assets
+    .map((asset) => asset.code)
+    .find((assetCode) => {
+      const normalized = normalizeHoldingCurrency(assetCode);
+      return normalized !== normalizedDefault && !used.has(normalized);
+    });
+  return available ?? "";
+}
+
+function addExtraHoldingToNode(
+  current: SnapshotAmountState,
+  node: TreeNodeWithChildren,
+  primaryCurrency: string,
+  assets: FinanceAsset[],
+): SnapshotAmountState {
+  const existing = current[node.id] ?? [];
+  const currencyCode = nextExtraHoldingCurrency(
+    existing.map((holding) => holding.currencyCode),
+    node.currency_code || primaryCurrency,
+    assets,
+  );
+  return {
+    ...current,
+    [node.id]: [
+      ...existing,
+      {
+        id: createHoldingId(),
+        currencyCode,
+        amount: "",
+        note: "",
+      },
+    ],
+  };
+}
+
+function updateHoldingInNode(
+  current: SnapshotAmountState,
+  nodeId: UUID,
+  holdingId: string,
+  patch: { currencyCode?: string; amount?: string; note?: string },
+): SnapshotAmountState {
+  if (!holdingId) {
+    const created = {
+      id: createHoldingId(),
+      currencyCode: normalizeHoldingCurrency(patch.currencyCode ?? ""),
+      amount: patch.amount ?? "",
+      note: patch.note ?? "",
+    };
+    return {
+      ...current,
+      [nodeId]: [...(current[nodeId] ?? []), created],
+    };
+  }
+  return {
+    ...current,
+    [nodeId]: (current[nodeId] ?? []).map((holding) =>
+      holding.id === holdingId
+        ? {
+            ...holding,
+            ...patch,
+            currencyCode:
+              patch.currencyCode !== undefined
+                ? normalizeHoldingCurrency(patch.currencyCode)
+                : holding.currencyCode,
+          }
+        : holding,
+    ),
+  };
+}
+
+function removeHoldingFromNode(
+  current: SnapshotAmountState,
+  nodeId: UUID,
+  holdingId: string,
+): SnapshotAmountState {
+  const remaining = (current[nodeId] ?? []).filter((holding) => holding.id !== holdingId);
+  if (remaining.length) {
+    return { ...current, [nodeId]: remaining };
+  }
+  const next = { ...current };
+  delete next[nodeId];
+  return next;
+}
+
+function getRequiredHoldingRateCurrencies(
+  amounts: SnapshotAmountState,
+  settlementCurrency: string,
+): string[] {
+  const settlement = normalizeHoldingCurrency(settlementCurrency);
+  const currencies = new Set<string>();
+  Object.values(amounts).forEach((holdings) => {
+    holdings.forEach((holding) => {
+      const amount = holding.amount.trim();
+      const currency = normalizeHoldingCurrency(holding.currencyCode);
+      if (amount && currency && currency !== settlement) {
+        currencies.add(currency);
+      }
+    });
+  });
+  return Array.from(currencies).sort((left, right) => left.localeCompare(right));
+}
+
 function buildAggregatedSnapshotAmounts(
   nodes: TreeNodeWithChildren[],
   amounts: SnapshotAmountState,
@@ -1230,21 +1573,21 @@ function buildAggregatedSnapshotAmounts(
   const result: Record<UUID, string> = {};
 
   const visit = (node: TreeNodeWithChildren): string => {
-    if (!node.children.length) {
-      const convertedAmount = convertSnapshotAmount(
-        amounts[node.id] ?? "",
-        node.currency_code || primaryCurrency,
-        primaryCurrency,
-        conversionRates,
-        assets,
-      );
-      if (convertedAmount) {
-        result[node.id] = convertedAmount;
-      }
-      return convertedAmount;
+    const convertedAmounts = (amounts[node.id] ?? [])
+      .map((holding) =>
+        convertSnapshotAmount(
+          holding.amount,
+          holding.currencyCode || node.currency_code || primaryCurrency,
+          primaryCurrency,
+          conversionRates,
+          assets,
+        ),
+      )
+      .filter(Boolean);
+    if (node.children.length) {
+      convertedAmounts.push(...node.children.map(visit));
     }
-
-    const total = sumAmountStrings(node.children.map(visit), primaryCurrency, assets);
+    const total = sumAmountStrings(convertedAmounts, primaryCurrency, assets);
     if (total) {
       result[node.id] = total;
     }
@@ -1264,27 +1607,29 @@ function buildNativeSnapshotAmounts(
   const result: Record<UUID, string> = {};
 
   const visit = (node: TreeNodeWithChildren): Map<string, number> => {
-    if (!node.children.length) {
-      const amount = amounts[node.id]?.trim() ?? "";
-      const parsed = Number(amount);
-      if (!amount || !Number.isFinite(parsed)) {
-        return new Map();
-      }
-      const currency = (node.currency_code || primaryCurrency).toUpperCase();
-      result[node.id] = formatAmountForAsset(amount, currency, assets);
-      return new Map([[currency, parsed]]);
-    }
-
     const totals = new Map<string, number>();
-    node.children.forEach((child) => {
-      visit(child).forEach((value, currency) => {
-        totals.set(currency, (totals.get(currency) ?? 0) + value);
-      });
+    (amounts[node.id] ?? []).forEach((holding) => {
+      const amount = holding.amount.trim() ?? "";
+      const parsed = parseDisplayAmount(amount);
+      if (!amount || !Number.isFinite(parsed)) {
+        return;
+      }
+      const currency = normalizeHoldingCurrency(
+        holding.currencyCode || node.currency_code || primaryCurrency,
+      );
+      totals.set(currency, (totals.get(currency) ?? 0) + parsed);
     });
+    if (node.children.length) {
+      node.children.forEach((child) => {
+        visit(child).forEach((value, currency) => {
+          totals.set(currency, (totals.get(currency) ?? 0) + value);
+        });
+      });
+    }
     if (totals.size) {
       result[node.id] = Array.from(totals.entries())
         .sort(([left], [right]) => left.localeCompare(right))
-        .map(([currency, value]) => formatNumberForAsset(value, currency, assets))
+        .map(([currency, value]) => `${formatNumberForAsset(value, currency, assets)} ${currency}`)
         .join(", ");
     }
     return totals;
@@ -1292,6 +1637,37 @@ function buildNativeSnapshotAmounts(
 
   nodes.forEach(visit);
   return result;
+}
+
+function buildNativeCurrencySummaryRows(
+  nodes: TreeNodeWithChildren[],
+  amounts: SnapshotAmountState,
+  primaryCurrency: string,
+  assets: FinanceAsset[],
+): AssetSummaryRow[] {
+  const totals = new Map<string, number>();
+  const visit = (node: TreeNodeWithChildren) => {
+    (amounts[node.id] ?? []).forEach((holding) => {
+      const amount = holding.amount.trim() ?? "";
+      const parsed = parseDisplayAmount(amount);
+      if (!amount || !Number.isFinite(parsed)) {
+        return;
+      }
+      const currency = normalizeHoldingCurrency(
+        holding.currencyCode || node.currency_code || primaryCurrency,
+      );
+      totals.set(currency, (totals.get(currency) ?? 0) + parsed);
+    });
+    node.children.forEach(visit);
+  };
+  nodes.forEach(visit);
+  return Array.from(totals.entries())
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([currency, value]) => ({
+      currency,
+      amount: formatNumberForAsset(value, currency, assets),
+      numericAmount: value,
+    }));
 }
 
 function buildConversionRateMap(
@@ -1395,7 +1771,7 @@ function amountInputPattern(decimalPlaces: number): string {
 
 function collectExpandableSnapshotNodeIds(
   nodes: SnapshotDisplayNode[],
-  target: Set<UUID>,
+  target: Set<string>,
 ) {
   nodes.forEach((node) => {
     if (node.children.length) {
@@ -1407,7 +1783,7 @@ function collectExpandableSnapshotNodeIds(
 
 function flattenVisibleSnapshotNodes(
   nodes: SnapshotDisplayNode[],
-  expandedIds: Set<UUID>,
+  expandedIds: Set<string>,
 ): SnapshotDisplayNode[] {
   const result: SnapshotDisplayNode[] = [];
   const walk = (items: SnapshotDisplayNode[]) => {

--- a/web/src/features/finance/utils.ts
+++ b/web/src/features/finance/utils.ts
@@ -31,8 +31,14 @@ export type TreeNodeWithChildren = FinanceTreeNode & {
   children: TreeNodeWithChildren[];
 };
 
-export type SnapshotAmountState = Record<UUID, string>;
-export type SnapshotNoteState = Record<UUID, string>;
+export type SnapshotHoldingState = {
+  id: string;
+  currencyCode: string;
+  amount: string;
+  note: string;
+};
+
+export type SnapshotAmountState = Record<UUID, SnapshotHoldingState[]>;
 
 export type RateSnapshotFormMode = "create" | "edit";
 

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -1408,6 +1408,7 @@
       "summary": "Summary",
       "details": "Details",
       "convertTo": "Convert to {{currency}}",
+      "share": "Share",
       "totalValue": "Total value"
     },
     "assets": {
@@ -1472,8 +1473,11 @@
       "periodStart": "Period start",
       "periodEnd": "Period end",
       "settlementCurrency": "Settlement asset",
-      "tableTitle": "Record finance entries",
+      "tableTitle": "Record account holdings",
       "node": "Node",
+      "asset": "Asset",
+      "addHolding": "Add holding",
+      "removeHolding": "Remove holding",
       "amount": "Amount",
       "currency": "Currency",
       "originalCurrency": "Original currency",
@@ -1488,7 +1492,7 @@
       "deleteTitle": "Delete snapshot",
       "deleteMessage": "Delete {{name}}?",
       "deleteConfirm": "Delete snapshot",
-      "noEntryNodes": "Add at least one leaf node before saving a snapshot.",
+      "noEntryNodes": "Add at least one finance node before saving a snapshot.",
       "auto": "Auto",
       "manual": "Manual",
       "source": "Source"
@@ -1547,6 +1551,7 @@
       "snapshotUpdated": "Finance snapshot updated",
       "snapshotDeleted": "Finance snapshot deleted",
       "noEntries": "Enter at least one amount before saving.",
+      "holdingAssetRequired": "Select or create an asset for every holding with an amount.",
       "rateSnapshotMissingRates": "The selected rate snapshot is missing: {{currencies}}.",
       "rateSnapshotRatesRequired": "Enter a positive rate for every required currency."
     }

--- a/web/src/locales/zh/common.json
+++ b/web/src/locales/zh/common.json
@@ -1408,6 +1408,7 @@
       "summary": "汇总",
       "details": "详情",
       "convertTo": "换算为 {{currency}}",
+      "share": "占比",
       "totalValue": "总值"
     },
     "assets": {
@@ -1472,8 +1473,11 @@
       "periodStart": "周期开始",
       "periodEnd": "周期结束",
       "settlementCurrency": "结算资产",
-      "tableTitle": "录入财务条目",
+      "tableTitle": "录入账户持仓",
       "node": "节点",
+      "asset": "资产",
+      "addHolding": "添加持仓",
+      "removeHolding": "移除持仓",
       "amount": "金额",
       "currency": "币种",
       "originalCurrency": "原币种",
@@ -1488,7 +1492,7 @@
       "deleteTitle": "删除快照",
       "deleteMessage": "删除 {{name}}？",
       "deleteConfirm": "删除快照",
-      "noEntryNodes": "保存快照前，请先添加至少一个叶子节点。",
+      "noEntryNodes": "保存快照前，请先添加至少一个财务节点。",
       "auto": "自动",
       "manual": "手动",
       "source": "来源"
@@ -1547,6 +1551,7 @@
       "snapshotUpdated": "财务快照已更新",
       "snapshotDeleted": "财务快照已删除",
       "noEntries": "保存前请至少填写一个金额。",
+      "holdingAssetRequired": "请为每条已填写金额的持仓选择或创建资产。",
       "rateSnapshotMissingRates": "当前汇率快照缺少这些币种：{{currencies}}。",
       "rateSnapshotRatesRequired": "请为每个必需币种填写正数汇率。"
     }


### PR DESCRIPTION
## 变更概述

- 支持在同一个 finance account node 下录入多条不同资产持仓，并将唯一约束调整为 snapshot + node + asset + auto flag。
- 快照编辑页改为按持仓行录入：节点默认资产作为主行，`+` 添加扩展持仓行，扩展行支持删除。
- 用户在资产选择框输入不存在的资产时可自动创建资产，默认精度沿用资产创建逻辑的 2 位精度。
- 父节点保持自动汇总展示，不允许直接编辑汇总值，但支持通过 `+` 添加父节点自身持仓。
- 浏览模式区分原始录入行与自动汇总行，避免单资产叶子节点重复显示，并在资产汇总中增加占比列。
- 增加迁移以放宽 finance snapshot entries 唯一索引，并清理旧实例中残留的 finance tree legacy columns。

## 需求关联

Closes #182

## 验证

- `npm run build`
- `bash ./scripts/doctor.sh`
