### PR TITLE
feat: Complete tag category usage flow

### DIFF
--- a/src/lifeos_cli/db/services/tags.py
+++ b/src/lifeos_cli/db/services/tags.py
@@ -2,13 +2,22 @@
 
 from __future__ import annotations
 
+from typing import Any
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from lifeos_cli.db.models.area import Area
+from lifeos_cli.db.models.event import Event
+from lifeos_cli.db.models.note import Note
+from lifeos_cli.db.models.person import Person
 from lifeos_cli.db.models.person_association import person_associations
 from lifeos_cli.db.models.tag import Tag
+from lifeos_cli.db.models.tag_association import tag_associations
+from lifeos_cli.db.models.task import Task
+from lifeos_cli.db.models.timelog import Timelog
+from lifeos_cli.db.models.vision import Vision
 from lifeos_cli.db.services.batching import BatchDeleteResult, batch_delete_records
 from lifeos_cli.db.services.collection_utils import deduplicate_preserving_order
 from lifeos_cli.db.services.entity_people import load_people_for_entities, sync_entity_people
@@ -20,6 +29,15 @@ from lifeos_cli.db.services.model_utils import (
 from lifeos_cli.db.services.read_models import TagView, build_tag_view
 
 VALID_TAG_ENTITY_TYPES = {"note", "person", "task", "vision", "area", "event", "timelog"}
+TAGGED_ENTITY_MODELS = {
+    "area": Area,
+    "event": Event,
+    "note": Note,
+    "person": Person,
+    "task": Task,
+    "timelog": Timelog,
+    "vision": Vision,
+}
 
 
 class TagNotFoundError(LookupError):
@@ -53,6 +71,12 @@ def validate_tag_entity_type(entity_type: str) -> str:
     return normalized
 
 
+def normalize_tag_category(category: str | None) -> str:
+    """Normalize a tag category."""
+    normalized = (category or "").strip().lower()
+    return normalized or "general"
+
+
 async def create_tag(
     session: AsyncSession,
     *,
@@ -66,7 +90,7 @@ async def create_tag(
     """Create a new tag."""
     normalized_name = normalize_tag_name(name)
     normalized_entity_type = validate_tag_entity_type(entity_type)
-    normalized_category = category.strip().lower() or "general"
+    normalized_category = normalize_tag_category(category)
     existing = await session.execute(
         select(Tag).where(
             Tag.name == normalized_name,
@@ -145,7 +169,7 @@ async def list_tags(
     if entity_type is not None:
         stmt = stmt.where(Tag.entity_type == validate_tag_entity_type(entity_type))
     if category is not None:
-        stmt = stmt.where(Tag.category == category.strip().lower())
+        stmt = stmt.where(Tag.category == normalize_tag_category(category))
     if person_id is not None:
         stmt = stmt.join(
             person_associations,
@@ -155,6 +179,24 @@ async def list_tags(
     stmt = stmt.order_by(Tag.name.asc(), Tag.id.asc()).offset(offset).limit(limit)
     tags = list((await session.execute(stmt)).scalars())
     return await _build_tag_views(session, tags)
+
+
+async def list_tag_categories(
+    session: AsyncSession,
+    *,
+    entity_type: str | None = None,
+    include_deleted: bool = False,
+) -> list[str]:
+    """List normalized categories present on tags."""
+    stmt = select(Tag.category).distinct()
+    if not include_deleted:
+        stmt = stmt.where(Tag.deleted_at.is_(None))
+    if entity_type is not None:
+        stmt = stmt.where(Tag.entity_type == validate_tag_entity_type(entity_type))
+    rows = (await session.execute(stmt)).scalars()
+    categories = {normalize_tag_category(category) for category in rows}
+    categories.add("general")
+    return sorted(categories)
 
 
 async def update_tag(
@@ -182,7 +224,7 @@ async def update_tag(
         raise TagNotFoundError(f"Tag {tag_id} was not found")
     next_name = normalize_tag_name(name) if name is not None else tag.name
     next_entity_type = validate_tag_entity_type(entity_type) if entity_type else tag.entity_type
-    next_category = category.strip().lower() if category is not None else tag.category
+    next_category = normalize_tag_category(category) if category is not None else tag.category
     conflict = await session.execute(
         select(Tag.id).where(
             Tag.name == next_name,
@@ -218,6 +260,132 @@ async def update_tag(
     await session.flush()
     await session.refresh(tag)
     return await _build_tag_view(session, tag)
+
+
+async def rename_tag_category(
+    session: AsyncSession,
+    *,
+    entity_type: str,
+    category: str,
+    new_category: str,
+) -> list[TagView]:
+    """Move all active tags in one category to another category."""
+    normalized_entity_type = validate_tag_entity_type(entity_type)
+    normalized_category = normalize_tag_category(category)
+    normalized_new_category = normalize_tag_category(new_category)
+    if normalized_category == normalized_new_category:
+        return []
+
+    stmt = select(Tag).where(
+        Tag.entity_type == normalized_entity_type,
+        Tag.category == normalized_category,
+        Tag.deleted_at.is_(None),
+    )
+    tags = list((await session.execute(stmt)).scalars())
+    conflict_names: list[str] = []
+    for tag in tags:
+        conflict = await session.execute(
+            select(Tag.id).where(
+                Tag.name == tag.name,
+                Tag.entity_type == normalized_entity_type,
+                Tag.category == normalized_new_category,
+                Tag.id != tag.id,
+                Tag.deleted_at.is_(None),
+            )
+        )
+        if conflict.scalar_one_or_none() is not None:
+            conflict_names.append(tag.name)
+    if conflict_names:
+        preview = ", ".join(sorted(conflict_names)[:3])
+        suffix = "" if len(conflict_names) <= 3 else f", and {len(conflict_names) - 3} more"
+        raise TagAlreadyExistsError(
+            f"Cannot rename category because matching tags already exist: {preview}{suffix}"
+        )
+    for tag in tags:
+        tag.category = normalized_new_category
+    await session.flush()
+    return await _build_tag_views(session, tags)
+
+
+async def bulk_update_tag_categories(
+    session: AsyncSession,
+    *,
+    tag_ids: list[UUID],
+    category: str,
+) -> tuple[list[TagView], list[UUID], list[str]]:
+    """Move selected active tags to another category with per-tag errors."""
+    normalized_category = normalize_tag_category(category)
+    updated: list[Tag] = []
+    failed_ids: list[UUID] = []
+    errors: list[str] = []
+
+    for tag_id in deduplicate_preserving_order(tag_ids):
+        tag = await load_model_by_id(
+            session,
+            model_cls=Tag,
+            model_id=tag_id,
+            include_deleted=False,
+        )
+        if tag is None:
+            failed_ids.append(tag_id)
+            errors.append(f"Tag {tag_id} was not found")
+            continue
+        conflict = await session.execute(
+            select(Tag.id).where(
+                Tag.name == tag.name,
+                Tag.entity_type == tag.entity_type,
+                Tag.category == normalized_category,
+                Tag.id != tag.id,
+                Tag.deleted_at.is_(None),
+            )
+        )
+        if conflict.scalar_one_or_none() is not None:
+            failed_ids.append(tag_id)
+            errors.append("Tag with the same name, entity type, and category already exists")
+            continue
+        tag.category = normalized_category
+        updated.append(tag)
+
+    await session.flush()
+    return await _build_tag_views(session, updated), failed_ids, errors
+
+
+async def count_tag_usage_by_entity_type(
+    session: AsyncSession,
+    *,
+    entity_type: str,
+) -> dict[UUID, int]:
+    """Count active tagged records by tag for one entity type."""
+    normalized_entity_type = validate_tag_entity_type(entity_type)
+    entity_model: Any = TAGGED_ENTITY_MODELS[normalized_entity_type]
+    stmt = (
+        select(tag_associations.c.tag_id, func.count(func.distinct(entity_model.id)))
+        .join(Tag, Tag.id == tag_associations.c.tag_id)
+        .join(entity_model, entity_model.id == tag_associations.c.entity_id)
+        .where(
+            tag_associations.c.entity_type == normalized_entity_type,
+            Tag.entity_type == normalized_entity_type,
+            Tag.deleted_at.is_(None),
+            entity_model.deleted_at.is_(None),
+        )
+        .group_by(tag_associations.c.tag_id)
+    )
+    rows = await session.execute(stmt)
+    return {tag_id: int(count) for tag_id, count in rows.all()}
+
+
+async def count_tag_usage(session: AsyncSession, *, tag_id: UUID) -> int:
+    """Count active tagged records for one tag."""
+    tag = await load_model_by_id(
+        session,
+        model_cls=Tag,
+        model_id=tag_id,
+        include_deleted=False,
+    )
+    if tag is None:
+        raise TagNotFoundError(f"Tag {tag_id} was not found")
+    usage_counts = await count_tag_usage_by_entity_type(session, entity_type=tag.entity_type)
+    return usage_counts.get(tag_id, 0)
 
 
 async def delete_tag(session: AsyncSession, *, tag_id: UUID) -> None:

--- a/src/lifeos_web/routers/stats.py
+++ b/src/lifeos_web/routers/stats.py
@@ -10,6 +10,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from lifeos_cli.db.services import tags as tag_services
 from lifeos_cli.db.services import timelog_stats
 from lifeos_web.deps import get_db_session
 from lifeos_web.schemas import ListResponse, Pagination
@@ -219,3 +220,27 @@ async def recompute_daily_areas(
     except timelog_stats.TimelogStatsValidationError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     return {"days_recomputed": len(rebuilt_dates)}
+
+
+@router.get("/tags/usage/{entity_type}")
+async def get_tag_usage_by_entity_type(
+    entity_type: str,
+    session: SessionDep,
+) -> dict[str, object]:
+    """Return active tagged-record counts for tags of one entity type."""
+    try:
+        normalized_entity_type = tag_services.validate_tag_entity_type(entity_type)
+        usage_counts = await tag_services.count_tag_usage_by_entity_type(
+            session,
+            entity_type=normalized_entity_type,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return {
+        "entity_type": normalized_entity_type,
+        "tag_stats": [
+            {"id": str(tag_id), "usage_count": count}
+            for tag_id, count in sorted(usage_counts.items(), key=lambda item: str(item[0]))
+        ],
+        "total_tags": len(usage_counts),
+    }

--- a/src/lifeos_web/routers/tags.py
+++ b/src/lifeos_web/routers/tags.py
@@ -12,11 +12,43 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from lifeos_cli.db.services import tags as tag_services
 from lifeos_cli.db.services.tags import VALID_TAG_ENTITY_TYPES
 from lifeos_web.deps import get_db_session
-from lifeos_web.schemas import ListResponse, Pagination, TagCreate, TagUpdate
+from lifeos_web.schemas import (
+    ListResponse,
+    Pagination,
+    TagBulkCategoryUpdate,
+    TagCategoryCreate,
+    TagCategoryUpdate,
+    TagCreate,
+    TagUpdate,
+)
 from lifeos_web.serialization import to_jsonable, to_jsonable_dict
 
 router = APIRouter(prefix="/tags", tags=["tags"])
 SessionDep = Annotated[AsyncSession, Depends(get_db_session)]
+
+DEFAULT_TAG_CATEGORIES: dict[str, tuple[str, ...]] = {
+    "note": ("general", "topic"),
+    "person": ("general", "location", "relation", "profession", "team"),
+}
+
+
+def _category_label(value: str) -> str:
+    """Return the fallback label for a category value."""
+    return value.replace("_", " ").title() if value else "General"
+
+
+def _category_option(value: str, entity_type: str | None) -> dict[str, object]:
+    normalized = tag_services.normalize_tag_category(value)
+    return {
+        "value": normalized,
+        "label": _category_label(normalized),
+        "entity_type": entity_type,
+    }
+
+
+def _normalize_category_value(payload: TagCategoryCreate | TagCategoryUpdate) -> str:
+    raw = getattr(payload, "value", None) or payload.label
+    return tag_services.normalize_tag_category(raw.replace(" ", "_"))
 
 
 @router.get("/", response_model=ListResponse)
@@ -59,10 +91,87 @@ async def list_tag_entity_types() -> list[str]:
 
 
 @router.get("/categories/")
-async def list_tag_categories(entity_type: str | None = None) -> list[dict[str, object]]:
-    """Return the default category option used by LifeOS tags."""
-    del entity_type
-    return [{"value": "general", "label": "General", "entity_type": None}]
+async def list_tag_categories(
+    session: SessionDep,
+    entity_type: str | None = None,
+) -> list[dict[str, object]]:
+    """Return built-in and persisted tag categories."""
+    try:
+        normalized_entity_type = (
+            tag_services.validate_tag_entity_type(entity_type) if entity_type else None
+        )
+        categories = set(
+            await tag_services.list_tag_categories(
+                session,
+                entity_type=normalized_entity_type,
+            )
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    categories.update(DEFAULT_TAG_CATEGORIES.get(normalized_entity_type or "", ("general",)))
+    return [_category_option(category, normalized_entity_type) for category in sorted(categories)]
+
+
+@router.post("/categories/")
+async def create_tag_category(
+    payload: TagCategoryCreate,
+    entity_type: str | None = None,
+) -> dict[str, object]:
+    """Return a normalized tag category option for the scoped entity type."""
+    try:
+        normalized_entity_type = (
+            tag_services.validate_tag_entity_type(entity_type) if entity_type else None
+        )
+        return _category_option(_normalize_category_value(payload), normalized_entity_type)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.patch("/categories/{category}")
+async def rename_tag_category(
+    category: str,
+    payload: TagCategoryUpdate,
+    session: SessionDep,
+    entity_type: str | None = None,
+) -> dict[str, object]:
+    """Rename a tag category by moving its active tags."""
+    if not entity_type:
+        raise HTTPException(status_code=400, detail="Tag category rename requires entity_type")
+    try:
+        normalized_entity_type = tag_services.validate_tag_entity_type(entity_type)
+        next_category = _normalize_category_value(payload)
+        await tag_services.rename_tag_category(
+            session,
+            entity_type=normalized_entity_type,
+            category=category,
+            new_category=next_category,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return _category_option(next_category, normalized_entity_type)
+
+
+@router.patch("/batch-update")
+async def bulk_update_tag_categories(
+    payload: TagBulkCategoryUpdate,
+    session: SessionDep,
+) -> dict[str, object]:
+    """Move selected tags to another category."""
+    try:
+        updated_tags, failed_ids, errors = await tag_services.bulk_update_tag_categories(
+            session,
+            tag_ids=payload.ids,
+            category=payload.category,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return {
+        "updated_count": len(updated_tags),
+        "failed_ids": [str(tag_id) for tag_id in failed_ids],
+        "errors": errors,
+        "updated_tags": [to_jsonable(tag) for tag in updated_tags],
+    }
 
 
 @router.post("/")
@@ -89,6 +198,23 @@ async def get_tag(tag_id: UUID, session: SessionDep) -> dict[str, object]:
     if tag is None:
         raise HTTPException(status_code=404, detail=f"Tag {tag_id} was not found")
     return to_jsonable_dict(tag)
+
+
+@router.get("/{tag_id}/usage")
+async def get_tag_usage(tag_id: UUID, session: SessionDep) -> dict[str, object]:
+    """Return active tagged-record count for one tag."""
+    tag = await tag_services.get_tag(session, tag_id=tag_id)
+    if tag is None:
+        raise HTTPException(status_code=404, detail=f"Tag {tag_id} was not found")
+    usage_count = await tag_services.count_tag_usage(session, tag_id=tag_id)
+    return {
+        "tag_id": str(tag.id),
+        "tag_name": tag.name,
+        "entity_type": tag.entity_type,
+        "category": tag.category,
+        "usage_by_entity_type": {tag.entity_type: usage_count},
+        "total_usage": usage_count,
+    }
 
 
 @router.patch("/{tag_id}")

--- a/src/lifeos_web/schemas.py
+++ b/src/lifeos_web/schemas.py
@@ -113,6 +113,26 @@ class TagUpdate(BaseModel):
     color: str | None = None
 
 
+class TagCategoryCreate(BaseModel):
+    """Payload for creating a tag category option from the Web UI."""
+
+    label: str
+    value: str | None = None
+
+
+class TagCategoryUpdate(BaseModel):
+    """Payload for renaming a tag category from the Web UI."""
+
+    label: str
+
+
+class TagBulkCategoryUpdate(BaseModel):
+    """Payload for moving existing tags to another category."""
+
+    ids: list[UUID] = Field(default_factory=list)
+    category: str
+
+
 class VisionCreate(BaseModel):
     """Payload for creating a vision from the Web UI."""
 

--- a/tests/test_tag_services.py
+++ b/tests/test_tag_services.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import asyncio
+
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from lifeos_cli.db.base import Base
+from lifeos_cli.db.services import people, tags
+
+
+async def _create_sqlite_session_factory() -> tuple[
+    AsyncEngine,
+    async_sessionmaker[AsyncSession],
+]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False, future=True)
+
+
+def test_count_person_tag_usage_counts_active_tagged_people() -> None:
+    async def run() -> None:
+        engine, session_factory = await _create_sqlite_session_factory()
+        try:
+            async with session_factory() as session:
+                tag = await tags.create_tag(
+                    session,
+                    name="Mentor",
+                    entity_type="person",
+                    category="relationship",
+                )
+                active_person = await people.create_person(
+                    session,
+                    name="Alice",
+                    tag_ids=[tag.id],
+                )
+                deleted_person = await people.create_person(
+                    session,
+                    name="Bob",
+                    tag_ids=[tag.id],
+                )
+                await people.delete_person(session, person_id=deleted_person.id)
+
+                counts = await tags.count_tag_usage_by_entity_type(
+                    session,
+                    entity_type="person",
+                )
+
+                assert counts == {tag.id: 1}
+                assert await tags.count_tag_usage(session, tag_id=tag.id) == 1
+                assert active_person.tags[0].id == tag.id
+        finally:
+            await engine.dispose()
+
+    asyncio.run(run())

--- a/tests/test_web_cli.py
+++ b/tests/test_web_cli.py
@@ -1167,6 +1167,223 @@ def test_web_tag_create_maps_to_lifeos_tag_service(
     assert response["name"] == "project"
 
 
+def test_web_tag_categories_include_builtin_and_existing_categories(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("fastapi")
+
+    from lifeos_web.routers import tags
+
+    async def fake_list_tag_categories(
+        _session: object,
+        *,
+        entity_type: str | None = None,
+    ) -> list[str]:
+        assert entity_type == "person"
+        return ["community", "relationship"]
+
+    monkeypatch.setattr(tags.tag_services, "list_tag_categories", fake_list_tag_categories)
+
+    response = asyncio.run(
+        tags.list_tag_categories(cast(AsyncSession, object()), entity_type="person")
+    )
+
+    values = [item["value"] for item in response]
+    assert values == [
+        "community",
+        "general",
+        "location",
+        "profession",
+        "relation",
+        "relationship",
+        "team",
+    ]
+
+
+def test_web_tag_category_create_returns_normalized_option() -> None:
+    pytest.importorskip("fastapi")
+
+    from lifeos_web.routers import tags
+    from lifeos_web.schemas import TagCategoryCreate
+
+    response = asyncio.run(
+        tags.create_tag_category(
+            TagCategoryCreate(label="Close Circle"),
+            entity_type="person",
+        )
+    )
+
+    assert response == {
+        "value": "close_circle",
+        "label": "Close Circle",
+        "entity_type": "person",
+    }
+
+
+def test_web_tag_category_rename_maps_to_lifeos_tag_service(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("fastapi")
+
+    from lifeos_web.routers import tags
+    from lifeos_web.schemas import TagCategoryUpdate
+
+    captured: dict[str, object] = {}
+
+    async def fake_rename_tag_category(_session: object, **kwargs: object) -> list[object]:
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(tags.tag_services, "rename_tag_category", fake_rename_tag_category)
+
+    response = asyncio.run(
+        tags.rename_tag_category(
+            "relationship",
+            TagCategoryUpdate(label="Close Circle"),
+            cast(AsyncSession, object()),
+            entity_type="person",
+        )
+    )
+
+    assert captured == {
+        "entity_type": "person",
+        "category": "relationship",
+        "new_category": "close_circle",
+    }
+    assert response["value"] == "close_circle"
+    assert response["entity_type"] == "person"
+
+
+def test_web_tag_bulk_category_update_returns_updated_tags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("fastapi")
+
+    from lifeos_web.routers import tags
+    from lifeos_web.schemas import TagBulkCategoryUpdate
+
+    tag_id = UUID("11111111-1111-1111-1111-111111111111")
+    missing_id = UUID("22222222-2222-2222-2222-222222222222")
+    updated_tag = TagView(
+        id=tag_id,
+        name="mentor",
+        entity_type="person",
+        category="relationship",
+        description=None,
+        color=None,
+        created_at=datetime(2026, 6, 1, 13, 0, tzinfo=timezone.utc),
+        updated_at=datetime(2026, 6, 1, 13, 0, tzinfo=timezone.utc),
+        deleted_at=None,
+        people=(),
+    )
+
+    async def fake_bulk_update_tag_categories(
+        _session: object,
+        *,
+        tag_ids: list[UUID],
+        category: str,
+    ) -> tuple[list[TagView], list[UUID], list[str]]:
+        assert tag_ids == [tag_id, missing_id]
+        assert category == "relationship"
+        return [updated_tag], [missing_id], [f"Tag {missing_id} was not found"]
+
+    monkeypatch.setattr(
+        tags.tag_services,
+        "bulk_update_tag_categories",
+        fake_bulk_update_tag_categories,
+    )
+
+    response = asyncio.run(
+        tags.bulk_update_tag_categories(
+            TagBulkCategoryUpdate(ids=[tag_id, missing_id], category="relationship"),
+            cast(AsyncSession, object()),
+        )
+    )
+
+    assert response["updated_count"] == 1
+    assert response["failed_ids"] == [str(missing_id)]
+    updated_tags = cast(list[dict[str, object]], response["updated_tags"])
+    assert updated_tags[0]["category"] == "relationship"
+
+
+def test_web_tag_usage_endpoint_returns_tagged_record_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("fastapi")
+
+    from lifeos_web.routers import tags
+
+    tag_id = UUID("11111111-1111-1111-1111-111111111111")
+    tag = TagView(
+        id=tag_id,
+        name="mentor",
+        entity_type="person",
+        category="relationship",
+        description=None,
+        color=None,
+        created_at=datetime(2026, 6, 1, 13, 0, tzinfo=timezone.utc),
+        updated_at=datetime(2026, 6, 1, 13, 0, tzinfo=timezone.utc),
+        deleted_at=None,
+        people=(),
+    )
+
+    async def fake_get_tag(_session: object, *, tag_id: UUID) -> TagView | None:
+        assert tag_id == UUID("11111111-1111-1111-1111-111111111111")
+        return tag
+
+    async def fake_count_tag_usage(_session: object, *, tag_id: UUID) -> int:
+        assert tag_id == UUID("11111111-1111-1111-1111-111111111111")
+        return 12
+
+    monkeypatch.setattr(tags.tag_services, "get_tag", fake_get_tag)
+    monkeypatch.setattr(tags.tag_services, "count_tag_usage", fake_count_tag_usage)
+
+    response = asyncio.run(tags.get_tag_usage(tag_id, cast(AsyncSession, object())))
+
+    assert response == {
+        "tag_id": str(tag_id),
+        "tag_name": "mentor",
+        "entity_type": "person",
+        "category": "relationship",
+        "usage_by_entity_type": {"person": 12},
+        "total_usage": 12,
+    }
+
+
+def test_web_stats_tag_usage_endpoint_returns_counts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("fastapi")
+
+    from lifeos_web.routers import stats
+
+    tag_id = UUID("11111111-1111-1111-1111-111111111111")
+
+    async def fake_count_tag_usage_by_entity_type(
+        _session: object,
+        *,
+        entity_type: str,
+    ) -> dict[UUID, int]:
+        assert entity_type == "person"
+        return {tag_id: 12}
+
+    monkeypatch.setattr(
+        stats.tag_services,
+        "count_tag_usage_by_entity_type",
+        fake_count_tag_usage_by_entity_type,
+    )
+
+    response = asyncio.run(
+        stats.get_tag_usage_by_entity_type("person", cast(AsyncSession, object()))
+    )
+
+    assert response == {
+        "entity_type": "person",
+        "tag_stats": [{"id": str(tag_id), "usage_count": 12}],
+        "total_tags": 1,
+    }
+
+
 def test_web_note_create_maps_selector_associations_to_lifeos_note_service(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/web/src/components/TimeEntryModal.tsx
+++ b/web/src/components/TimeEntryModal.tsx
@@ -70,8 +70,6 @@ const TimeEntryModal = ({
     [modalStateRaw],
   );
 
-  // Removed unused local edited flag
-
   const toastRaw = useToast();
 
   // Memoize toast object to prevent unnecessary re-renders

--- a/web/src/features/tags/controller/useTagManagerController.ts
+++ b/web/src/features/tags/controller/useTagManagerController.ts
@@ -627,7 +627,7 @@ export function useTagManagerController({
   const createCategoryMutation = useMutation({
     mutationFn: (label: string) =>
       tagsApi.createCategory({ label }, categoryQueryScope),
-    onSuccess: async (createdCategory) => {
+    onSuccess: (createdCategory) => {
       queryClient.setQueryData<TagCategoryOption[]>(
         tagsKeys.categories(categoryQueryScope),
         (prev) => {
@@ -638,27 +638,23 @@ export function useTagManagerController({
           return next;
         },
       );
-      await refreshTagCaches(
-        "Failed to refresh tag caches after category create",
-        {
-          includeEntityTypes: true,
-          relatedEntityType: normalizedEntityTypeScope,
-        },
-      );
     },
   });
 
   const renameCategoryMutation = useMutation({
     mutationFn: ({ value, label }: { value: string; label: string }) =>
       tagsApi.renameCategory(value, { label }, categoryQueryScope),
-    onSuccess: async (updatedCategory) => {
+    onSuccess: async (updatedCategory, variables) => {
       queryClient.setQueryData<TagCategoryOption[]>(
         tagsKeys.categories(categoryQueryScope),
         (prev) => {
-          const next = Array.isArray(prev) ? [...prev] : [];
-          return next.map((item) =>
-            item.value === updatedCategory.value ? updatedCategory : item,
-          );
+          const next = Array.isArray(prev)
+            ? prev.filter((item) => item.value !== variables.value)
+            : [];
+          if (!next.some((item) => item.value === updatedCategory.value)) {
+            next.push(updatedCategory);
+          }
+          return next;
         },
       );
       await refreshTagCaches(

--- a/web/src/layouts/AppShell.tsx
+++ b/web/src/layouts/AppShell.tsx
@@ -1,12 +1,11 @@
 import { useEffect, useState } from "react";
-import { Link, useLocation, useRouter } from "@tanstack/react-router";
+import { Link, useLocation } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
 import { PageHeaderProvider } from "@/contexts/PageHeaderProvider";
 import { AutoPageHeader } from "@/components/PageHeader";
 import { useModuleConfig } from "@/hooks/useModuleConfig";
 import { useVisibleModules } from "@/hooks/queries/useVisibleModules";
 import { usePageHeader } from "@/contexts/PageHeaderContext";
-import { logger } from "@/utils/core";
 import ActionButton from "@/components/ActionButton";
 import { Icon } from "@/components/icons";
 import type { IconName } from "@/components/icons";
@@ -18,7 +17,6 @@ interface AppShellProps {
 export default function AppShell({ children }: AppShellProps) {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const location = useLocation();
-  const router = useRouter();
 
   // Handle escape key to close drawer
   useEffect(() => {
@@ -36,19 +34,6 @@ export default function AppShell({ children }: AppShellProps) {
   useEffect(() => {
     setIsDrawerOpen(false);
   }, [location.pathname]);
-
-  // Preload frequently visited routes to reduce navigation latency
-  useEffect(() => {
-    const preloadTargets: Array<{ to: "/notes" }> = [
-      { to: "/notes" },
-    ];
-
-    preloadTargets.forEach((target) => {
-      router.preloadRoute(target).catch((error: unknown) => {
-        logger.debug("Route preload failed", target.to, error);
-      });
-    });
-  }, [router]);
 
   return (
     <PageHeaderProvider>

--- a/web/src/layouts/__tests__/AppShell.test.tsx
+++ b/web/src/layouts/__tests__/AppShell.test.tsx
@@ -22,9 +22,6 @@ vi.mock("@tanstack/react-router", () => ({
     </a>
   ),
   useLocation: () => ({ pathname: "/notes" }),
-  useRouter: () => ({
-    preloadRoute: vi.fn().mockResolvedValue(undefined),
-  }),
 }));
 
 vi.mock("@/contexts/PageHeaderProvider", () => ({

--- a/web/src/services/api/__tests__/tags.test.ts
+++ b/web/src/services/api/__tests__/tags.test.ts
@@ -47,4 +47,157 @@ describe("tagsApi", () => {
       category: "general",
     });
   });
+
+  it("creates tag categories with the scoped entity type", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          value: "close_circle",
+          label: "Close Circle",
+          entity_type: "person",
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    const created = await tagsApi.createCategory(
+      { label: "Close Circle" },
+      "person",
+    );
+
+    expect(created.value).toBe("close_circle");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(
+      `${localUrl(ENDPOINTS.TAGS.CATEGORIES)}?entity_type=person`,
+    );
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(String(init.body))).toEqual({ label: "Close Circle" });
+  });
+
+  it("renames tag categories with the scoped entity type", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          value: "close_circle",
+          label: "Close Circle",
+          entity_type: "person",
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    const updated = await tagsApi.renameCategory(
+      "relationship",
+      { label: "Close Circle" },
+      "person",
+    );
+
+    expect(updated.value).toBe("close_circle");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(
+      `${localUrl(ENDPOINTS.TAGS.CATEGORY_BY_VALUE("relationship"))}?entity_type=person`,
+    );
+    expect(init.method).toBe("PATCH");
+    expect(JSON.parse(String(init.body))).toEqual({ label: "Close Circle" });
+  });
+
+  it("moves selected tags to another category", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          updated_count: 1,
+          failed_ids: [],
+          errors: [],
+          updated_tags: [],
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    const response = await tagsApi.bulkUpdateCategories({
+      ids: ["11111111-1111-1111-1111-111111111111"],
+      category: "relationship",
+    });
+
+    expect(response.updated_count).toBe(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(localUrl(ENDPOINTS.TAGS.BATCH_UPDATE));
+    expect(init.method).toBe("PATCH");
+    expect(JSON.parse(String(init.body))).toEqual({
+      ids: ["11111111-1111-1111-1111-111111111111"],
+      category: "relationship",
+    });
+  });
+
+  it("loads single tag usage through the LifeOS Web API", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          tag_id: "11111111-1111-1111-1111-111111111111",
+          tag_name: "mentor",
+          entity_type: "person",
+          category: "relationship",
+          usage_by_entity_type: { person: 12 },
+          total_usage: 12,
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    const response = await tagsApi.getUsage(
+      "11111111-1111-1111-1111-111111111111",
+    );
+
+    expect(response.total_usage).toBe(12);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(
+      localUrl(ENDPOINTS.TAGS.USAGE("11111111-1111-1111-1111-111111111111")),
+    );
+    expect(init.method).toBe("GET");
+  });
+
+  it("loads batch tag usage by entity type through stats", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          entity_type: "person",
+          tag_stats: [
+            {
+              id: "11111111-1111-1111-1111-111111111111",
+              usage_count: 12,
+            },
+          ],
+          total_tags: 1,
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    const response = await tagsApi.getStatsBatch("person");
+
+    expect(response.tag_stats[0].usage_count).toBe(12);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(localUrl(ENDPOINTS.STATS.TAGS_USAGE("person")));
+    expect(init.method).toBe("GET");
+  });
 });

--- a/web/src/services/api/endpoints.ts
+++ b/web/src/services/api/endpoints.ts
@@ -7,6 +7,8 @@ export const ENDPOINTS = {
     BATCH_UPDATE: `${API_V1}/tags/batch-update`,
     ENTITY_TYPES: `${API_V1}/tags/entity-types/`,
     CATEGORIES: `${API_V1}/tags/categories/`,
+    CATEGORY_BY_VALUE: (value: string) =>
+      `${API_V1}/tags/categories/${encodeURIComponent(value)}`,
     USAGE: (id: string) => `${API_V1}/tags/${id}/usage`,
   },
   VISIONS: {

--- a/web/src/services/api/tags.ts
+++ b/web/src/services/api/tags.ts
@@ -73,9 +73,6 @@ interface TagListMeta {
 
 export type TagListResponse = ListResponse<Tag, TagListMeta>;
 
-const unsupported = () =>
-  Promise.reject(new Error("Tags are not supported by LifeOS Web UI yet."));
-
 export const tagsApi = {
   getAll: (params?: {
     entity_type?: string;
@@ -90,35 +87,36 @@ export const tagsApi = {
       entity_type: entityType,
     }),
   createCategory: (
-    _payload: TagCategoryCreate,
-    _entityType: string,
-  ): Promise<TagCategoryOption> => unsupported(),
+    payload: TagCategoryCreate,
+    entityType: string,
+  ): Promise<TagCategoryOption> =>
+    http.post<TagCategoryOption>(ENDPOINTS.TAGS.CATEGORIES, payload, {
+      entity_type: entityType,
+    }),
   renameCategory: (
-    _value: string,
-    _payload: TagCategoryUpdate,
-    _entityType: string,
-  ): Promise<TagCategoryOption> => unsupported(),
+    value: string,
+    payload: TagCategoryUpdate,
+    entityType: string,
+  ): Promise<TagCategoryOption> =>
+    http.patch<TagCategoryOption>(ENDPOINTS.TAGS.CATEGORY_BY_VALUE(value), payload, {
+      entity_type: entityType,
+    }),
   create: (tag: TagCreate): Promise<Tag> =>
     http.post<Tag>(ENDPOINTS.TAGS.BASE, tag),
   getById: (id: UUID): Promise<Tag> => http.get<Tag>(ENDPOINTS.TAGS.BY_ID(id)),
   update: (id: UUID, tag: TagUpdate): Promise<Tag> =>
     http.patch<Tag>(ENDPOINTS.TAGS.BY_ID(id), tag),
   bulkUpdateCategories: (
-    _payload: TagBulkUpdateRequest,
-  ): Promise<TagBulkUpdateResponse> => unsupported(),
+    payload: TagBulkUpdateRequest,
+  ): Promise<TagBulkUpdateResponse> =>
+    http.patch<TagBulkUpdateResponse>(ENDPOINTS.TAGS.BATCH_UPDATE, payload),
   delete: (id: UUID): Promise<void> => http.delete<void>(ENDPOINTS.TAGS.BY_ID(id)),
   getUsage: (id: UUID): Promise<TagUsageStats> =>
-    Promise.resolve({
-      tag_id: id,
-      tag_name: "",
-      entity_type: "",
-      category: "",
-      usage_by_entity_type: {},
-      total_usage: 0,
-    }),
-  getStatsBatch: async (entityType: string) => ({
-    entity_type: entityType,
-    tag_stats: [] as Array<{ id: UUID; name: string; usage_count: number }>,
-    total_tags: 0,
-  }),
+    http.get<TagUsageStats>(ENDPOINTS.TAGS.USAGE(id)),
+  getStatsBatch: (entityType: string) =>
+    http.get<{
+      entity_type: string;
+      tag_stats: Array<{ id: UUID; name?: string; usage_count: number }>;
+      total_tags: number;
+    }>(ENDPOINTS.STATS.TAGS_USAGE(entityType)),
 };


### PR DESCRIPTION
## 变更概述

- 让标签分类发现基于数据库中 active tags 的实际分类，同时保留 persons、notes 的默认分类入口。
- 接通标签分类创建、重命名、批量移动接口，并让前端 TagManager 消费真实后端能力。
- 新增标签使用量统计 API，TagManager 显示 person/note/vision 等实体的实际使用数量，不再依赖 tag 详情里的关联 people 列表。
- 移除 AppShell 的全局手动 route preload，避免 TanStack Router 在预加载期间触发 `_nonReactive` 内部状态异常。
- 清理一个确定无效的历史残留注释，并确认框架入口、兼容 alias、未接线接入层边界不属于本次可删除死代码。

## 根因

标签数据结构本身支持 `category`，但 Web API 的分类发现此前固定返回 `general`，导致已有非 general 分类无法在标签管理界面闭环消费。标签管理界面的使用量此前也没有真实后端统计来源，`people: []` 表示 tag 详情关联对象列表为空，不应被当作“使用人数”。

## 验证

- `bash ./scripts/dead_code_check.sh`
- `npm run lint`
- `npm test -- --run src/layouts/__tests__/AppShell.test.tsx src/services/api/__tests__/tags.test.ts src/components/__tests__/TagManagerModal.test.tsx`
- `bash ./scripts/doctor.sh`

Closes #184
