### PR TITLE
fix: finance snapshots and note sidebar stats

### DIFF
--- a/src/lifeos_cli/db/services/notes.py
+++ b/src/lifeos_cli/db/services/notes.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import Select, exists, or_, select
+from sqlalchemy import Select, exists, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.elements import ColumnElement
 
@@ -51,6 +51,16 @@ class NoteBatchUpdateResult:
     failed_ids: tuple[UUID, ...]
     errors: tuple[str, ...]
     replacement_count: int
+
+
+@dataclass(frozen=True)
+class NotePersonUsage:
+    """Aggregated active-note usage for one associated person."""
+
+    id: UUID
+    name: str
+    display_name: str
+    usage_count: int
 
 
 def _normalize_note_content(content: str) -> str:
@@ -105,6 +115,7 @@ def _note_query(
                     tag_associations.c.entity_type == "note",
                     tag_associations.c.entity_id == Note.id,
                     tag_associations.c.tag_id == tag_id,
+                    Tag.id == tag_associations.c.tag_id,
                     Tag.id == tag_id,
                     Tag.deleted_at.is_(None),
                 )
@@ -356,6 +367,41 @@ async def list_notes(
         .limit(limit)
     )
     return await _build_note_views(session, list((await session.execute(stmt)).scalars()))
+
+
+async def count_note_usage_by_person(session: AsyncSession) -> list[NotePersonUsage]:
+    """Count active notes by associated active person."""
+    stmt = (
+        select(
+            Person.id,
+            Person.name,
+            func.count(func.distinct(Note.id)).label("usage_count"),
+        )
+        .join(
+            Association,
+            (Association.target_id == Person.id)
+            & (Association.source_model == "note")
+            & (Association.target_model == "person")
+            & (Association.link_type == "is_about"),
+        )
+        .join(Note, Note.id == Association.source_id)
+        .where(
+            Note.deleted_at.is_(None),
+            Person.deleted_at.is_(None),
+        )
+        .group_by(Person.id, Person.name)
+        .order_by(Person.name.asc(), Person.id.asc())
+    )
+    rows = await session.execute(stmt)
+    return [
+        NotePersonUsage(
+            id=person_id,
+            name=name,
+            display_name=name,
+            usage_count=int(usage_count),
+        )
+        for person_id, name, usage_count in rows.all()
+    ]
 
 
 async def search_notes(

--- a/src/lifeos_web/routers/notes.py
+++ b/src/lifeos_web/routers/notes.py
@@ -120,6 +120,24 @@ async def list_notes(
     )
 
 
+@router.get("/stats/persons")
+async def get_note_person_usage_stats(session: SessionDep) -> dict[str, object]:
+    """Return active-note usage counts grouped by associated person."""
+    person_stats = await note_services.count_note_usage_by_person(session)
+    return {
+        "person_stats": [
+            {
+                "id": str(row.id),
+                "name": row.name,
+                "display_name": row.display_name,
+                "usage_count": row.usage_count,
+            }
+            for row in person_stats
+        ],
+        "total_persons": len(person_stats),
+    }
+
+
 @router.post("/")
 async def create_note(
     payload: NoteCreate,

--- a/tests/test_note_services.py
+++ b/tests/test_note_services.py
@@ -1,14 +1,33 @@
 from __future__ import annotations
 
 import asyncio
+import warnings
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock
 from uuid import UUID
 
 import pytest
+from sqlalchemy.exc import SAWarning
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
 
-from lifeos_cli.db.services import notes
+from lifeos_cli.db.base import Base
+from lifeos_cli.db.services import notes, people, tags
+
+
+async def _create_sqlite_session_factory() -> tuple[
+    AsyncEngine,
+    async_sessionmaker[AsyncSession],
+]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False, future=True)
 
 
 def test_create_note_flushes_without_committing(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -34,6 +53,69 @@ def test_create_note_flushes_without_committing(monkeypatch: pytest.MonkeyPatch)
     session.flush.assert_awaited_once()
     session.refresh.assert_awaited_once_with(note)
     session.commit.assert_not_called()
+
+
+def test_list_notes_by_tag_does_not_emit_cartesian_product_warning() -> None:
+    async def run() -> None:
+        engine, session_factory = await _create_sqlite_session_factory()
+        try:
+            async with session_factory() as session:
+                tag = await tags.create_tag(
+                    session,
+                    name="Project",
+                    entity_type="note",
+                    category="general",
+                )
+                created_note = await notes.create_note(
+                    session,
+                    content="Tagged note",
+                    tag_ids=[tag.id],
+                )
+
+                with warnings.catch_warnings(record=True) as caught:
+                    warnings.simplefilter("always", SAWarning)
+                    rows = await notes.list_notes(session, tag_id=tag.id)
+
+                assert [row.id for row in rows] == [created_note.id]
+                assert not any(
+                    issubclass(item.category, SAWarning)
+                    and "cartesian product" in str(item.message)
+                    for item in caught
+                )
+        finally:
+            await engine.dispose()
+
+    asyncio.run(run())
+
+
+def test_count_note_usage_by_person_counts_active_notes() -> None:
+    async def run() -> None:
+        engine, session_factory = await _create_sqlite_session_factory()
+        try:
+            async with session_factory() as session:
+                person = await people.create_person(session, name="Alice")
+                active_note = await notes.create_note(
+                    session,
+                    content="Active note",
+                    person_ids=[person.id],
+                )
+                deleted_note = await notes.create_note(
+                    session,
+                    content="Deleted note",
+                    person_ids=[person.id],
+                )
+                await notes.delete_note(session, note_id=deleted_note.id)
+
+                stats = await notes.count_note_usage_by_person(session)
+
+                assert active_note.people[0].id == person.id
+                assert [(row.id, row.name, row.display_name, row.usage_count) for row in stats] == [
+                    (person.id, "Alice", "Alice", 1),
+                ]
+        finally:
+            await engine.dispose()
+
+    asyncio.run(run())
 
 
 def test_batch_update_note_content_does_not_rollback_missing_note(

--- a/tests/test_web_cli.py
+++ b/tests/test_web_cli.py
@@ -2047,6 +2047,47 @@ def test_web_stats_tag_usage_endpoint_returns_counts(
     }
 
 
+def test_web_note_person_usage_stats_endpoint_returns_counts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("fastapi")
+
+    from lifeos_cli.db.services.notes import NotePersonUsage
+    from lifeos_web.routers import notes
+
+    person_id = UUID("11111111-1111-1111-1111-111111111111")
+
+    async def fake_count_note_usage_by_person(_session: object) -> list[NotePersonUsage]:
+        return [
+            NotePersonUsage(
+                id=person_id,
+                name="Alice",
+                display_name="Alice",
+                usage_count=3,
+            )
+        ]
+
+    monkeypatch.setattr(
+        notes.note_services,
+        "count_note_usage_by_person",
+        fake_count_note_usage_by_person,
+    )
+
+    response = asyncio.run(notes.get_note_person_usage_stats(cast(AsyncSession, object())))
+
+    assert response == {
+        "person_stats": [
+            {
+                "id": str(person_id),
+                "name": "Alice",
+                "display_name": "Alice",
+                "usage_count": 3,
+            }
+        ],
+        "total_persons": 1,
+    }
+
+
 def test_web_note_create_maps_selector_associations_to_lifeos_note_service(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/web/src/features/finance/AmountText.tsx
+++ b/web/src/features/finance/AmountText.tsx
@@ -1,0 +1,154 @@
+type FinanceAmountTextProps = {
+  amount: string;
+  currencyCode?: string | null;
+  value?: number | null;
+  showCurrency?: boolean;
+  className?: string;
+};
+
+type FinanceAmountListTextProps = {
+  value: string;
+  className?: string;
+};
+
+type FinanceAssetSymbolProps = {
+  symbol: string;
+  className?: string;
+  inheritTone?: boolean;
+};
+
+const subduedTextClass = "font-normal opacity-65";
+
+export function FinanceAmountText({
+  amount,
+  currencyCode,
+  value,
+  showCurrency = true,
+  className = "",
+}: FinanceAmountTextProps) {
+  const text = amount.trim();
+  if (!text) {
+    return (
+      <span className={["text-base-content/40", className].filter(Boolean).join(" ")}>-</span>
+    );
+  }
+
+  const parts = splitAmountText(text);
+  const numericValue = typeof value === "number" ? value : parseNumericAmount(text);
+  const toneClass =
+    Number.isFinite(numericValue) && numericValue < 0 ? "text-warning" : "text-base-content";
+  const symbol = currencyCode?.trim().toUpperCase();
+
+  return (
+    <span
+      className={[
+        "inline-flex items-baseline gap-1 whitespace-nowrap tabular-nums",
+        toneClass,
+        className,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      <span className="font-medium">
+        {parts.sign}
+        {parts.integer}
+      </span>
+      {parts.fraction ? <span className={subduedTextClass}>{parts.fraction}</span> : null}
+      {showCurrency && symbol ? <FinanceAssetSymbol symbol={symbol} inheritTone /> : null}
+    </span>
+  );
+}
+
+export function FinanceAmountListText({ value, className = "" }: FinanceAmountListTextProps) {
+  const items = parseAmountList(value);
+  if (!items.length) {
+    return (
+      <span className={["text-base-content/40", className].filter(Boolean).join(" ")}>-</span>
+    );
+  }
+
+  return (
+    <span
+      className={[
+        "inline-flex flex-wrap items-baseline gap-x-2 gap-y-1 tabular-nums",
+        className,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      {items.map((item, index) => (
+        <span
+          key={`${item.amount}:${item.currencyCode}:${index}`}
+          className="inline-flex items-baseline gap-1"
+        >
+          {index > 0 ? <span className="text-base-content/40">,</span> : null}
+          <FinanceAmountText amount={item.amount} currencyCode={item.currencyCode} />
+        </span>
+      ))}
+    </span>
+  );
+}
+
+export function FinanceAssetSymbol({
+  symbol,
+  className = "",
+  inheritTone = false,
+}: FinanceAssetSymbolProps) {
+  return (
+    <span
+      className={[
+        "whitespace-nowrap",
+        inheritTone ? "" : "text-base-content",
+        subduedTextClass,
+        className,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      {symbol.trim().toUpperCase()}
+    </span>
+  );
+}
+
+function splitAmountText(value: string): { sign: string; integer: string; fraction: string } {
+  const normalized = value.trim();
+  const sign = normalized.startsWith("-") || normalized.startsWith("+") ? normalized[0] : "";
+  const unsigned = sign ? normalized.slice(1) : normalized;
+  const decimalIndex = findDecimalSeparatorIndex(unsigned);
+  if (decimalIndex === -1) {
+    return { sign, integer: unsigned || "0", fraction: "" };
+  }
+  return {
+    sign,
+    integer: unsigned.slice(0, decimalIndex) || "0",
+    fraction: unsigned.slice(decimalIndex),
+  };
+}
+
+function findDecimalSeparatorIndex(value: string): number {
+  const dotIndex = value.lastIndexOf(".");
+  const commaIndex = value.lastIndexOf(",");
+  return Math.max(dotIndex, commaIndex);
+}
+
+function parseNumericAmount(value: string): number {
+  return Number(value.trim().replace(",", "."));
+}
+
+function parseAmountList(value: string): Array<{ amount: string; currencyCode: string }> {
+  return value
+    .split(/,\s+/)
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .map((item) => {
+      const match = item.match(/^(.+?)\s+([A-Za-z][A-Za-z0-9._-]*)$/);
+      if (!match) {
+        return null;
+      }
+      return {
+        amount: match[1].trim(),
+        currencyCode: match[2].trim().toUpperCase(),
+      };
+    })
+    .filter((item): item is { amount: string; currencyCode: string } => Boolean(item));
+}

--- a/web/src/features/finance/AmountText.tsx
+++ b/web/src/features/finance/AmountText.tsx
@@ -1,3 +1,5 @@
+import { financeTextClass } from "./styles";
+
 type FinanceAmountTextProps = {
   amount: string;
   currencyCode?: string | null;
@@ -29,7 +31,9 @@ export function FinanceAmountText({
   const text = amount.trim();
   if (!text) {
     return (
-      <span className={["text-base-content/40", className].filter(Boolean).join(" ")}>-</span>
+      <span className={[financeTextClass.placeholder, className].filter(Boolean).join(" ")}>
+        -
+      </span>
     );
   }
 
@@ -58,7 +62,9 @@ export function FinanceAmountListText({ value, className = "" }: FinanceAmountLi
   const items = parseAmountList(value);
   if (!items.length) {
     return (
-      <span className={["text-base-content/40", className].filter(Boolean).join(" ")}>-</span>
+      <span className={[financeTextClass.placeholder, className].filter(Boolean).join(" ")}>
+        -
+      </span>
     );
   }
 
@@ -76,7 +82,7 @@ export function FinanceAmountListText({ value, className = "" }: FinanceAmountLi
           key={`${item.amount}:${item.currencyCode}:${index}`}
           className="inline-flex items-baseline gap-1"
         >
-          {index > 0 ? <span className="text-base-content/40">,</span> : null}
+          {index > 0 ? <span className={financeTextClass.placeholder}>,</span> : null}
           <FinanceAmountText amount={item.amount} currencyCode={item.currencyCode} />
         </span>
       ))}

--- a/web/src/features/finance/AmountText.tsx
+++ b/web/src/features/finance/AmountText.tsx
@@ -33,7 +33,6 @@ export function FinanceAmountText({
     );
   }
 
-  const parts = splitAmountText(text);
   const numericValue = typeof value === "number" ? value : parseNumericAmount(text);
   const toneClass =
     Number.isFinite(numericValue) && numericValue < 0 ? "text-warning" : "text-base-content";
@@ -49,11 +48,7 @@ export function FinanceAmountText({
         .filter(Boolean)
         .join(" ")}
     >
-      <span className="font-medium">
-        {parts.sign}
-        {parts.integer}
-      </span>
-      {parts.fraction ? <span className={subduedTextClass}>{parts.fraction}</span> : null}
+      <span className="font-medium">{text}</span>
       {showCurrency && symbol ? <FinanceAssetSymbol symbol={symbol} inheritTone /> : null}
     </span>
   );
@@ -108,27 +103,6 @@ export function FinanceAssetSymbol({
       {symbol.trim().toUpperCase()}
     </span>
   );
-}
-
-function splitAmountText(value: string): { sign: string; integer: string; fraction: string } {
-  const normalized = value.trim();
-  const sign = normalized.startsWith("-") || normalized.startsWith("+") ? normalized[0] : "";
-  const unsigned = sign ? normalized.slice(1) : normalized;
-  const decimalIndex = findDecimalSeparatorIndex(unsigned);
-  if (decimalIndex === -1) {
-    return { sign, integer: unsigned || "0", fraction: "" };
-  }
-  return {
-    sign,
-    integer: unsigned.slice(0, decimalIndex) || "0",
-    fraction: unsigned.slice(decimalIndex),
-  };
-}
-
-function findDecimalSeparatorIndex(value: string): number {
-  const dotIndex = value.lastIndexOf(".");
-  const commaIndex = value.lastIndexOf(",");
-  return Math.max(dotIndex, commaIndex);
 }
 
 function parseNumericAmount(value: string): number {

--- a/web/src/features/finance/RateSnapshotsWorkspace.tsx
+++ b/web/src/features/finance/RateSnapshotsWorkspace.tsx
@@ -45,6 +45,7 @@ import {
   type RateRowState,
   type RateSnapshotFormMode,
 } from "./utils";
+import { financeTextClass } from "./styles";
 import { useFinanceAssetSource } from "./useFinanceAssetSource";
 
 export function RateSnapshotsWorkspace() {
@@ -350,7 +351,9 @@ export function RateSnapshotsWorkspace() {
               </div>
 
               <div className="rounded-lg border border-base-200">
-                <div className="grid grid-cols-[minmax(5rem,0.7fr)_minmax(7rem,1fr)_auto_minmax(5rem,0.7fr)_minmax(7rem,1fr)_auto] gap-2 border-b border-base-200 bg-base-200/40 px-3 py-2 text-xs uppercase text-base-content/60">
+                <div
+                  className={`grid grid-cols-[minmax(5rem,0.7fr)_minmax(7rem,1fr)_auto_minmax(5rem,0.7fr)_minmax(7rem,1fr)_auto] gap-2 border-b border-base-200 px-3 py-2 ${financeTextClass.tableHeader}`}
+                >
                   <span>{t("finance.rates.baseAmount")}</span>
                   <span>{t("finance.rates.baseAsset")}</span>
                   <span />
@@ -394,7 +397,7 @@ export function RateSnapshotsWorkspace() {
                           updateRateSnapshotMutation.isPending
                         }
                       />
-                      <span className="text-center text-base-content/60">=</span>
+                      <span className={`text-center ${financeTextClass.placeholder}`}>=</span>
                       <TextInput
                         size="sm"
                         inputMode="decimal"
@@ -481,35 +484,35 @@ export function RateSnapshotsWorkspace() {
                 />
               }
             />
-            <div className="grid grid-cols-1 gap-3 rounded-lg border border-base-200 bg-base-200/30 p-3 text-sm sm:grid-cols-3">
+            <div className="grid grid-cols-1 gap-3 rounded-lg border border-base-200 bg-base-200/30 p-3 sm:grid-cols-3">
               <div>
-                <p className="text-xs uppercase text-base-content/50">
+                <p className={financeTextClass.fieldLabel}>
                   {t("finance.rates.capturedAt")}
                 </p>
-                <p className="mt-1 font-medium text-base-content">
+                <p className={`mt-1 ${financeTextClass.rowTitle}`}>
                   {formatDateTime(currentSnapshot.captured_at)}
                 </p>
               </div>
               <div>
-                <p className="text-xs uppercase text-base-content/50">
+                <p className={financeTextClass.fieldLabel}>
                   {t("finance.rates.source")}
                 </p>
-                <p className="mt-1 font-medium text-base-content">
+                <p className={`mt-1 ${financeTextClass.rowTitle}`}>
                   {currentSnapshot.source || "-"}
                 </p>
               </div>
               <div>
-                <p className="text-xs uppercase text-base-content/50">
+                <p className={financeTextClass.fieldLabel}>
                   {t("finance.rates.note")}
                 </p>
-                <p className="mt-1 whitespace-pre-wrap text-base-content/80">
+                <p className={`mt-1 whitespace-pre-wrap ${financeTextClass.bodyMuted}`}>
                   {currentSnapshot.note || "-"}
                 </p>
               </div>
             </div>
             <div className="overflow-x-auto rounded-lg border border-base-200">
               <table className="table table-sm">
-                <thead className="bg-base-200/60 text-xs uppercase text-base-content/60">
+                <thead className={financeTextClass.tableHeader}>
                   <tr>
                     <th className="text-right">{t("finance.rates.baseAmount")}</th>
                     <th>{t("finance.rates.baseAsset")}</th>
@@ -526,7 +529,7 @@ export function RateSnapshotsWorkspace() {
                   ))}
                   {!(currentSnapshot.entries ?? []).length ? (
                     <tr>
-                      <td colSpan={5} className="text-center text-base-content/40">
+                      <td colSpan={5} className={`text-center ${financeTextClass.placeholder}`}>
                         -
                       </td>
                     </tr>
@@ -536,7 +539,9 @@ export function RateSnapshotsWorkspace() {
             </div>
           </>
         ) : (
-          <div className="rounded-lg border border-dashed border-base-300 p-6 text-center text-sm text-base-content/60">
+          <div
+            className={`rounded-lg border border-dashed border-base-300 p-6 text-center ${financeTextClass.helperText}`}
+          >
             {t("finance.rates.empty")}
             <div className="mt-4 flex justify-center">
               <CreateNewButton
@@ -653,7 +658,7 @@ export function FinanceAssetManagerModal({
       bodyOverflow="auto"
     >
       <div className="space-y-4">
-        <p className="text-sm text-base-content/60">{t("finance.assets.description")}</p>
+        <p className={financeTextClass.helperText}>{t("finance.assets.description")}</p>
         <form
           className="grid grid-cols-1 gap-2 sm:grid-cols-[8rem_minmax(0,1fr)_8rem_auto]"
           onSubmit={submitAsset}
@@ -692,7 +697,7 @@ export function FinanceAssetManagerModal({
         </form>
         <div className="max-h-[520px] overflow-y-auto pr-1">
           <table className="table table-sm">
-            <thead className="bg-base-200/60 text-xs uppercase text-base-content/60">
+            <thead className={financeTextClass.tableHeader}>
               <tr>
                 <th>{t("finance.assets.code")}</th>
                 <th>{t("finance.assets.name")}</th>
@@ -713,7 +718,7 @@ export function FinanceAssetManagerModal({
                           onChange={(event) => setEditingAssetCode(event.target.value.toUpperCase())}
                         />
                       ) : (
-                        <span className="font-medium">{asset.code}</span>
+                        <FinanceAssetSymbol symbol={asset.code} />
                       )}
                     </td>
                     <td>
@@ -842,7 +847,7 @@ function RateEntryEquationCells({
       <td>
         <FinanceAssetSymbol symbol={entry.base_currency} />
       </td>
-      <td className="text-center text-base-content/50">=</td>
+      <td className={`text-center ${financeTextClass.placeholder}`}>=</td>
       <td className="text-right">
         <FinanceAmountText
           amount={formatAmountForAsset(entry.rate, entry.quote_currency, assets)}

--- a/web/src/features/finance/RateSnapshotsWorkspace.tsx
+++ b/web/src/features/finance/RateSnapshotsWorkspace.tsx
@@ -35,6 +35,7 @@ import {
   SnapshotNavigator,
   SnapshotSelectorToolbar,
 } from "./SnapshotChrome";
+import { FinanceAmountText, FinanceAssetSymbol } from "./AmountText";
 import {
   isoToDateTimeLocal,
   localDateTimeToIso,
@@ -831,15 +832,27 @@ function RateEntryEquationCells({
 }) {
   return (
     <>
-      <td className="text-right font-medium tabular-nums text-base-content">
-        {formatAmountForAsset("1", entry.base_currency, assets)}
+      <td className="text-right">
+        <FinanceAmountText
+          amount={formatAmountForAsset("1", entry.base_currency, assets)}
+          currencyCode={entry.base_currency}
+          showCurrency={false}
+        />
       </td>
-      <td className="font-medium text-info/80">{entry.base_currency}</td>
+      <td>
+        <FinanceAssetSymbol symbol={entry.base_currency} />
+      </td>
       <td className="text-center text-base-content/50">=</td>
-      <td className="text-right font-medium tabular-nums text-base-content">
-        {formatAmountForAsset(entry.rate, entry.quote_currency, assets)}
+      <td className="text-right">
+        <FinanceAmountText
+          amount={formatAmountForAsset(entry.rate, entry.quote_currency, assets)}
+          currencyCode={entry.quote_currency}
+          showCurrency={false}
+        />
       </td>
-      <td className="font-medium text-info/80">{entry.quote_currency}</td>
+      <td>
+        <FinanceAssetSymbol symbol={entry.quote_currency} />
+      </td>
     </>
   );
 }

--- a/web/src/features/finance/RateSnapshotsWorkspace.tsx
+++ b/web/src/features/finance/RateSnapshotsWorkspace.tsx
@@ -468,11 +468,7 @@ export function RateSnapshotsWorkspace() {
         ) : currentSnapshot ? (
           <>
             <SnapshotNavigator
-              title={
-                <span title={formatRateSnapshotTooltip(currentSnapshot, assets)}>
-                  {rateSnapshotLabel(currentSnapshot)}
-                </span>
-              }
+              title={rateSnapshotLabel(currentSnapshot)}
               rightSlot={
                 <SnapshotActionButtons
                   editLabel={t("finance.rates.editSnapshot")}
@@ -484,43 +480,59 @@ export function RateSnapshotsWorkspace() {
                 />
               }
             />
-            <div className="overflow-x-auto">
+            <div className="grid grid-cols-1 gap-3 rounded-lg border border-base-200 bg-base-200/30 p-3 text-sm sm:grid-cols-3">
+              <div>
+                <p className="text-xs uppercase text-base-content/50">
+                  {t("finance.rates.capturedAt")}
+                </p>
+                <p className="mt-1 font-medium text-base-content">
+                  {formatDateTime(currentSnapshot.captured_at)}
+                </p>
+              </div>
+              <div>
+                <p className="text-xs uppercase text-base-content/50">
+                  {t("finance.rates.source")}
+                </p>
+                <p className="mt-1 font-medium text-base-content">
+                  {currentSnapshot.source || "-"}
+                </p>
+              </div>
+              <div>
+                <p className="text-xs uppercase text-base-content/50">
+                  {t("finance.rates.note")}
+                </p>
+                <p className="mt-1 whitespace-pre-wrap text-base-content/80">
+                  {currentSnapshot.note || "-"}
+                </p>
+              </div>
+            </div>
+            <div className="overflow-x-auto rounded-lg border border-base-200">
               <table className="table table-sm">
                 <thead className="bg-base-200/60 text-xs uppercase text-base-content/60">
                   <tr>
-                    <th>{t("finance.rates.capturedAt")}</th>
-                    <th>{t("finance.rates.source")}</th>
-                    <th>{t("finance.rates.rate")}</th>
+                    <th className="text-right">{t("finance.rates.baseAmount")}</th>
+                    <th>{t("finance.rates.baseAsset")}</th>
+                    <th className="text-center">{t("finance.rates.rate")}</th>
+                    <th className="text-right">{t("finance.rates.quoteAmount")}</th>
+                    <th>{t("finance.rates.quoteAsset")}</th>
                   </tr>
                 </thead>
                 <tbody>
                   {(currentSnapshot.entries ?? []).map((entry) => (
                     <tr key={entry.id}>
-                      <td>{formatDateTime(entry.captured_at ?? currentSnapshot.captured_at)}</td>
-                      <td>{entry.source || currentSnapshot.source}</td>
-                      <td>
-                        <span className="font-medium tabular-nums">
-                          {formatRateEntryEquation(entry, assets)}
-                        </span>
-                      </td>
+                      <RateEntryEquationCells entry={entry} assets={assets} />
                     </tr>
                   ))}
                   {!(currentSnapshot.entries ?? []).length ? (
                     <tr>
-                      <td>{formatDateTime(currentSnapshot.captured_at)}</td>
-                      <td>{currentSnapshot.source}</td>
-                      <td className="text-base-content/40">-</td>
+                      <td colSpan={5} className="text-center text-base-content/40">
+                        -
+                      </td>
                     </tr>
                   ) : null}
                 </tbody>
               </table>
             </div>
-            {currentSnapshot.note ? (
-              <div className="mt-4 rounded-lg border border-dashed border-base-200 p-3 text-sm text-base-content/70">
-                <p className="font-medium text-base-content">{t("finance.rates.note")}</p>
-                <p className="mt-1 whitespace-pre-wrap">{currentSnapshot.note}</p>
-              </div>
-            ) : null}
           </>
         ) : (
           <div className="rounded-lg border border-dashed border-base-300 p-6 text-center text-sm text-base-content/60">
@@ -810,21 +822,24 @@ function parseDecimalPlaces(value: string): number {
   return Math.min(8, Math.max(0, parsed));
 }
 
-function formatRateEntryEquation(
-  entry: NonNullable<FinanceRateSnapshot["entries"]>[number],
-  assets: FinanceAsset[],
-) {
-  return `${formatAmountForAsset("1", entry.base_currency, assets)} ${
-    entry.base_currency
-  } = ${formatAmountForAsset(entry.rate, entry.quote_currency, assets)} ${entry.quote_currency}`;
-}
-
-function formatRateSnapshotTooltip(
-  snapshot: FinanceRateSnapshot,
-  assets: FinanceAsset[],
-) {
-  const lines = (snapshot.entries ?? []).map((entry) =>
-    formatRateEntryEquation(entry, assets),
+function RateEntryEquationCells({
+  entry,
+  assets,
+}: {
+  entry: NonNullable<FinanceRateSnapshot["entries"]>[number];
+  assets: FinanceAsset[];
+}) {
+  return (
+    <>
+      <td className="text-right font-medium tabular-nums text-base-content">
+        {formatAmountForAsset("1", entry.base_currency, assets)}
+      </td>
+      <td className="font-medium text-info/80">{entry.base_currency}</td>
+      <td className="text-center text-base-content/50">=</td>
+      <td className="text-right font-medium tabular-nums text-base-content">
+        {formatAmountForAsset(entry.rate, entry.quote_currency, assets)}
+      </td>
+      <td className="font-medium text-info/80">{entry.quote_currency}</td>
+    </>
   );
-  return lines.length ? lines.join("\n") : rateSnapshotLabel(snapshot);
 }

--- a/web/src/features/finance/SnapshotChrome.tsx
+++ b/web/src/features/finance/SnapshotChrome.tsx
@@ -1,9 +1,10 @@
-import ActionButton, {
-  CreateNewButton,
-} from "@/components/ActionButton";
+import { useTranslation } from "react-i18next";
+
+import ActionButton, { CreateNewButton } from "@/components/ActionButton";
 import EnumSelect from "@/components/selects/EnumSelect";
 import type { UUID } from "@/types/primitive";
-import { useTranslation } from "react-i18next";
+
+import { financeTextClass } from "./styles";
 
 export function SnapshotSelectorToolbar({
   selectValue,
@@ -38,7 +39,7 @@ export function SnapshotSelectorToolbar({
     <section className="rounded-2xl border border-base-200 bg-base-100 p-4 shadow-sm">
       <div className="grid grid-cols-1 items-center gap-3 lg:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)]">
         {description ? (
-          <p className="min-w-0 text-sm text-base-content/70">{description}</p>
+          <p className={`min-w-0 ${financeTextClass.bodyMuted}`}>{description}</p>
         ) : (
           <span aria-hidden="true" />
         )}
@@ -151,13 +152,15 @@ export function SnapshotNavigator({
       <div className="flex flex-grow flex-wrap items-center gap-3">
         <div>
           {typeof title === "string" ? (
-            <p className="text-lg font-semibold text-base-content">{title}</p>
+            <p className={financeTextClass.moduleTitle}>{title}</p>
           ) : (
             title
           )}
         </div>
       </div>
-      {rightSlot ? <div className="text-right text-sm text-base-content/70">{rightSlot}</div> : null}
+      {rightSlot ? (
+        <div className={`text-right ${financeTextClass.bodyMuted}`}>{rightSlot}</div>
+      ) : null}
     </header>
   );
 }

--- a/web/src/features/finance/SnapshotPanels.tsx
+++ b/web/src/features/finance/SnapshotPanels.tsx
@@ -614,6 +614,7 @@ function SnapshotEntryTreeTable({
                 <FinanceAmountText
                   amount={displayConvertedAmount}
                   currencyCode={primaryCurrency}
+                  showCurrency={false}
                 />
               </span>
             ) : (
@@ -722,6 +723,7 @@ function SnapshotEntryTreeTable({
                     <FinanceAmountText
                       amount={convertedHoldingAmount}
                       currencyCode={primaryCurrency}
+                      showCurrency={false}
                     />
                   </span>
                 ) : (
@@ -774,7 +776,7 @@ function SnapshotEntryTreeTable({
                   {t("finance.snapshot.originalAmount")}
                 </th>
                 <th className="min-w-[10rem] px-4 py-2">
-                  {t("finance.snapshot.convertedAmount", { currency: primaryCurrency })}
+                  {t("finance.metrics.convertTo", { currency: primaryCurrency })}
                 </th>
                 <th className="min-w-[10rem] px-4 py-2">
                   {t("finance.snapshot.note")}
@@ -873,14 +875,13 @@ function AssetSummaryPanel({
   return (
     <div className="rounded-lg border border-base-300 bg-base-100">
       <div className="flex flex-wrap items-center justify-between gap-3 border-b border-base-200 px-3 py-2">
-        <h4 className="font-semibold text-base-content">{t("finance.metrics.assetSummary")}</h4>
+        <h4 className="text-base font-semibold text-base-content">
+          {t("finance.metrics.assetSummary")}
+        </h4>
         <span className="text-right text-sm text-base-content/70" title={rateSnapshotTooltip}>
           {t("finance.rates.tabTitle")}
           <span className="ml-2 text-base-content">{rateSnapshotLabelText}</span>
         </span>
-      </div>
-      <div className="px-3 pt-3 text-sm font-semibold text-base-content">
-        {t("finance.metrics.summary")}
       </div>
       <div className="overflow-x-auto">
         <table className="table table-sm">
@@ -933,6 +934,7 @@ function AssetSummaryPanel({
                       amount={row.convertedAmount}
                       currencyCode={primaryCurrency}
                       value={row.convertedValue}
+                      showCurrency={false}
                     />
                   ) : (
                     <span className="text-base-content/40">-</span>
@@ -1046,8 +1048,10 @@ export function SnapshotDetail({
       />
 
       <div className="rounded-lg border border-base-300">
-        <div className="border-b border-base-200 px-3 py-2 text-sm font-semibold text-base-content">
-          {t("finance.metrics.details")}
+        <div className="border-b border-base-200 px-3 py-2">
+          <h4 className="text-base font-semibold text-base-content">
+            {t("finance.metrics.details")}
+          </h4>
         </div>
         <div className="overflow-x-auto">
           <table className="table table-sm">
@@ -1063,7 +1067,7 @@ export function SnapshotDetail({
                   {t("finance.snapshot.originalAmount")}
                 </th>
                 <th className="min-w-[10rem] px-4 py-2">
-                  {t("finance.snapshot.convertedAmount", { currency: snapshot.primary_currency })}
+                  {t("finance.metrics.convertTo", { currency: snapshot.primary_currency })}
                 </th>
                 <th className="min-w-[12rem]">{t("finance.snapshot.note")}</th>
               </tr>
@@ -1144,6 +1148,7 @@ export function SnapshotDetail({
                           )}
                           currencyCode={snapshot.primary_currency}
                           value={parseDisplayAmount(node.amountConverted)}
+                          showCurrency={false}
                         />
                       ) : (
                         <span className="text-base-content/40">-</span>

--- a/web/src/features/finance/SnapshotPanels.tsx
+++ b/web/src/features/finance/SnapshotPanels.tsx
@@ -913,7 +913,9 @@ function AssetSummaryPanel({
             {rowsWithShare.map((row) => (
               <tr key={row.currency}>
                 <td className="font-medium">{row.currency}</td>
-                <td className="text-right tabular-nums">{row.amount}</td>
+                <td className={`text-right tabular-nums ${amountToneClass(row.numericAmount)}`}>
+                  {row.amount}
+                </td>
                 <td className="text-right tabular-nums">
                   {row.rateInfo ? (
                     <span title={rateInfoTooltip(row.rateInfo, assets)}>
@@ -929,7 +931,9 @@ function AssetSummaryPanel({
                 </td>
                 <td className="text-right tabular-nums">
                   {row.convertedAmount ? (
-                    `${row.convertedAmount} ${primaryCurrency}`
+                    <span className={amountToneClass(row.convertedValue)}>
+                      {row.convertedAmount} {primaryCurrency}
+                    </span>
                   ) : (
                     <span className="text-base-content/40">-</span>
                   )}
@@ -946,7 +950,7 @@ function AssetSummaryPanel({
         <span className="text-sm font-medium text-base-content/70">
           {t("finance.metrics.totalValue")}
         </span>
-        <span className="font-semibold tabular-nums text-base-content">
+        <span className={`font-semibold tabular-nums ${amountToneClass(totalValue)}`}>
           {totalValue === null
             ? "-"
             : `${formatNumberForAsset(totalValue, primaryCurrency, assets)} ${primaryCurrency}`}
@@ -1756,6 +1760,19 @@ function sumSnapshotNodeAmounts(
 function isNegativeAmount(value: string | null | undefined): boolean {
   const numeric = parseDisplayAmount(value ?? "");
   return Number.isFinite(numeric) && numeric < 0;
+}
+
+function amountToneClass(value: number | null | undefined): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return "text-base-content";
+  }
+  if (value > 0) {
+    return "text-success";
+  }
+  if (value < 0) {
+    return "text-error";
+  }
+  return "text-base-content";
 }
 
 function parseDisplayAmount(value: string): number {

--- a/web/src/features/finance/SnapshotPanels.tsx
+++ b/web/src/features/finance/SnapshotPanels.tsx
@@ -16,6 +16,7 @@ import type {
 import type { UUID } from "@/types/primitive";
 
 import { FinanceAmountListText, FinanceAmountText, FinanceAssetSymbol } from "./AmountText";
+import { financeTextClass } from "./styles";
 import {
   dateToEndIso,
   dateToStartIso,
@@ -234,7 +235,7 @@ export function SnapshotFormPanel({
           onChange={(event) => setTitle(event.target.value)}
           placeholder={t("finance.snapshot.titlePlaceholder")}
           aria-label={t("finance.snapshot.title")}
-          className="max-w-xl text-lg font-semibold"
+          className={`max-w-xl ${financeTextClass.moduleTitle}`}
         />
         <div className="flex justify-end gap-2">
           <ActionButton
@@ -386,7 +387,7 @@ function InlineFinanceField({
 }) {
   return (
     <label className="grid items-center gap-2 sm:grid-cols-[8rem_minmax(0,1fr)]">
-      <span className="text-sm font-medium text-base-content/70">{label}</span>
+      <span className={financeTextClass.inlineLabel}>{label}</span>
       <div className="min-w-0">{children}</div>
     </label>
   );
@@ -541,14 +542,14 @@ function SnapshotEntryTreeTable({
                 </span>
               )}
               <div className="min-w-0 flex flex-col gap-1 sm:flex-row sm:items-center sm:gap-3">
-                <p className="truncate font-semibold text-base-content">{node.name}</p>
+                <p className={`truncate ${financeTextClass.rowTitle}`}>{node.name}</p>
               </div>
             </div>
           </td>
           <td className="align-top text-center">
             <span className="inline-flex min-h-[2.25rem] items-center">
               {hasChildren ? (
-                <span className="text-base-content/40">-</span>
+                <span className={financeTextClass.placeholder}>-</span>
               ) : (
                 <FinanceAssetSymbol symbol={defaultCurrency} />
               )}
@@ -557,7 +558,9 @@ function SnapshotEntryTreeTable({
           <td className="align-top">
             {hasChildren ? (
               <div className="flex min-w-[12rem] items-start gap-2">
-                <div className="min-h-[2.25rem] flex-1 rounded-md border border-dashed border-base-200 px-3 py-2 text-sm">
+                <div
+                  className={`min-h-[2.25rem] flex-1 rounded-md border border-dashed border-base-200 px-3 py-2 ${financeTextClass.helperText}`}
+                >
                   <FinanceAmountListText value={nativeAggregatedAmount} />
                 </div>
                 <ActionButton
@@ -618,14 +621,14 @@ function SnapshotEntryTreeTable({
                 />
               </span>
             ) : (
-              <span className="inline-flex min-h-[2.25rem] items-center rounded-md border border-dashed border-base-200 px-3 text-sm text-base-content/40">
+              <span className={`inline-flex min-h-[2.25rem] items-center rounded-md border border-dashed border-base-200 px-3 text-sm ${financeTextClass.placeholder}`}>
                 -
               </span>
             )}
           </td>
           <td className="align-top">
             {hasChildren ? (
-              <span className="inline-flex min-h-[2.25rem] items-center text-base-content/40">
+              <span className={`inline-flex min-h-[2.25rem] items-center ${financeTextClass.placeholder}`}>
                 -
               </span>
             ) : (
@@ -727,7 +730,7 @@ function SnapshotEntryTreeTable({
                     />
                   </span>
                 ) : (
-                  <span className="inline-flex min-h-[2.25rem] items-center rounded-md border border-dashed border-base-200 px-3 text-sm text-base-content/40">
+                  <span className={`inline-flex min-h-[2.25rem] items-center rounded-md border border-dashed border-base-200 px-3 text-sm ${financeTextClass.placeholder}`}>
                     -
                   </span>
                 )}
@@ -758,13 +761,13 @@ function SnapshotEntryTreeTable({
 
   return (
     <div className="rounded-lg border border-base-200">
-      <div className="border-b border-base-200 bg-base-200/40 px-4 py-2 text-sm font-semibold text-base-content">
+      <div className={`border-b border-base-200 bg-base-200/40 px-4 py-2 ${financeTextClass.panelTitle}`}>
         {t("finance.snapshot.tableTitle")}
       </div>
       {treeNodes.length ? (
         <div className="overflow-x-auto p-3 pb-4">
           <table className="min-w-full text-sm">
-            <thead className="bg-base-200/60 text-left text-xs uppercase text-base-content/60">
+            <thead className={`text-left ${financeTextClass.tableHeader}`}>
               <tr>
                 <th className="w-[40%] min-w-[12rem] px-4 py-2">
                   {t("finance.snapshot.node")}
@@ -787,7 +790,7 @@ function SnapshotEntryTreeTable({
           </table>
         </div>
       ) : (
-        <div className="px-4 py-8 text-center text-sm text-base-content/60">
+        <div className={`px-4 py-8 text-center ${financeTextClass.helperText}`}>
           {t("finance.snapshot.noEntryNodes")}
         </div>
       )}
@@ -875,17 +878,17 @@ function AssetSummaryPanel({
   return (
     <div className="rounded-lg border border-base-300 bg-base-100">
       <div className="flex flex-wrap items-center justify-between gap-3 border-b border-base-200 px-3 py-2">
-        <h4 className="text-base font-semibold text-base-content">
+        <h4 className={financeTextClass.panelTitle}>
           {t("finance.metrics.assetSummary")}
         </h4>
-        <span className="text-right text-sm text-base-content/70" title={rateSnapshotTooltip}>
+        <span className={`text-right ${financeTextClass.bodyMuted}`} title={rateSnapshotTooltip}>
           {t("finance.rates.tabTitle")}
           <span className="ml-2 text-base-content">{rateSnapshotLabelText}</span>
         </span>
       </div>
       <div className="overflow-x-auto">
         <table className="table table-sm">
-          <thead className="bg-base-200/50 text-xs uppercase text-base-content/60">
+          <thead className={financeTextClass.tableHeader}>
             <tr>
               <th>{t("finance.snapshot.currency")}</th>
               <th className="text-right">{t("finance.snapshot.amount")}</th>
@@ -925,7 +928,7 @@ function AssetSummaryPanel({
                       />
                     </span>
                   ) : (
-                    <span className="text-base-content/40">-</span>
+                    <span className={financeTextClass.placeholder}>-</span>
                   )}
                 </td>
                 <td className="text-right">
@@ -937,11 +940,11 @@ function AssetSummaryPanel({
                       showCurrency={false}
                     />
                   ) : (
-                    <span className="text-base-content/40">-</span>
+                    <span className={financeTextClass.placeholder}>-</span>
                   )}
                 </td>
                 <td className="text-right tabular-nums">
-                  {row.share || <span className="text-base-content/40">-</span>}
+                  {row.share || <span className={financeTextClass.placeholder}>-</span>}
                 </td>
               </tr>
             ))}
@@ -949,12 +952,12 @@ function AssetSummaryPanel({
         </table>
       </div>
       <div className="flex items-center justify-end gap-3 border-t border-base-200 px-3 py-2">
-        <span className="text-sm font-medium text-base-content/70">
+        <span className={financeTextClass.inlineLabel}>
           {t("finance.metrics.totalValue")}
         </span>
         <span className="font-semibold">
           {totalValue === null ? (
-            <span className="text-base-content/40">-</span>
+            <span className={financeTextClass.placeholder}>-</span>
           ) : (
             <FinanceAmountText
               amount={formatNumberForAsset(totalValue, primaryCurrency, assets)}
@@ -1049,13 +1052,13 @@ export function SnapshotDetail({
 
       <div className="rounded-lg border border-base-300">
         <div className="border-b border-base-200 px-3 py-2">
-          <h4 className="text-base font-semibold text-base-content">
+          <h4 className={financeTextClass.panelTitle}>
             {t("finance.metrics.details")}
           </h4>
         </div>
         <div className="overflow-x-auto">
           <table className="table table-sm">
-            <thead className="bg-base-200/60 text-xs uppercase text-base-content/60">
+            <thead className={financeTextClass.tableHeader}>
               <tr>
                 <th className="w-[40%] min-w-[12rem] px-4 py-2">
                   {t("finance.snapshot.node")}
@@ -1072,7 +1075,7 @@ export function SnapshotDetail({
                 <th className="min-w-[12rem]">{t("finance.snapshot.note")}</th>
               </tr>
             </thead>
-            <tbody className="align-top text-sm text-base-content/80">
+            <tbody className={financeTextClass.tableBody}>
               {visibleNodes.map((node) => {
                 const hasChildren = node.children.length > 0;
                 const isExpanded = expandedIds.has(node.id);
@@ -1115,7 +1118,7 @@ export function SnapshotDetail({
                         )}
                         <div className="min-w-0 space-y-1">
                           {hasNodeLabel ? (
-                            <span className="font-medium text-base-content">{node.name}</span>
+                            <span className={financeTextClass.rowTitle}>{node.name}</span>
                           ) : null}
                         </div>
                       </div>
@@ -1124,7 +1127,7 @@ export function SnapshotDetail({
                       {node.currencyCode ? (
                         <FinanceAssetSymbol symbol={node.currencyCode} />
                       ) : (
-                        <span className="text-base-content/40">-</span>
+                        <span className={financeTextClass.placeholder}>-</span>
                       )}
                     </td>
                     <td className="align-top">
@@ -1151,16 +1154,16 @@ export function SnapshotDetail({
                           showCurrency={false}
                         />
                       ) : (
-                        <span className="text-base-content/40">-</span>
+                        <span className={financeTextClass.placeholder}>-</span>
                       )}
                     </td>
                     <td className="align-top">
                       {node.note ? (
-                        <span className="block min-h-[2.25rem] text-sm text-base-content/80">
+                        <span className={`block min-h-[2.25rem] ${financeTextClass.bodyMuted}`}>
                           {node.note}
                         </span>
                       ) : (
-                        <span className="text-base-content/40">-</span>
+                        <span className={financeTextClass.placeholder}>-</span>
                       )}
                     </td>
                   </tr>
@@ -1168,7 +1171,7 @@ export function SnapshotDetail({
               })}
               {!visibleNodes.length ? (
                 <tr>
-                  <td colSpan={5} className="text-center text-base-content/60 py-6">
+                  <td colSpan={5} className={`text-center py-6 ${financeTextClass.helperText}`}>
                     {t("finance.history.noSelection")}
                   </td>
                 </tr>
@@ -1179,8 +1182,8 @@ export function SnapshotDetail({
       </div>
 
       {snapshotNote ? (
-        <div className="rounded-lg border border-dashed border-base-200 p-3 text-sm text-base-content/70">
-          <p className="font-medium text-base-content">{t("finance.snapshot.note")}</p>
+        <div className={`rounded-lg border border-dashed border-base-200 p-3 ${financeTextClass.bodyMuted}`}>
+          <p className={financeTextClass.rowTitle}>{t("finance.snapshot.note")}</p>
           <p className="mt-1 whitespace-pre-wrap">{snapshotNote}</p>
         </div>
       ) : null}

--- a/web/src/features/finance/SnapshotPanels.tsx
+++ b/web/src/features/finance/SnapshotPanels.tsx
@@ -761,7 +761,9 @@ function SnapshotEntryTreeTable({
 
   return (
     <div className="rounded-lg border border-base-200">
-      <div className={`border-b border-base-200 bg-base-200/40 px-4 py-2 ${financeTextClass.panelTitle}`}>
+      <div
+        className={`border-b border-base-200 bg-base-200/40 px-4 py-2 ${financeTextClass.sectionTitle}`}
+      >
         {t("finance.snapshot.tableTitle")}
       </div>
       {treeNodes.length ? (
@@ -878,7 +880,7 @@ function AssetSummaryPanel({
   return (
     <div className="rounded-lg border border-base-300 bg-base-100">
       <div className="flex flex-wrap items-center justify-between gap-3 border-b border-base-200 px-3 py-2">
-        <h4 className={financeTextClass.panelTitle}>
+        <h4 className={financeTextClass.sectionTitle}>
           {t("finance.metrics.assetSummary")}
         </h4>
         <span className={`text-right ${financeTextClass.bodyMuted}`} title={rateSnapshotTooltip}>
@@ -1052,7 +1054,7 @@ export function SnapshotDetail({
 
       <div className="rounded-lg border border-base-300">
         <div className="border-b border-base-200 px-3 py-2">
-          <h4 className={financeTextClass.panelTitle}>
+          <h4 className={financeTextClass.sectionTitle}>
             {t("finance.metrics.details")}
           </h4>
         </div>

--- a/web/src/features/finance/SnapshotPanels.tsx
+++ b/web/src/features/finance/SnapshotPanels.tsx
@@ -15,13 +15,13 @@ import type {
 } from "@/services/api/finance";
 import type { UUID } from "@/types/primitive";
 
+import { FinanceAmountListText, FinanceAmountText, FinanceAssetSymbol } from "./AmountText";
 import {
   dateToEndIso,
   dateToStartIso,
   assetDecimalPlaces,
   flattenTree,
   formatAmountForAsset,
-  formatMoney,
   formatNumberForAsset,
   isoToDateInput,
   isoToDateTimeLocal,
@@ -506,8 +506,6 @@ function SnapshotEntryTreeTable({
         : "";
       const displayConvertedAmount = hasChildren ? aggregatedAmount : defaultConvertedAmount;
       const defaultAmountNegative = isNegativeAmount(defaultAmount);
-      const nativeAggregatedNegative = isNegativeAmount(nativeAggregatedAmount);
-      const displayConvertedNegative = isNegativeAmount(displayConvertedAmount);
 
       const rows: React.ReactNode[] = [
         <tr
@@ -548,22 +546,19 @@ function SnapshotEntryTreeTable({
             </div>
           </td>
           <td className="align-top text-center">
-            <span className="inline-flex min-h-[2.25rem] items-center text-base-content/70">
-              {defaultCurrency}
+            <span className="inline-flex min-h-[2.25rem] items-center">
+              {hasChildren ? (
+                <span className="text-base-content/40">-</span>
+              ) : (
+                <FinanceAssetSymbol symbol={defaultCurrency} />
+              )}
             </span>
           </td>
           <td className="align-top">
             {hasChildren ? (
               <div className="flex min-w-[12rem] items-start gap-2">
-                <div
-                  className={[
-                    "min-h-[2.25rem] flex-1 rounded-md border border-dashed border-base-200 px-3 py-2 text-sm",
-                    nativeAggregatedNegative ? "text-error" : "text-base-content/80",
-                  ]
-                    .filter(Boolean)
-                    .join(" ")}
-                >
-                  {nativeAggregatedAmount || "-"}
+                <div className="min-h-[2.25rem] flex-1 rounded-md border border-dashed border-base-200 px-3 py-2 text-sm">
+                  <FinanceAmountListText value={nativeAggregatedAmount} />
                 </div>
                 <ActionButton
                   label=""
@@ -586,7 +581,7 @@ function SnapshotEntryTreeTable({
                   inputMode="decimal"
                   pattern={amountInputPattern(assetDecimalPlaces(assets, defaultCurrency))}
                   size="sm"
-                  className={defaultAmountNegative ? "text-error" : "text-base-content"}
+                  className={defaultAmountNegative ? "text-warning" : "text-base-content"}
                   value={defaultAmount}
                   onChange={(event) =>
                     onChangeHolding(node.id, defaultHolding?.id ?? "", {
@@ -615,15 +610,11 @@ function SnapshotEntryTreeTable({
           </td>
           <td className="align-top">
             {displayConvertedAmount ? (
-              <span
-                className={[
-                  "inline-flex min-h-[2.25rem] items-center rounded-md border border-dashed border-base-200 px-3 text-sm",
-                  displayConvertedNegative ? "text-error" : "text-base-content/80",
-                ]
-                  .filter(Boolean)
-                  .join(" ")}
-              >
-                {displayConvertedAmount}
+              <span className="inline-flex min-h-[2.25rem] items-center rounded-md border border-dashed border-base-200 px-3 text-sm">
+                <FinanceAmountText
+                  amount={displayConvertedAmount}
+                  currencyCode={primaryCurrency}
+                />
               </span>
             ) : (
               <span className="inline-flex min-h-[2.25rem] items-center rounded-md border border-dashed border-base-200 px-3 text-sm text-base-content/40">
@@ -671,7 +662,6 @@ function SnapshotEntryTreeTable({
               : ""
             : "";
           const amountNegative = isNegativeAmount(holding.amount);
-          const holdingConvertedNegative = isNegativeAmount(convertedHoldingAmount);
           rows.push(
             <tr
               key={`${node.id}:${holding.id}`}
@@ -705,7 +695,7 @@ function SnapshotEntryTreeTable({
                       assetDecimalPlaces(assets, holdingPrecisionCurrency),
                     )}
                     size="sm"
-                    className={amountNegative ? "text-error" : "text-base-content"}
+                    className={amountNegative ? "text-warning" : "text-base-content"}
                     value={holding.amount}
                     onChange={(event) =>
                       onChangeHolding(node.id, holding.id, { amount: event.target.value })
@@ -728,15 +718,11 @@ function SnapshotEntryTreeTable({
               </td>
               <td className="align-top">
                 {convertedHoldingAmount ? (
-                  <span
-                    className={[
-                      "inline-flex min-h-[2.25rem] items-center rounded-md border border-dashed border-base-200 px-3 text-sm",
-                      holdingConvertedNegative ? "text-error" : "text-base-content/80",
-                    ]
-                      .filter(Boolean)
-                      .join(" ")}
-                  >
-                    {convertedHoldingAmount}
+                  <span className="inline-flex min-h-[2.25rem] items-center rounded-md border border-dashed border-base-200 px-3 text-sm">
+                    <FinanceAmountText
+                      amount={convertedHoldingAmount}
+                      currencyCode={primaryCurrency}
+                    />
                   </span>
                 ) : (
                   <span className="inline-flex min-h-[2.25rem] items-center rounded-md border border-dashed border-base-200 px-3 text-sm text-base-content/40">
@@ -912,28 +898,42 @@ function AssetSummaryPanel({
           <tbody>
             {rowsWithShare.map((row) => (
               <tr key={row.currency}>
-                <td className="font-medium">{row.currency}</td>
-                <td className={`text-right tabular-nums ${amountToneClass(row.numericAmount)}`}>
-                  {row.amount}
+                <td>
+                  <FinanceAssetSymbol symbol={row.currency} />
                 </td>
-                <td className="text-right tabular-nums">
+                <td className="text-right">
+                  <FinanceAmountText
+                    amount={row.amount}
+                    currencyCode={row.currency}
+                    value={row.numericAmount}
+                    showCurrency={false}
+                  />
+                </td>
+                <td className="text-right">
                   {row.rateInfo ? (
                     <span title={rateInfoTooltip(row.rateInfo, assets)}>
-                      {formatAmountForAsset(
-                        row.rateInfo.rate,
-                        row.rateInfo.quoteCurrency,
-                        assets,
-                      )}
+                      <FinanceAmountText
+                        amount={formatAmountForAsset(
+                          row.rateInfo.rate,
+                          row.rateInfo.quoteCurrency,
+                          assets,
+                        )}
+                        currencyCode={row.rateInfo.quoteCurrency}
+                        value={Number(row.rateInfo.rate)}
+                        showCurrency={false}
+                      />
                     </span>
                   ) : (
                     <span className="text-base-content/40">-</span>
                   )}
                 </td>
-                <td className="text-right tabular-nums">
+                <td className="text-right">
                   {row.convertedAmount ? (
-                    <span className={amountToneClass(row.convertedValue)}>
-                      {row.convertedAmount} {primaryCurrency}
-                    </span>
+                    <FinanceAmountText
+                      amount={row.convertedAmount}
+                      currencyCode={primaryCurrency}
+                      value={row.convertedValue}
+                    />
                   ) : (
                     <span className="text-base-content/40">-</span>
                   )}
@@ -950,10 +950,16 @@ function AssetSummaryPanel({
         <span className="text-sm font-medium text-base-content/70">
           {t("finance.metrics.totalValue")}
         </span>
-        <span className={`font-semibold tabular-nums ${amountToneClass(totalValue)}`}>
-          {totalValue === null
-            ? "-"
-            : `${formatNumberForAsset(totalValue, primaryCurrency, assets)} ${primaryCurrency}`}
+        <span className="font-semibold">
+          {totalValue === null ? (
+            <span className="text-base-content/40">-</span>
+          ) : (
+            <FinanceAmountText
+              amount={formatNumberForAsset(totalValue, primaryCurrency, assets)}
+              currencyCode={primaryCurrency}
+              value={totalValue}
+            />
+          )}
         </span>
       </div>
     </div>
@@ -1068,20 +1074,6 @@ export function SnapshotDetail({
                 const isExpanded = expandedIds.has(node.id);
                 const hasNodeLabel = node.name.trim().length > 0;
                 const isAggregateRow = hasChildren || node.isAutoGenerated;
-                const originalAmount = parseDisplayAmount(node.amount);
-                const convertedAmount = parseDisplayAmount(node.amountConverted);
-                const originalAmountClass =
-                  originalAmount > 0
-                    ? "text-success"
-                    : originalAmount < 0
-                      ? "text-error"
-                      : "text-base-content";
-                const convertedAmountClass =
-                  convertedAmount > 0
-                    ? "text-success"
-                    : convertedAmount < 0
-                      ? "text-error"
-                      : "text-base-content";
 
                 return (
                   <tr
@@ -1124,19 +1116,35 @@ export function SnapshotDetail({
                         </div>
                       </div>
                     </td>
-                    <td className="align-top text-center text-base-content/70">
-                      {(node.currencyCode || snapshot.primary_currency).toUpperCase()}
+                    <td className="align-top text-center">
+                      {node.currencyCode ? (
+                        <FinanceAssetSymbol symbol={node.currencyCode} />
+                      ) : (
+                        <span className="text-base-content/40">-</span>
+                      )}
                     </td>
                     <td className="align-top">
-                      <span className={`tabular-nums ${originalAmountClass}`}>
-                        {node.amount || "-"}
-                      </span>
+                      {node.currencyCode ? (
+                        <FinanceAmountText
+                          amount={node.amount}
+                          currencyCode={node.currencyCode}
+                          showCurrency={false}
+                        />
+                      ) : (
+                        <FinanceAmountListText value={node.amount} />
+                      )}
                     </td>
                     <td className="align-top">
                       {usesConvertedAggregation && node.amountConverted ? (
-                        <span className={`tabular-nums ${convertedAmountClass}`}>
-                          {formatMoney(node.amountConverted, snapshot.primary_currency, assets)}
-                        </span>
+                        <FinanceAmountText
+                          amount={formatAmountForAsset(
+                            node.amountConverted,
+                            snapshot.primary_currency,
+                            assets,
+                          )}
+                          currencyCode={snapshot.primary_currency}
+                          value={parseDisplayAmount(node.amountConverted)}
+                        />
                       ) : (
                         <span className="text-base-content/40">-</span>
                       )}
@@ -1760,19 +1768,6 @@ function sumSnapshotNodeAmounts(
 function isNegativeAmount(value: string | null | undefined): boolean {
   const numeric = parseDisplayAmount(value ?? "");
   return Number.isFinite(numeric) && numeric < 0;
-}
-
-function amountToneClass(value: number | null | undefined): string {
-  if (typeof value !== "number" || !Number.isFinite(value)) {
-    return "text-base-content";
-  }
-  if (value > 0) {
-    return "text-success";
-  }
-  if (value < 0) {
-    return "text-error";
-  }
-  return "text-base-content";
 }
 
 function parseDisplayAmount(value: string): number {

--- a/web/src/features/finance/__tests__/AmountText.test.tsx
+++ b/web/src/features/finance/__tests__/AmountText.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { FinanceAmountListText, FinanceAmountText } from "@/features/finance/AmountText";
+
+describe("FinanceAmountText", () => {
+  it("uses normal text color for positive values and subdues decimals and symbols", () => {
+    render(<FinanceAmountText amount="123.4500" currencyCode="USD" />);
+
+    expect(screen.getByText("123").className).toContain("font-medium");
+    expect(screen.getByText(".4500").className).toContain("opacity-65");
+    expect(screen.getByText("USD").className).toContain("opacity-65");
+    expect(screen.getByText("123").parentElement?.className).toContain("text-base-content");
+    expect(screen.getByText("123").parentElement?.className).not.toContain("text-warning");
+  });
+
+  it("uses warning text color for negative values", () => {
+    render(<FinanceAmountText amount="-42.50" currencyCode="CNY" />);
+
+    expect(screen.getByText("-42").parentElement?.className).toContain("text-warning");
+    expect(screen.getByText("CNY").className).not.toContain("text-base-content");
+  });
+});
+
+describe("FinanceAmountListText", () => {
+  it("renders comma-separated finance amount pairs with the shared amount style", () => {
+    render(<FinanceAmountListText value="10.00 USD, -2.50 BTC" />);
+
+    const usd = screen.getByText("USD");
+    const btc = screen.getByText("BTC");
+
+    expect(within(usd.parentElement as HTMLElement).getByText("10").className).toContain(
+      "font-medium",
+    );
+    expect(within(btc.parentElement as HTMLElement).getByText("-2").parentElement?.className).toContain(
+      "text-warning",
+    );
+  });
+});

--- a/web/src/features/finance/__tests__/AmountText.test.tsx
+++ b/web/src/features/finance/__tests__/AmountText.test.tsx
@@ -4,20 +4,22 @@ import { describe, expect, it } from "vitest";
 import { FinanceAmountListText, FinanceAmountText } from "@/features/finance/AmountText";
 
 describe("FinanceAmountText", () => {
-  it("uses normal text color for positive values and subdues decimals and symbols", () => {
+  it("keeps the full numeric text visually continuous and subdues only symbols", () => {
     render(<FinanceAmountText amount="123.4500" currencyCode="USD" />);
 
-    expect(screen.getByText("123").className).toContain("font-medium");
-    expect(screen.getByText(".4500").className).toContain("opacity-65");
+    expect(screen.getByText("123.4500").className).toContain("font-medium");
+    expect(screen.queryByText(".4500")).toBeNull();
     expect(screen.getByText("USD").className).toContain("opacity-65");
-    expect(screen.getByText("123").parentElement?.className).toContain("text-base-content");
-    expect(screen.getByText("123").parentElement?.className).not.toContain("text-warning");
+    expect(screen.getByText("123.4500").parentElement?.className).toContain(
+      "text-base-content",
+    );
+    expect(screen.getByText("123.4500").parentElement?.className).not.toContain("text-warning");
   });
 
   it("uses warning text color for negative values", () => {
     render(<FinanceAmountText amount="-42.50" currencyCode="CNY" />);
 
-    expect(screen.getByText("-42").parentElement?.className).toContain("text-warning");
+    expect(screen.getByText("-42.50").parentElement?.className).toContain("text-warning");
     expect(screen.getByText("CNY").className).not.toContain("text-base-content");
   });
 });
@@ -29,11 +31,11 @@ describe("FinanceAmountListText", () => {
     const usd = screen.getByText("USD");
     const btc = screen.getByText("BTC");
 
-    expect(within(usd.parentElement as HTMLElement).getByText("10").className).toContain(
+    expect(within(usd.parentElement as HTMLElement).getByText("10.00").className).toContain(
       "font-medium",
     );
-    expect(within(btc.parentElement as HTMLElement).getByText("-2").parentElement?.className).toContain(
-      "text-warning",
-    );
+    expect(
+      within(btc.parentElement as HTMLElement).getByText("-2.50").parentElement?.className,
+    ).toContain("text-warning");
   });
 });

--- a/web/src/features/finance/__tests__/utils.test.ts
+++ b/web/src/features/finance/__tests__/utils.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { snapshotLabel } from "@/features/finance/utils";
-import type { FinanceSnapshot } from "@/services/api/finance";
+import { rateSnapshotLabel, snapshotLabel } from "@/features/finance/utils";
+import type { FinanceRateSnapshot, FinanceSnapshot } from "@/services/api/finance";
 
 const baseSnapshot = {
   id: "snapshot-1",
@@ -30,5 +30,25 @@ describe("finance snapshot labels", () => {
         title: " ",
       } as FinanceSnapshot),
     ).not.toBe(" ");
+  });
+});
+
+describe("finance rate snapshot labels", () => {
+  it("uses only the captured timestamp", () => {
+    const label = rateSnapshotLabel({
+      id: "rate-snapshot-1",
+      captured_at: "2026-06-25T12:00:00.000Z",
+      source: "manual",
+      entries: [
+        {
+          id: "rate-entry-1",
+          base_currency: "BTC",
+          quote_currency: "USDT",
+          rate: "100000",
+        },
+      ],
+    } as FinanceRateSnapshot);
+
+    expect(label).not.toContain("BTC/USDT");
   });
 });

--- a/web/src/features/finance/styles.ts
+++ b/web/src/features/finance/styles.ts
@@ -1,0 +1,12 @@
+export const financeTextClass = {
+  moduleTitle: "text-base font-semibold text-base-content",
+  panelTitle: "text-base font-semibold text-base-content",
+  rowTitle: "font-medium text-base-content",
+  inlineLabel: "text-sm font-medium text-base-content/70",
+  bodyMuted: "text-sm text-base-content/70",
+  helperText: "text-sm text-base-content/60",
+  fieldLabel: "text-xs uppercase text-base-content/60",
+  tableHeader: "bg-base-200/60 text-xs uppercase text-base-content/60",
+  tableBody: "align-top text-sm text-base-content/80",
+  placeholder: "text-base-content/40",
+};

--- a/web/src/features/finance/styles.ts
+++ b/web/src/features/finance/styles.ts
@@ -1,7 +1,8 @@
 export const financeTextClass = {
   moduleTitle: "text-base font-semibold text-base-content",
-  panelTitle: "text-base font-semibold text-base-content",
+  sectionTitle: "text-base font-semibold text-base-content",
   rowTitle: "font-medium text-base-content",
+  treeNodeTitle: "text-sm font-medium text-base-content",
   inlineLabel: "text-sm font-medium text-base-content/70",
   bodyMuted: "text-sm text-base-content/70",
   helperText: "text-sm text-base-content/60",

--- a/web/src/features/finance/styles.ts
+++ b/web/src/features/finance/styles.ts
@@ -3,6 +3,7 @@ export const financeTextClass = {
   sectionTitle: "text-base font-semibold text-base-content",
   rowTitle: "font-medium text-base-content",
   treeNodeTitle: "text-sm font-medium text-base-content",
+  treeNodeSymbol: "text-xs",
   inlineLabel: "text-sm font-medium text-base-content/70",
   bodyMuted: "text-sm text-base-content/70",
   helperText: "text-sm text-base-content/60",

--- a/web/src/features/finance/utils.ts
+++ b/web/src/features/finance/utils.ts
@@ -183,12 +183,7 @@ export function snapshotLabel(snapshot: FinanceSnapshot) {
 }
 
 export function rateSnapshotLabel(snapshot: FinanceRateSnapshot) {
-  const pairs = (snapshot.entries ?? [])
-    .map((entry) => `${entry.base_currency}/${entry.quote_currency}`)
-    .join(", ");
-  return pairs
-    ? `${formatDateTime(snapshot.captured_at)} · ${pairs}`
-    : formatDateTime(snapshot.captured_at);
+  return formatDateTime(snapshot.captured_at);
 }
 
 export function getRequiredRateCurrencies(

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -1404,7 +1404,7 @@
       "net": "Net",
       "entries": "Entries",
       "amountsByCurrency": "Amounts by currency",
-      "assetSummary": "Asset summary",
+      "assetSummary": "Summary",
       "summary": "Summary",
       "details": "Details",
       "convertTo": "Convert to {{currency}}",

--- a/web/src/locales/zh/common.json
+++ b/web/src/locales/zh/common.json
@@ -1404,7 +1404,7 @@
       "net": "净额",
       "entries": "条目",
       "amountsByCurrency": "按币种汇总",
-      "assetSummary": "资产汇总",
+      "assetSummary": "汇总",
       "summary": "汇总",
       "details": "详情",
       "convertTo": "换算为 {{currency}}",

--- a/web/src/pages/FinancePage.tsx
+++ b/web/src/pages/FinancePage.tsx
@@ -1441,7 +1441,7 @@ function TreeNodeRow({
           onClick={() => onToggleNode(node.id)}
         />
         <div className="min-w-0 flex flex-1 items-center gap-2">
-          <span className={`truncate ${financeTextClass.rowTitle}`}>{node.name}</span>
+          <span className={`truncate ${financeTextClass.treeNodeTitle}`}>{node.name}</span>
           <span className="shrink-0">
             <FinanceAssetSymbol symbol={node.currency_code || "-"} />
           </span>

--- a/web/src/pages/FinancePage.tsx
+++ b/web/src/pages/FinancePage.tsx
@@ -1443,7 +1443,10 @@ function TreeNodeRow({
         <div className="min-w-0 flex flex-1 items-center gap-2">
           <span className={`truncate ${financeTextClass.treeNodeTitle}`}>{node.name}</span>
           <span className="shrink-0">
-            <FinanceAssetSymbol symbol={node.currency_code || "-"} />
+            <FinanceAssetSymbol
+              symbol={node.currency_code || "-"}
+              className={financeTextClass.treeNodeSymbol}
+            />
           </span>
         </div>
         <ActionButton

--- a/web/src/pages/FinancePage.tsx
+++ b/web/src/pages/FinancePage.tsx
@@ -59,6 +59,8 @@ import {
   SnapshotNavigator,
   SnapshotSelectorToolbar,
 } from "@/features/finance/SnapshotChrome";
+import { FinanceAssetSymbol } from "@/features/finance/AmountText";
+import { financeTextClass } from "@/features/finance/styles";
 import { useFinanceAssetSource } from "@/features/finance/useFinanceAssetSource";
 
 const PRESETS: PresetConfig[] = [
@@ -364,7 +366,9 @@ function FinancePresetWorkspace({ preset }: { preset: PresetConfig }) {
 
   if (!tree) {
     return (
-      <div className="rounded-2xl border border-dashed border-base-200 bg-base-100 p-8 text-center text-sm text-base-content/70">
+      <div
+        className={`rounded-2xl border border-dashed border-base-200 bg-base-100 p-8 text-center ${financeTextClass.bodyMuted}`}
+      >
         <p>{t("finance.tree.noTrees")}</p>
       </div>
     );
@@ -800,7 +804,9 @@ function FinanceTreesWorkspace() {
             </div>
           </>
         ) : (
-          <div className="rounded-lg border border-dashed border-base-300 p-6 text-center text-sm text-base-content/60">
+          <div
+            className={`rounded-lg border border-dashed border-base-300 p-6 text-center ${financeTextClass.helperText}`}
+          >
             {t("finance.tree.noTrees")}
           </div>
         )}
@@ -932,7 +938,7 @@ function FinanceTreeFormPanel({
           />
         </FormField>
       </div>
-      <label className="flex items-center gap-2 text-sm text-base-content/80">
+      <label className={`flex items-center gap-2 ${financeTextClass.bodyMuted}`}>
         <input
           type="checkbox"
           className="checkbox checkbox-sm"
@@ -1045,7 +1051,9 @@ function SnapshotModule({
     }
 
     return (
-      <div className="rounded-2xl border border-dashed border-base-200 bg-base-100 p-8 text-center text-sm text-base-content/70">
+      <div
+        className={`rounded-2xl border border-dashed border-base-200 bg-base-100 p-8 text-center ${financeTextClass.bodyMuted}`}
+      >
         <p>{t("finance.history.empty")}</p>
         <div className="mt-4 flex justify-center">
           <CreateNewButton
@@ -1125,7 +1133,7 @@ function SnapshotModule({
                 rateSnapshots={rateSnapshots}
               />
             ) : (
-              <p className="py-4 text-sm text-base-content/70">
+              <p className={`py-4 ${financeTextClass.bodyMuted}`}>
                 {t("finance.history.noSelection")}
               </p>
             )}
@@ -1155,7 +1163,7 @@ function FinanceTreeManagerPanel({
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <p className="text-sm text-base-content/60">{t("finance.tree.manageHint")}</p>
+        <p className={financeTextClass.helperText}>{t("finance.tree.manageHint")}</p>
         <CreateNewButton
           label={t("finance.tree.addNode")}
           onClick={onCreateRootNode}
@@ -1363,7 +1371,9 @@ function FinanceTreeView({
 
   if (!treeNodes.length) {
     return (
-      <div className="rounded-lg border border-dashed border-base-300 bg-base-100 p-6 text-center text-sm text-base-content/60">
+      <div
+        className={`rounded-lg border border-dashed border-base-300 bg-base-100 p-6 text-center ${financeTextClass.helperText}`}
+      >
         {t("finance.tree.empty")}
       </div>
     );
@@ -1431,8 +1441,10 @@ function TreeNodeRow({
           onClick={() => onToggleNode(node.id)}
         />
         <div className="min-w-0 flex flex-1 items-center gap-2">
-          <span className="font-medium truncate">{node.name}</span>
-          <span className="shrink-0 text-xs text-base-content/60">{node.currency_code || "-"}</span>
+          <span className={`truncate ${financeTextClass.rowTitle}`}>{node.name}</span>
+          <span className="shrink-0">
+            <FinanceAssetSymbol symbol={node.currency_code || "-"} />
+          </span>
         </div>
         <ActionButton
           label=""

--- a/web/src/services/api/__tests__/notes.test.ts
+++ b/web/src/services/api/__tests__/notes.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ENDPOINTS } from "@/services/api/endpoints";
+import { notesApi } from "@/services/api/notes";
+
+const localUrl = (path: string) => new URL(path, "http://localhost").toString();
+
+describe("notesApi", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("loads note tag and person usage into note stats", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const url = String(input);
+      if (url.startsWith(localUrl(ENDPOINTS.NOTES.BASE))) {
+        if (url === localUrl(ENDPOINTS.NOTES.STATS_PERSONS)) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                person_stats: [
+                  {
+                    id: "22222222-2222-2222-2222-222222222222",
+                    name: "Alice",
+                    display_name: "Alice",
+                    usage_count: 1,
+                  },
+                ],
+                total_persons: 1,
+              }),
+              {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+              },
+            ),
+          );
+        }
+
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              items: [],
+              pagination: { page: 1, size: 1, total: 3, pages: 3 },
+              meta: {},
+            }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          ),
+        );
+      }
+
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            entity_type: "note",
+            tag_stats: [
+              {
+                id: "11111111-1111-1111-1111-111111111111",
+                usage_count: 2,
+              },
+            ],
+            total_tags: 1,
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      );
+    });
+
+    const stats = await notesApi.getStats();
+
+    expect(stats.total_notes).toBe(3);
+    expect(stats.tag_stats).toEqual([
+      {
+        id: "11111111-1111-1111-1111-111111111111",
+        name: "",
+        usage_count: 2,
+      },
+    ]);
+    expect(stats.person_stats).toEqual([
+      {
+        id: "22222222-2222-2222-2222-222222222222",
+        name: "Alice",
+        display_name: "Alice",
+        usage_count: 1,
+      },
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const requestedUrls = fetchMock.mock.calls.map(([url]) => String(url));
+    expect(requestedUrls.some((url) => url.startsWith(localUrl(ENDPOINTS.NOTES.BASE)))).toBe(true);
+    expect(requestedUrls).toContain(localUrl(ENDPOINTS.STATS.TAGS_USAGE("note")));
+    expect(requestedUrls).toContain(localUrl(ENDPOINTS.NOTES.STATS_PERSONS));
+  });
+});

--- a/web/src/services/api/endpoints.ts
+++ b/web/src/services/api/endpoints.ts
@@ -114,9 +114,7 @@ export const ENDPOINTS = {
     DAY_BREAKDOWN: `${API_V1}/stats/day-breakdown`,
     AGGREGATED_AREAS: `${API_V1}/stats/aggregated-areas`,
     DAILY_AREAS_RECOMPUTE: `${API_V1}/stats/daily-areas/recompute`,
-    NOTES_TOTAL: `${API_V1}/stats/notes/total`,
     TAGS_USAGE: (entityType: string) =>
       `${API_V1}/stats/tags/usage/${entityType}`,
-    TAGS_USAGE_NOTE: `${API_V1}/stats/tags/usage/note`,
   },
 } as const;

--- a/web/src/services/api/notes.ts
+++ b/web/src/services/api/notes.ts
@@ -1,7 +1,7 @@
 import { http } from "./client";
 import { ENDPOINTS } from "./endpoints";
 import type { PersonSummary } from "./types/common";
-import type { Tag } from "./tags";
+import { tagsApi, type Tag } from "./tags";
 import type { UUID } from "@/types/primitive";
 import type { ListResponse } from "@/types/pagination";
 
@@ -122,6 +122,11 @@ export interface NoteStats {
     display_name: string;
     usage_count: number;
   }>;
+}
+
+interface NotePersonStatsResponse {
+  person_stats: NoteStats["person_stats"];
+  total_persons: number;
 }
 
 export type NoteTagFilterMode = "any" | "all" | "none";
@@ -273,11 +278,19 @@ export const notesApi = {
 
   // New method to get statistics (aggregated from split endpoints)
   getStats: async (): Promise<NoteStats> => {
-    const notes = await notesApi.fetchPaged({ page: 1, size: 1 });
+    const [notes, tagUsage, personUsage] = await Promise.all([
+      notesApi.fetchPaged({ page: 1, size: 1 }),
+      tagsApi.getStatsBatch("note"),
+      http.get<NotePersonStatsResponse>(ENDPOINTS.NOTES.STATS_PERSONS),
+    ]);
     return {
       total_notes: notes.pagination.total,
-      tag_stats: [],
-      person_stats: [],
+      tag_stats: tagUsage.tag_stats.map((tagStat) => ({
+        id: tagStat.id,
+        name: tagStat.name ?? "",
+        usage_count: tagStat.usage_count,
+      })),
+      person_stats: personUsage.person_stats,
     };
   },
 


### PR DESCRIPTION
## 背景

本 PR 修复 finance 页面汇率快照展示细节，并修复 notes 页面右侧栏统计数据不准确的问题。

Closes #188

## 变更

- 汇率快照标题只显示采集时间，避免汇率对过多导致标题过长。
- 汇率快照详情改为上方展示公共属性，下方逐行展示汇率。
- 新增 finance 专用金额展示组件，统一汇率快照、资产汇总、快照详情中的 amount / asset symbol 样式。
- finance 金额展示改为 DaisyUI 兼容规则：正数和普通文本一致，负数使用 `text-warning`；asset symbol 通过字重/透明度弱化，数值本身保持连续一致渲染。
- 收敛 finance 页面 typography：统一导航/面板标题、表格表头、字段标签、空态、弱化文本和占位符样式，减少单页内零散字号细节。
- 资产负债表/现金流页的汇总与详情标题层级保持一致；汇总区移除重复小标题。
- 换算列统一使用“换算为 {{currency}}”表头，单元格只显示数值，不重复显示资产 symbol。
- notes 统计接入真实 tag usage 与 person usage，修复右侧 tag 数量和关联人员为空的问题。
- 修复 note tag filter 查询中的 `tag_associations` / `tags` 笛卡尔积 warning。
- 清理未使用且无实现/重复的 stats endpoint 常量。

## 验证

- `npm --prefix web run lint`
- `npm --prefix web run typecheck:test`
- `npm --prefix web run test -- src/features/finance/__tests__/AmountText.test.tsx src/features/finance/__tests__/utils.test.ts`
- `npm --prefix web run test -- src/services/api/__tests__/notes.test.ts src/services/api/__tests__/tags.test.ts src/features/finance/__tests__/utils.test.ts`
- `uv run pytest tests/test_note_services.py tests/test_web_cli.py -k "note_usage_by_person or cartesian_product or note_person_usage_stats"`
- `npm --prefix web run build`
- `bash ./scripts/doctor.sh`

## 风险与说明

- notes 人员统计新增 `/notes/stats/persons`，只统计 active note 与 active person 的 `is_about` 关联。
- 本 PR 没有改动数据库 schema。
