### PR TITLE
enhance: Persist web preferences and refine people management

### DIFF
--- a/src/lifeos_cli/application/configuration.py
+++ b/src/lifeos_cli/application/configuration.py
@@ -25,11 +25,17 @@ from lifeos_cli.config import (
     normalize_database_schema,
     parse_boolean_value,
     resolve_config_path,
+    validate_calendar_first_day_of_week,
+    validate_calendar_system,
     validate_database_url,
     validate_day_starts_at,
     validate_language,
+    validate_navigation_visible_modules,
+    validate_notes_card_min_collapsed_lines,
+    validate_tasks_default_planning_preset,
     validate_theme,
     validate_timezone_name,
+    validate_todos_default_inbox_vision,
     validate_vision_experience_rate_per_hour,
     validate_week_starts_on,
     write_database_settings,
@@ -72,6 +78,16 @@ SUPPORTED_CONFIG_KEYS = (
     "preferences.week_starts_on",
     "preferences.vision_experience_rate_per_hour",
     "preferences.theme",
+    "preferences.calendar_first_day_of_week",
+    "preferences.calendar_system",
+    "preferences.navigation_visible_modules",
+    "preferences.notes_card_min_collapsed_lines",
+    "preferences.notes_export_planning_include_cycle_notes",
+    "preferences.notes_export_planning_include_task_notes",
+    "preferences.planning_show_habit_actions",
+    "preferences.tasks_default_planning_preset",
+    "preferences.timelog_auto_set_task_planning",
+    "preferences.todos_default_inbox_vision",
 )
 
 
@@ -184,6 +200,18 @@ def build_preferences_settings(request: InitializationRequest) -> PreferencesSet
         ),
         config_file=config_path,
         theme=validate_theme(current.theme),
+        calendar_first_day_of_week=current.calendar_first_day_of_week,
+        calendar_system=current.calendar_system,
+        navigation_visible_modules=current.navigation_visible_modules,
+        notes_card_min_collapsed_lines=current.notes_card_min_collapsed_lines,
+        notes_export_planning_include_cycle_notes=(
+            current.notes_export_planning_include_cycle_notes
+        ),
+        notes_export_planning_include_task_notes=current.notes_export_planning_include_task_notes,
+        planning_show_habit_actions=current.planning_show_habit_actions,
+        tasks_default_planning_preset=current.tasks_default_planning_preset,
+        timelog_auto_set_task_planning=current.timelog_auto_set_task_planning,
+        todos_default_inbox_vision=current.todos_default_inbox_vision,
     )
 
 
@@ -276,6 +304,68 @@ def set_runtime_config_value(
         preferences_settings = replace(
             preferences_settings,
             theme=validate_theme(value),
+        )
+    elif normalized_key == "preferences.calendar_first_day_of_week":
+        preferences_settings = replace(
+            preferences_settings,
+            calendar_first_day_of_week=validate_calendar_first_day_of_week(value),
+        )
+    elif normalized_key == "preferences.calendar_system":
+        preferences_settings = replace(
+            preferences_settings,
+            calendar_system=validate_calendar_system(value),
+        )
+    elif normalized_key == "preferences.navigation_visible_modules":
+        preferences_settings = replace(
+            preferences_settings,
+            navigation_visible_modules=validate_navigation_visible_modules(value),
+        )
+    elif normalized_key == "preferences.notes_card_min_collapsed_lines":
+        preferences_settings = replace(
+            preferences_settings,
+            notes_card_min_collapsed_lines=validate_notes_card_min_collapsed_lines(value),
+        )
+    elif normalized_key == "preferences.notes_export_planning_include_cycle_notes":
+        preferences_settings = replace(
+            preferences_settings,
+            notes_export_planning_include_cycle_notes=parse_boolean_value(
+                value,
+                field_name="Config key `preferences.notes_export_planning_include_cycle_notes`",
+            ),
+        )
+    elif normalized_key == "preferences.notes_export_planning_include_task_notes":
+        preferences_settings = replace(
+            preferences_settings,
+            notes_export_planning_include_task_notes=parse_boolean_value(
+                value,
+                field_name="Config key `preferences.notes_export_planning_include_task_notes`",
+            ),
+        )
+    elif normalized_key == "preferences.planning_show_habit_actions":
+        preferences_settings = replace(
+            preferences_settings,
+            planning_show_habit_actions=parse_boolean_value(
+                value,
+                field_name="Config key `preferences.planning_show_habit_actions`",
+            ),
+        )
+    elif normalized_key == "preferences.tasks_default_planning_preset":
+        preferences_settings = replace(
+            preferences_settings,
+            tasks_default_planning_preset=validate_tasks_default_planning_preset(value),
+        )
+    elif normalized_key == "preferences.timelog_auto_set_task_planning":
+        preferences_settings = replace(
+            preferences_settings,
+            timelog_auto_set_task_planning=parse_boolean_value(
+                value,
+                field_name="Config key `preferences.timelog_auto_set_task_planning`",
+            ),
+        )
+    elif normalized_key == "preferences.todos_default_inbox_vision":
+        preferences_settings = replace(
+            preferences_settings,
+            todos_default_inbox_vision=validate_todos_default_inbox_vision(value),
         )
 
     written_path = write_database_settings(

--- a/src/lifeos_cli/config.py
+++ b/src/lifeos_cli/config.py
@@ -36,6 +36,27 @@ DEFAULT_DAY_STARTS_AT = "00:00"
 DEFAULT_WEEK_STARTS_ON = "monday"
 DEFAULT_VISION_EXPERIENCE_RATE_PER_HOUR = 60
 DEFAULT_THEME = "system"
+DEFAULT_CALENDAR_FIRST_DAY_OF_WEEK = 1
+DEFAULT_CALENDAR_SYSTEM = "gregorian"
+DEFAULT_NAVIGATION_VISIBLE_MODULES = (
+    "visions",
+    "habits",
+    "planning",
+    "timelog",
+    "finance",
+    "insights",
+    "calendar",
+    "notes",
+    "persons",
+    "settings",
+)
+DEFAULT_NOTES_CARD_MIN_COLLAPSED_LINES = 5
+DEFAULT_NOTES_EXPORT_PLANNING_INCLUDE_CYCLE_NOTES = False
+DEFAULT_NOTES_EXPORT_PLANNING_INCLUDE_TASK_NOTES = True
+DEFAULT_PLANNING_SHOW_HABIT_ACTIONS = True
+DEFAULT_TASKS_DEFAULT_PLANNING_PRESET = "none"
+DEFAULT_TIMELOG_AUTO_SET_TASK_PLANNING = False
+DEFAULT_TODOS_DEFAULT_INBOX_VISION = None
 MAX_VISION_EXPERIENCE_RATE_PER_HOUR = 3600
 SUPPORTED_THEMES = (
     "system",
@@ -67,10 +88,17 @@ SUPPORTED_THEMES = (
     "coffee",
     "winter",
 )
+SUPPORTED_CALENDAR_SYSTEMS = ("gregorian", "mayan_13_moon")
+SUPPORTED_NAVIGATION_MODULES = DEFAULT_NAVIGATION_VISIBLE_MODULES
+SUPPORTED_NOTES_CARD_MIN_COLLAPSED_LINES = (3, 5, 7, 9, 11, 13, 15)
+SUPPORTED_TASKS_DEFAULT_PLANNING_PRESETS = ("none", "today", "this_week", "this_month")
 _SCHEMA_NAME_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _LANGUAGE_TAG_PATTERN = re.compile(r"^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$")
 _DAY_STARTS_AT_PATTERN = re.compile(r"^(?P<hour>[01]\d|2[0-3]):(?P<minute>[0-5]\d)$")
 _WEEK_STARTS_ON_VALUES = {"monday", "sunday"}
+_UUID_PATTERN = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
 
 
 class ConfigurationError(RuntimeError):
@@ -231,10 +259,12 @@ def _normalize_language_value(language: str) -> str:
 def validate_language(language: str) -> str:
     """Validate a language tag used for user-facing preferences."""
     normalized = _normalize_language_value(language)
+    if normalized.lower() == "auto":
+        return "auto"
     if not _LANGUAGE_TAG_PATTERN.match(normalized):
         raise ConfigurationError(
-            "Preference `language` must be a valid language tag such as `en`, "
-            "`en-CA`, or `zh-Hans`."
+            "Preference `language` must be `auto` or a valid language tag such as "
+            "`en`, `en-CA`, or `zh-Hans`."
         )
     return normalized
 
@@ -298,6 +328,100 @@ def validate_theme(value: str) -> str:
     return normalized
 
 
+def _parse_string_list(value: object, *, field_name: str) -> list[str]:
+    if isinstance(value, str):
+        normalized = value.strip()
+        if not normalized:
+            return []
+        return [item.strip() for item in normalized.split(",") if item.strip()]
+    if isinstance(value, list | tuple):
+        items: list[str] = []
+        for item in value:
+            if not isinstance(item, str):
+                raise ConfigurationError(f"Preference `{field_name}` must contain strings.")
+            items.append(item.strip())
+        return [item for item in items if item]
+    raise ConfigurationError(f"Preference `{field_name}` must be a list of strings.")
+
+
+def validate_calendar_first_day_of_week(value: int | str) -> int:
+    """Validate the preferred first day used by Web calendar views."""
+    if isinstance(value, bool):
+        raise ConfigurationError("Preference `calendar_first_day_of_week` must be an integer.")
+    try:
+        normalized = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ConfigurationError(
+            "Preference `calendar_first_day_of_week` must be an integer."
+        ) from exc
+    if normalized < 1 or normalized > 7:
+        raise ConfigurationError("Preference `calendar_first_day_of_week` must be between 1 and 7.")
+    return normalized
+
+
+def validate_calendar_system(value: str) -> str:
+    """Validate the preferred Web calendar system."""
+    normalized = value.strip()
+    if normalized not in SUPPORTED_CALENDAR_SYSTEMS:
+        supported = ", ".join(SUPPORTED_CALENDAR_SYSTEMS)
+        raise ConfigurationError(f"Preference `calendar_system` must be one of: {supported}.")
+    return normalized
+
+
+def validate_navigation_visible_modules(value: object) -> tuple[str, ...]:
+    """Validate the Web navigation module visibility preference."""
+    modules = _parse_string_list(value, field_name="navigation_visible_modules")
+    unsupported = [module for module in modules if module not in SUPPORTED_NAVIGATION_MODULES]
+    if unsupported:
+        supported = ", ".join(SUPPORTED_NAVIGATION_MODULES)
+        raise ConfigurationError(
+            "Preference `navigation_visible_modules` contains unsupported modules: "
+            f"{', '.join(unsupported)}. Supported modules: {supported}."
+        )
+    return tuple(dict.fromkeys(modules))
+
+
+def validate_notes_card_min_collapsed_lines(value: int | str) -> int:
+    """Validate the Web note card collapsed preview size."""
+    if isinstance(value, bool):
+        raise ConfigurationError("Preference `notes_card_min_collapsed_lines` must be an integer.")
+    try:
+        normalized = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ConfigurationError(
+            "Preference `notes_card_min_collapsed_lines` must be an integer."
+        ) from exc
+    if normalized not in SUPPORTED_NOTES_CARD_MIN_COLLAPSED_LINES:
+        supported = ", ".join(str(item) for item in SUPPORTED_NOTES_CARD_MIN_COLLAPSED_LINES)
+        raise ConfigurationError(
+            f"Preference `notes_card_min_collapsed_lines` must be one of: {supported}."
+        )
+    return normalized
+
+
+def validate_tasks_default_planning_preset(value: str) -> str:
+    """Validate the default planning preset for new Web tasks."""
+    normalized = value.strip()
+    if normalized not in SUPPORTED_TASKS_DEFAULT_PLANNING_PRESETS:
+        supported = ", ".join(SUPPORTED_TASKS_DEFAULT_PLANNING_PRESETS)
+        raise ConfigurationError(
+            f"Preference `tasks_default_planning_preset` must be one of: {supported}."
+        )
+    return normalized
+
+
+def validate_todos_default_inbox_vision(value: str | None) -> str | None:
+    """Validate the optional default inbox vision identifier used by Web planning."""
+    if value is None:
+        return None
+    normalized = value.strip()
+    if not normalized:
+        return None
+    if not _UUID_PATTERN.match(normalized):
+        raise ConfigurationError("Preference `todos_default_inbox_vision` must be a UUID when set.")
+    return normalized.lower()
+
+
 def _parse_bool(value: str) -> bool:
     normalized = value.strip().lower()
     return normalized in {"1", "true", "yes", "on"}
@@ -318,6 +442,10 @@ def _serialize_toml_string(value: str) -> str:
     return f'"{escaped}"'
 
 
+def _serialize_toml_string_list(values: tuple[str, ...]) -> str:
+    return f"[{', '.join(_serialize_toml_string(value) for value in values)}]"
+
+
 def _render_database_table(settings: DatabaseSettings) -> str:
     """Render the `[database]` TOML table for persisted settings."""
     lines = ["[database]"]
@@ -331,17 +459,36 @@ def _render_database_table(settings: DatabaseSettings) -> str:
 
 def _render_preferences_table(settings: PreferencesSettings) -> str:
     """Render the `[preferences]` TOML table for persisted settings."""
-    return "\n".join(
-        (
-            "[preferences]",
-            f"timezone = {_serialize_toml_string(settings.timezone)}",
-            f"language = {_serialize_toml_string(settings.language)}",
-            f"day_starts_at = {_serialize_toml_string(settings.day_starts_at)}",
-            f"week_starts_on = {_serialize_toml_string(settings.week_starts_on)}",
-            f"vision_experience_rate_per_hour = {settings.vision_experience_rate_per_hour}",
-            f"theme = {_serialize_toml_string(settings.theme)}",
+    lines = [
+        "[preferences]",
+        f"timezone = {_serialize_toml_string(settings.timezone)}",
+        f"language = {_serialize_toml_string(settings.language)}",
+        f"day_starts_at = {_serialize_toml_string(settings.day_starts_at)}",
+        f"week_starts_on = {_serialize_toml_string(settings.week_starts_on)}",
+        f"vision_experience_rate_per_hour = {settings.vision_experience_rate_per_hour}",
+        f"theme = {_serialize_toml_string(settings.theme)}",
+        f"calendar_first_day_of_week = {settings.calendar_first_day_of_week}",
+        f"calendar_system = {_serialize_toml_string(settings.calendar_system)}",
+        "navigation_visible_modules = "
+        f"{_serialize_toml_string_list(settings.navigation_visible_modules)}",
+        f"notes_card_min_collapsed_lines = {settings.notes_card_min_collapsed_lines}",
+        "notes_export_planning_include_cycle_notes = "
+        f"{'true' if settings.notes_export_planning_include_cycle_notes else 'false'}",
+        "notes_export_planning_include_task_notes = "
+        f"{'true' if settings.notes_export_planning_include_task_notes else 'false'}",
+        "planning_show_habit_actions = "
+        f"{'true' if settings.planning_show_habit_actions else 'false'}",
+        f"tasks_default_planning_preset = "
+        f"{_serialize_toml_string(settings.tasks_default_planning_preset)}",
+        f"timelog_auto_set_task_planning = "
+        f"{'true' if settings.timelog_auto_set_task_planning else 'false'}",
+    ]
+    if settings.todos_default_inbox_vision is not None:
+        lines.append(
+            "todos_default_inbox_vision = "
+            f"{_serialize_toml_string(settings.todos_default_inbox_vision)}"
         )
-    )
+    return "\n".join(lines)
 
 
 def _replace_top_level_table(existing_content: str, *, table_name: str, replacement: str) -> str:
@@ -524,6 +671,20 @@ class PreferencesSettings:
     vision_experience_rate_per_hour: int
     config_file: Path
     theme: str = DEFAULT_THEME
+    calendar_first_day_of_week: int = DEFAULT_CALENDAR_FIRST_DAY_OF_WEEK
+    calendar_system: str = DEFAULT_CALENDAR_SYSTEM
+    navigation_visible_modules: tuple[str, ...] = DEFAULT_NAVIGATION_VISIBLE_MODULES
+    notes_card_min_collapsed_lines: int = DEFAULT_NOTES_CARD_MIN_COLLAPSED_LINES
+    notes_export_planning_include_cycle_notes: bool = (
+        DEFAULT_NOTES_EXPORT_PLANNING_INCLUDE_CYCLE_NOTES
+    )
+    notes_export_planning_include_task_notes: bool = (
+        DEFAULT_NOTES_EXPORT_PLANNING_INCLUDE_TASK_NOTES
+    )
+    planning_show_habit_actions: bool = DEFAULT_PLANNING_SHOW_HABIT_ACTIONS
+    tasks_default_planning_preset: str = DEFAULT_TASKS_DEFAULT_PLANNING_PRESET
+    timelog_auto_set_task_planning: bool = DEFAULT_TIMELOG_AUTO_SET_TASK_PLANNING
+    todos_default_inbox_vision: str | None = DEFAULT_TODOS_DEFAULT_INBOX_VISION
 
     @classmethod
     def from_env(
@@ -548,6 +709,24 @@ class PreferencesSettings:
         file_week_starts_on = preference_values.get("week_starts_on")
         file_vision_experience_rate = preference_values.get("vision_experience_rate_per_hour")
         file_theme = preference_values.get("theme")
+        file_calendar_first_day_of_week = preference_values.get("calendar_first_day_of_week")
+        file_calendar_system = preference_values.get("calendar_system")
+        file_navigation_visible_modules = preference_values.get("navigation_visible_modules")
+        file_notes_card_min_collapsed_lines = preference_values.get(
+            "notes_card_min_collapsed_lines"
+        )
+        file_notes_export_include_cycle_notes = preference_values.get(
+            "notes_export_planning_include_cycle_notes"
+        )
+        file_notes_export_include_task_notes = preference_values.get(
+            "notes_export_planning_include_task_notes"
+        )
+        file_planning_show_habit_actions = preference_values.get("planning_show_habit_actions")
+        file_tasks_default_planning_preset = preference_values.get("tasks_default_planning_preset")
+        file_timelog_auto_set_task_planning = preference_values.get(
+            "timelog_auto_set_task_planning"
+        )
+        file_todos_default_inbox_vision = preference_values.get("todos_default_inbox_vision")
 
         timezone_value = source.get("LIFEOS_TIMEZONE") if include_overrides else None
         if timezone_value is None and isinstance(file_timezone, str):
@@ -585,6 +764,79 @@ class PreferencesSettings:
         theme_value = file_theme if isinstance(file_theme, str) else DEFAULT_THEME
         theme = validate_theme(theme_value)
 
+        calendar_first_day_of_week_value = (
+            file_calendar_first_day_of_week
+            if file_calendar_first_day_of_week is not None
+            else DEFAULT_CALENDAR_FIRST_DAY_OF_WEEK
+        )
+        calendar_first_day_of_week = validate_calendar_first_day_of_week(
+            calendar_first_day_of_week_value
+        )
+
+        calendar_system_value = (
+            file_calendar_system
+            if isinstance(file_calendar_system, str)
+            else DEFAULT_CALENDAR_SYSTEM
+        )
+        calendar_system = validate_calendar_system(calendar_system_value)
+
+        navigation_visible_modules_value = (
+            file_navigation_visible_modules
+            if file_navigation_visible_modules is not None
+            else DEFAULT_NAVIGATION_VISIBLE_MODULES
+        )
+        navigation_visible_modules = validate_navigation_visible_modules(
+            navigation_visible_modules_value
+        )
+
+        notes_card_min_collapsed_lines_value = (
+            file_notes_card_min_collapsed_lines
+            if file_notes_card_min_collapsed_lines is not None
+            else DEFAULT_NOTES_CARD_MIN_COLLAPSED_LINES
+        )
+        notes_card_min_collapsed_lines = validate_notes_card_min_collapsed_lines(
+            notes_card_min_collapsed_lines_value
+        )
+
+        notes_export_include_cycle_notes = (
+            bool(file_notes_export_include_cycle_notes)
+            if isinstance(file_notes_export_include_cycle_notes, bool)
+            else DEFAULT_NOTES_EXPORT_PLANNING_INCLUDE_CYCLE_NOTES
+        )
+        notes_export_include_task_notes = (
+            bool(file_notes_export_include_task_notes)
+            if isinstance(file_notes_export_include_task_notes, bool)
+            else DEFAULT_NOTES_EXPORT_PLANNING_INCLUDE_TASK_NOTES
+        )
+        planning_show_habit_actions = (
+            bool(file_planning_show_habit_actions)
+            if isinstance(file_planning_show_habit_actions, bool)
+            else DEFAULT_PLANNING_SHOW_HABIT_ACTIONS
+        )
+
+        tasks_default_planning_preset_value = (
+            file_tasks_default_planning_preset
+            if isinstance(file_tasks_default_planning_preset, str)
+            else DEFAULT_TASKS_DEFAULT_PLANNING_PRESET
+        )
+        tasks_default_planning_preset = validate_tasks_default_planning_preset(
+            tasks_default_planning_preset_value
+        )
+
+        timelog_auto_set_task_planning = (
+            bool(file_timelog_auto_set_task_planning)
+            if isinstance(file_timelog_auto_set_task_planning, bool)
+            else DEFAULT_TIMELOG_AUTO_SET_TASK_PLANNING
+        )
+        todos_default_inbox_vision_value = (
+            file_todos_default_inbox_vision
+            if isinstance(file_todos_default_inbox_vision, str)
+            else DEFAULT_TODOS_DEFAULT_INBOX_VISION
+        )
+        todos_default_inbox_vision = validate_todos_default_inbox_vision(
+            todos_default_inbox_vision_value
+        )
+
         return cls(
             timezone=timezone_value,
             language=language_value,
@@ -593,6 +845,16 @@ class PreferencesSettings:
             vision_experience_rate_per_hour=vision_experience_rate,
             config_file=config_path,
             theme=theme,
+            calendar_first_day_of_week=calendar_first_day_of_week,
+            calendar_system=calendar_system,
+            navigation_visible_modules=navigation_visible_modules,
+            notes_card_min_collapsed_lines=notes_card_min_collapsed_lines,
+            notes_export_planning_include_cycle_notes=notes_export_include_cycle_notes,
+            notes_export_planning_include_task_notes=notes_export_include_task_notes,
+            planning_show_habit_actions=planning_show_habit_actions,
+            tasks_default_planning_preset=tasks_default_planning_preset,
+            timelog_auto_set_task_planning=timelog_auto_set_task_planning,
+            todos_default_inbox_vision=todos_default_inbox_vision,
         )
 
 

--- a/src/lifeos_cli/db/services/people.py
+++ b/src/lifeos_cli/db/services/people.py
@@ -160,15 +160,18 @@ async def update_person(
         raise PersonNotFoundError(f"Person {person_id} was not found")
     if name is not None:
         normalized_name = name.strip()
-        conflict = await session.execute(
-            select(Person.id).where(
-                Person.name == normalized_name,
-                Person.id != person_id,
-                Person.deleted_at.is_(None),
+        if normalized_name != person.name:
+            conflict = await session.execute(
+                select(Person.id).where(
+                    Person.name == normalized_name,
+                    Person.id != person_id,
+                    Person.deleted_at.is_(None),
+                )
             )
-        )
-        if conflict.scalar_one_or_none() is not None:
-            raise PersonAlreadyExistsError(f"Person with name {normalized_name!r} already exists")
+            if conflict.scalar_one_or_none() is not None:
+                raise PersonAlreadyExistsError(
+                    f"Person with name {normalized_name!r} already exists"
+                )
         person.name = normalized_name
     if clear_description:
         person.description = None

--- a/src/lifeos_cli/i18n.py
+++ b/src/lifeos_cli/i18n.py
@@ -37,11 +37,16 @@ def resolve_locale() -> str:
     """Resolve the active locale for user-facing CLI text."""
     env_locale = os.environ.get("LIFEOS_LANGUAGE")
     if env_locale:
+        if env_locale.strip().lower() == "auto":
+            return detect_default_language()
         return env_locale
     try:
-        return get_preferences_settings().language
+        preference_locale = get_preferences_settings().language
     except ConfigurationError:
         return detect_default_language()
+    if preference_locale.strip().lower() == "auto":
+        return detect_default_language()
+    return preference_locale
 
 
 def _validate_catalog_name(catalog_name: str) -> None:

--- a/src/lifeos_web/routers/preferences.py
+++ b/src/lifeos_web/routers/preferences.py
@@ -139,7 +139,7 @@ def _sync_effective_config_preference_to_file(key: str) -> Any:
     if effective_value != file_value:
         set_runtime_config_value(
             key=config_key,
-            value=str(effective_value),
+            value=_config_payload_to_string(effective_value),
             refresh_runtime=False,
         )
         effective_value = _extract_config_preference_value(get_preferences_settings(), key)

--- a/src/lifeos_web/routers/preferences.py
+++ b/src/lifeos_web/routers/preferences.py
@@ -34,26 +34,33 @@ _VISIBLE_MODULES = [
 
 _CONFIG_KEY_MAP = {
     "appearance.theme": "preferences.theme",
+    "calendar.first_day_of_week": "preferences.calendar_first_day_of_week",
+    "calendar.system": "preferences.calendar_system",
+    "navigation.visible_modules": "preferences.navigation_visible_modules",
+    "notes.card_min_collapsed_lines": "preferences.notes_card_min_collapsed_lines",
+    "notes.export_planning.include_cycle_notes": (
+        "preferences.notes_export_planning_include_cycle_notes"
+    ),
+    "notes.export_planning.include_task_notes": (
+        "preferences.notes_export_planning_include_task_notes"
+    ),
+    "planning.show_habit_actions": "preferences.planning_show_habit_actions",
     "system.timezone": "preferences.timezone",
+    "system.language": "preferences.language",
+    "tasks.default_planning_preset": "preferences.tasks_default_planning_preset",
+    "timeLog.auto_set_task_planning": "preferences.timelog_auto_set_task_planning",
+    "todos.default_inbox_vision": "preferences.todos_default_inbox_vision",
     "visions.experience_rate_per_hour": "preferences.vision_experience_rate_per_hour",
 }
 
 _CONFIG_ENV_KEY_MAP = {
+    "system.language": "LIFEOS_LANGUAGE",
     "system.timezone": "LIFEOS_TIMEZONE",
     "visions.experience_rate_per_hour": "LIFEOS_VISION_EXPERIENCE_RATE_PER_HOUR",
 }
 
 _STATIC_DEFAULTS: dict[str, Any] = {
-    "calendar.first_day_of_week": 1,
-    "calendar.system": "gregorian",
     "dashboard.area_order": [],
-    "navigation.visible_modules": _VISIBLE_MODULES,
-    "notes.card_min_collapsed_lines": 5,
-    "notes.export_planning.include_cycle_notes": False,
-    "notes.export_planning.include_task_notes": True,
-    "planning.show_habit_actions": True,
-    "tasks.default_planning_preset": "none",
-    "timeLog.auto_set_task_planning": False,
 }
 
 _META: dict[str, dict[str, Any]] = {
@@ -92,8 +99,30 @@ class PreferenceUpdate(BaseModel):
 def _extract_config_preference_value(preferences: PreferencesSettings, key: str) -> Any:
     if key == "appearance.theme":
         return preferences.theme
+    if key == "calendar.first_day_of_week":
+        return preferences.calendar_first_day_of_week
+    if key == "calendar.system":
+        return preferences.calendar_system
+    if key == "navigation.visible_modules":
+        return list(preferences.navigation_visible_modules)
+    if key == "notes.card_min_collapsed_lines":
+        return preferences.notes_card_min_collapsed_lines
+    if key == "notes.export_planning.include_cycle_notes":
+        return preferences.notes_export_planning_include_cycle_notes
+    if key == "notes.export_planning.include_task_notes":
+        return preferences.notes_export_planning_include_task_notes
+    if key == "planning.show_habit_actions":
+        return preferences.planning_show_habit_actions
     if key == "system.timezone":
         return preferences.timezone
+    if key == "system.language":
+        return preferences.language
+    if key == "tasks.default_planning_preset":
+        return preferences.tasks_default_planning_preset
+    if key == "timeLog.auto_set_task_planning":
+        return preferences.timelog_auto_set_task_planning
+    if key == "todos.default_inbox_vision":
+        return preferences.todos_default_inbox_vision
     if key == "visions.experience_rate_per_hour":
         return preferences.vision_experience_rate_per_hour
     return None
@@ -122,25 +151,29 @@ def _set_process_config_override(key: str, value: Any) -> None:
     if env_key is None:
         return
     if env_key in os.environ:
-        os.environ[env_key] = str(value)
+        os.environ[env_key] = _config_payload_to_string(value)
     clear_config_cache()
-
-
-def _config_preference_value(key: str) -> Any:
-    if key in _CONFIG_KEY_MAP:
-        return _sync_effective_config_preference_to_file(key)
-    return None
 
 
 def _default_value(key: str) -> Any:
     if key in _CONFIG_KEY_MAP:
-        return _config_preference_value(key)
+        return _sync_effective_config_preference_to_file(key)
     return _STATIC_DEFAULTS.get(key)
+
+
+def _config_payload_to_string(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, list | tuple):
+        return ",".join(str(item) for item in value)
+    if value is None:
+        return ""
+    return str(value)
 
 
 def _preference_response(key: str) -> dict[str, Any]:
     if key in _CONFIG_KEY_MAP:
-        value = _config_preference_value(key)
+        value = _sync_effective_config_preference_to_file(key)
     else:
         value = _VALUES.get(key, _STATIC_DEFAULTS.get(key))
     meta = {
@@ -165,7 +198,7 @@ async def set_preference(key: str, payload: PreferenceUpdate) -> dict[str, Any]:
         try:
             set_runtime_config_value(
                 key=config_key,
-                value=str(payload.value),
+                value=_config_payload_to_string(payload.value),
                 refresh_runtime=False,
             )
         except ConfigurationError as exc:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -20,12 +20,18 @@ from lifeos_cli.config import (
     ensure_database_driver_available,
     parse_boolean_value,
     resolve_config_path,
+    validate_calendar_first_day_of_week,
+    validate_calendar_system,
     validate_database_schema_name,
     validate_database_url,
     validate_day_starts_at,
     validate_language,
+    validate_navigation_visible_modules,
+    validate_notes_card_min_collapsed_lines,
+    validate_tasks_default_planning_preset,
     validate_theme,
     validate_timezone_name,
+    validate_todos_default_inbox_vision,
     validate_vision_experience_rate_per_hour,
     validate_week_starts_on,
     write_database_settings,
@@ -161,6 +167,16 @@ def test_preferences_settings_read_config_file(tmp_path: Path) -> None:
                 'week_starts_on = "sunday"',
                 "vision_experience_rate_per_hour = 90",
                 'theme = "night"',
+                "calendar_first_day_of_week = 7",
+                'calendar_system = "mayan_13_moon"',
+                'navigation_visible_modules = ["visions", "notes", "settings"]',
+                "notes_card_min_collapsed_lines = 9",
+                "notes_export_planning_include_cycle_notes = true",
+                "notes_export_planning_include_task_notes = false",
+                "planning_show_habit_actions = false",
+                'tasks_default_planning_preset = "today"',
+                "timelog_auto_set_task_planning = true",
+                'todos_default_inbox_vision = "11111111-1111-1111-1111-111111111111"',
                 "",
             )
         ),
@@ -175,6 +191,16 @@ def test_preferences_settings_read_config_file(tmp_path: Path) -> None:
     assert settings.week_starts_on == "sunday"
     assert settings.vision_experience_rate_per_hour == 90
     assert settings.theme == "night"
+    assert settings.calendar_first_day_of_week == 7
+    assert settings.calendar_system == "mayan_13_moon"
+    assert settings.navigation_visible_modules == ("visions", "notes", "settings")
+    assert settings.notes_card_min_collapsed_lines == 9
+    assert settings.notes_export_planning_include_cycle_notes is True
+    assert settings.notes_export_planning_include_task_notes is False
+    assert settings.planning_show_habit_actions is False
+    assert settings.tasks_default_planning_preset == "today"
+    assert settings.timelog_auto_set_task_planning is True
+    assert settings.todos_default_inbox_vision == "11111111-1111-1111-1111-111111111111"
 
 
 def test_preferences_settings_can_ignore_env_overrides(tmp_path: Path) -> None:
@@ -453,6 +479,38 @@ def test_validate_timezone_name_rejects_unknown_values() -> None:
 
 def test_validate_language_accepts_bcp47_like_values() -> None:
     assert validate_language("zh_Hans.UTF-8") == "zh-Hans"
+    assert validate_language("auto") == "auto"
+
+
+def test_validate_web_preferences_reject_invalid_values() -> None:
+    assert validate_calendar_first_day_of_week("7") == 7
+    assert validate_calendar_system("mayan_13_moon") == "mayan_13_moon"
+    assert validate_navigation_visible_modules(["visions", "notes", "visions"]) == (
+        "visions",
+        "notes",
+    )
+    assert validate_notes_card_min_collapsed_lines("9") == 9
+    assert validate_tasks_default_planning_preset("this_week") == "this_week"
+    assert (
+        validate_todos_default_inbox_vision("11111111-1111-1111-1111-111111111111")
+        == "11111111-1111-1111-1111-111111111111"
+    )
+
+    invalid_cases = (
+        lambda: validate_calendar_first_day_of_week("8"),
+        lambda: validate_calendar_system("julian"),
+        lambda: validate_navigation_visible_modules(["visions", "unknown"]),
+        lambda: validate_notes_card_min_collapsed_lines("4"),
+        lambda: validate_tasks_default_planning_preset("tomorrow"),
+        lambda: validate_todos_default_inbox_vision("not-a-uuid"),
+    )
+    for invalid in invalid_cases:
+        try:
+            invalid()
+        except ConfigurationError:
+            pass
+        else:
+            raise AssertionError("invalid Web preference should fail validation")
 
 
 def test_detect_default_language_uses_environment() -> None:
@@ -741,6 +799,51 @@ def test_set_runtime_config_value_updates_theme_preference(
     assert 'theme = "night"' in config_path.read_text(encoding="utf-8")
 
 
+def test_set_runtime_config_value_updates_web_preferences(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "lifeos" / "config.toml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("LIFEOS_CONFIG_FILE", str(config_path))
+    config_path.write_text(
+        "\n".join(
+            (
+                "[database]",
+                'schema = "lifeos"',
+                "echo = false",
+                "",
+                "[preferences]",
+                'timezone = "UTC"',
+                'language = "en"',
+                'day_starts_at = "00:00"',
+                'week_starts_on = "monday"',
+                "vision_experience_rate_per_hour = 60",
+                "",
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    set_runtime_config_value(
+        key="preferences.navigation_visible_modules",
+        value="visions,notes,settings",
+    )
+    set_runtime_config_value(
+        key="preferences.notes_card_min_collapsed_lines",
+        value="11",
+    )
+    set_runtime_config_value(
+        key="preferences.todos_default_inbox_vision",
+        value="11111111-1111-1111-1111-111111111111",
+    )
+
+    content = config_path.read_text(encoding="utf-8")
+    assert 'navigation_visible_modules = ["visions", "notes", "settings"]' in content
+    assert "notes_card_min_collapsed_lines = 11" in content
+    assert 'todos_default_inbox_vision = "11111111-1111-1111-1111-111111111111"' in content
+
+
 def test_build_database_settings_uses_injected_prompts(
     monkeypatch,
     tmp_path: Path,
@@ -807,6 +910,68 @@ def test_build_preferences_settings_uses_explicit_values(monkeypatch, tmp_path: 
     assert settings.week_starts_on == "sunday"
     assert settings.vision_experience_rate_per_hour == 120
     assert settings.config_file == config_path
+
+
+def test_build_preferences_settings_preserves_existing_web_preferences(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "lifeos" / "config.toml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("LIFEOS_CONFIG_FILE", str(config_path))
+    config_path.write_text(
+        "\n".join(
+            (
+                "[preferences]",
+                'timezone = "UTC"',
+                'language = "en"',
+                'day_starts_at = "00:00"',
+                'week_starts_on = "monday"',
+                "vision_experience_rate_per_hour = 60",
+                'theme = "night"',
+                "calendar_first_day_of_week = 7",
+                'calendar_system = "mayan_13_moon"',
+                'navigation_visible_modules = ["visions", "notes", "settings"]',
+                "notes_card_min_collapsed_lines = 11",
+                "notes_export_planning_include_cycle_notes = true",
+                "notes_export_planning_include_task_notes = false",
+                "planning_show_habit_actions = false",
+                'tasks_default_planning_preset = "this_week"',
+                "timelog_auto_set_task_planning = true",
+                'todos_default_inbox_vision = "11111111-1111-1111-1111-111111111111"',
+                "",
+            )
+        ),
+        encoding="utf-8",
+    )
+    request = InitializationRequest(
+        database_url=None,
+        schema=None,
+        echo=None,
+        timezone="America/Toronto",
+        language=None,
+        day_starts_at=None,
+        week_starts_on=None,
+        vision_experience_rate_per_hour=None,
+        non_interactive=True,
+        is_interactive=False,
+        prompts=None,
+    )
+
+    settings = build_preferences_settings(request)
+
+    assert settings.timezone == "America/Toronto"
+    assert settings.theme == "night"
+    assert settings.calendar_first_day_of_week == 7
+    assert settings.calendar_system == "mayan_13_moon"
+    assert settings.navigation_visible_modules == ("visions", "notes", "settings")
+    assert settings.notes_card_min_collapsed_lines == 11
+    assert settings.notes_export_planning_include_cycle_notes is True
+    assert settings.notes_export_planning_include_task_notes is False
+    assert settings.planning_show_habit_actions is False
+    assert settings.tasks_default_planning_preset == "this_week"
+    assert settings.timelog_auto_set_task_planning is True
+    assert settings.todos_default_inbox_vision == "11111111-1111-1111-1111-111111111111"
 
 
 def test_build_preferences_settings_rejects_invalid_explicit_vision_experience_rate(

--- a/tests/test_domain_services_core.py
+++ b/tests/test_domain_services_core.py
@@ -274,6 +274,46 @@ def test_update_person_can_clear_optional_fields(monkeypatch: pytest.MonkeyPatch
     session.commit.assert_not_called()
 
 
+def test_update_person_skips_duplicate_check_when_name_is_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    person = SimpleNamespace(
+        id=UUID("33333333-3333-3333-3333-333333333333"),
+        name="Alice",
+        description=None,
+        nicknames=None,
+        birth_date=None,
+        location=None,
+    )
+    session = SimpleNamespace(flush=AsyncMock(), refresh=AsyncMock(), commit=AsyncMock())
+
+    async def fake_load_person(
+        _: object,
+        *,
+        model_cls: object,
+        model_id: UUID,
+    ) -> object:
+        assert model_cls is people.Person
+        assert model_id == UUID("33333333-3333-3333-3333-333333333333")
+        return person
+
+    monkeypatch.setattr(people, "load_model_by_id", fake_load_person)
+    monkeypatch.setattr(people, "_build_person_view", _identity_view)
+
+    updated_person = asyncio.run(
+        people.update_person(
+            cast(Any, session),
+            person_id=UUID("33333333-3333-3333-3333-333333333333"),
+            name="Alice",
+        )
+    )
+
+    assert updated_person.name == "Alice"
+    assert not hasattr(session, "execute")
+    session.flush.assert_awaited_once()
+    session.commit.assert_not_called()
+
+
 def test_update_vision_can_clear_optional_fields(monkeypatch: pytest.MonkeyPatch) -> None:
     vision = SimpleNamespace(
         id=UUID("44444444-4444-4444-4444-444444444444"),

--- a/tests/test_web_cli.py
+++ b/tests/test_web_cli.py
@@ -2383,3 +2383,121 @@ def test_web_theme_preference_persists_to_cli_config(
     assert reloaded["value"] == "night"
 
     assert 'theme = "night"' in config_path.read_text(encoding="utf-8")
+
+
+def test_web_language_preference_persists_to_cli_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    pytest.importorskip("fastapi")
+
+    from lifeos_web.routers.preferences import PreferenceUpdate, get_preference, set_preference
+
+    config_path = install_test_config(
+        monkeypatch=monkeypatch,
+        tmp_path=tmp_path,
+        include_preferences=True,
+        language="en",
+    )
+    monkeypatch.delenv("LIFEOS_LANGUAGE", raising=False)
+    clear_config_cache()
+
+    updated = asyncio.run(
+        set_preference(
+            "system.language",
+            PreferenceUpdate(value="auto", module="system"),
+        )
+    )
+
+    assert updated["value"] == "auto"
+    clear_config_cache()
+    reloaded = asyncio.run(get_preference("system.language"))
+    assert reloaded["value"] == "auto"
+    assert 'language = "auto"' in config_path.read_text(encoding="utf-8")
+
+
+def test_web_visible_modules_preference_persists_to_cli_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    pytest.importorskip("fastapi")
+
+    from lifeos_web.routers.preferences import PreferenceUpdate, get_preference, set_preference
+
+    config_path = install_test_config(
+        monkeypatch=monkeypatch,
+        tmp_path=tmp_path,
+        include_preferences=True,
+    )
+
+    updated = asyncio.run(
+        set_preference(
+            "navigation.visible_modules",
+            PreferenceUpdate(value=["visions", "notes", "settings"], module="navigation"),
+        )
+    )
+
+    assert updated["value"] == ["visions", "notes", "settings"]
+    clear_config_cache()
+    reloaded = asyncio.run(get_preference("navigation.visible_modules"))
+    assert reloaded["value"] == ["visions", "notes", "settings"]
+    assert 'navigation_visible_modules = ["visions", "notes", "settings"]' in (
+        config_path.read_text(encoding="utf-8")
+    )
+
+
+def test_web_note_collapse_preference_persists_to_cli_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    pytest.importorskip("fastapi")
+
+    from lifeos_web.routers.preferences import PreferenceUpdate, get_preference, set_preference
+
+    config_path = install_test_config(
+        monkeypatch=monkeypatch,
+        tmp_path=tmp_path,
+        include_preferences=True,
+    )
+
+    updated = asyncio.run(
+        set_preference(
+            "notes.card_min_collapsed_lines",
+            PreferenceUpdate(value=11, module="notes"),
+        )
+    )
+
+    assert updated["value"] == 11
+    clear_config_cache()
+    reloaded = asyncio.run(get_preference("notes.card_min_collapsed_lines"))
+    assert reloaded["value"] == 11
+    assert "notes_card_min_collapsed_lines = 11" in config_path.read_text(encoding="utf-8")
+
+
+def test_web_default_inbox_vision_preference_persists_to_cli_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    pytest.importorskip("fastapi")
+
+    from lifeos_web.routers.preferences import PreferenceUpdate, get_preference, set_preference
+
+    config_path = install_test_config(
+        monkeypatch=monkeypatch,
+        tmp_path=tmp_path,
+        include_preferences=True,
+    )
+    vision_id = "11111111-1111-1111-1111-111111111111"
+
+    updated = asyncio.run(
+        set_preference(
+            "todos.default_inbox_vision",
+            PreferenceUpdate(value=vision_id, module="todos"),
+        )
+    )
+
+    assert updated["value"] == vision_id
+    clear_config_cache()
+    reloaded = asyncio.run(get_preference("todos.default_inbox_vision"))
+    assert reloaded["value"] == vision_id
+    assert f'todos_default_inbox_vision = "{vision_id}"' in config_path.read_text(encoding="utf-8")

--- a/web/src/components/PersonDetailModal.tsx
+++ b/web/src/components/PersonDetailModal.tsx
@@ -98,7 +98,7 @@ const PersonDetailModal: React.FC<PersonDetailModalProps> = ({
         {person.name && (
           <div>
             <label className="block text-base font-medium text-base-content/70">
-              {t("auth.name")}
+              {t("personDetail.name")}
             </label>
             <p className="text-base">{person.name}</p>
           </div>

--- a/web/src/components/PersonFormModal.tsx
+++ b/web/src/components/PersonFormModal.tsx
@@ -258,7 +258,7 @@ const PersonFormModal: React.FC<PersonFormModalProps> = ({
         className="space-y-3 sm:space-y-4 lg:space-y-5"
       >
         {/* Name Field */}
-        <FormField label={t("auth.name")} htmlFor="person-name-input">
+        <FormField label={t("personDetail.name")} htmlFor="person-name-input">
           <TextInput
             id="person-name-input"
             name="person-name-input"

--- a/web/src/components/PersonManager.tsx
+++ b/web/src/components/PersonManager.tsx
@@ -390,7 +390,7 @@ const PersonManager: React.FC<PersonManagerProps> = ({
               onClick={() => handleSort("name")}
               className="text-left text-sm font-medium uppercase tracking-wider flex items-center gap-1"
             >
-              <span>{t("auth.name")}</span>
+              <span>{t("personDetail.name")}</span>
               {sortField === "name" && (
                 <Icon
                   name="chevron-down"

--- a/web/src/features/people/tagFilters.ts
+++ b/web/src/features/people/tagFilters.ts
@@ -1,0 +1,30 @@
+import type { UUID } from "@/types/primitive";
+
+export interface PersonTagFilterState {
+  filteredByTag: boolean;
+  selectedTagId: UUID | null;
+}
+
+export function getNextPersonTagFilterState(
+  current: PersonTagFilterState,
+  tagId: UUID,
+): PersonTagFilterState {
+  if (current.filteredByTag && current.selectedTagId === tagId) {
+    return {
+      filteredByTag: false,
+      selectedTagId: null,
+    };
+  }
+
+  return {
+    filteredByTag: true,
+    selectedTagId: tagId,
+  };
+}
+
+export function formatPersonTagFilterLabel(
+  tagName: string,
+  usageCount: number | null,
+): string {
+  return usageCount === null ? tagName : `${tagName} (${usageCount})`;
+}

--- a/web/src/features/people/tagFilters.ts
+++ b/web/src/features/people/tagFilters.ts
@@ -28,3 +28,10 @@ export function formatPersonTagFilterLabel(
 ): string {
   return usageCount === null ? tagName : `${tagName} (${usageCount})`;
 }
+
+export function getPersonTagUsageCount(
+  usageCounts: ReadonlyMap<UUID, number> | null,
+  tagId: UUID,
+): number | null {
+  return usageCounts === null ? null : (usageCounts.get(tagId) ?? 0);
+}

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -1699,6 +1699,7 @@
     "saveFailed": "Save failed, please try again later"
   },
   "personDetail": {
+    "name": "Name",
     "nicknames": "Nicknames",
     "primaryNickname": "Primary Nickname",
     "birthDate": "Birth Date",

--- a/web/src/locales/zh/common.json
+++ b/web/src/locales/zh/common.json
@@ -1699,6 +1699,7 @@
     "saveFailed": "保存失败，请稍后重试"
   },
   "personDetail": {
+    "name": "姓名",
     "nicknames": "昵称",
     "primaryNickname": "主要昵称",
     "birthDate": "生日",

--- a/web/src/pages/PersonsPage.tsx
+++ b/web/src/pages/PersonsPage.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
+import { useQuery } from "@tanstack/react-query";
 import PersonManager from "@/components/PersonManager";
 import ExpandableCard from "@/components/ExpandableCard";
 import TagManager from "@/components/TagManagerModal";
@@ -10,8 +11,13 @@ import { usePersonActivitiesPage } from "@/hooks/queries/usePersons";
 import { useTagSelectorSource } from "@/hooks/selectors/useTagSelectorSource";
 import { usePersistentState } from "@/hooks/usePersistentState";
 import ActionButton from "@/components/ActionButton";
+import {
+  formatPersonTagFilterLabel,
+  getNextPersonTagFilterState,
+} from "@/features/people/tagFilters";
 import type { PersonSummary } from "@/services/api";
-import type { Tag } from "@/services/api/tags";
+import { tagsApi, type Tag } from "@/services/api/tags";
+import { tagsKeys } from "@/services/api/queryKeys";
 import type { UUID } from "@/types/primitive";
 import type { PersonActivityType } from "@/services/api/persons";
 
@@ -74,6 +80,21 @@ const PersonsPage: React.FC = () => {
       entityType: "person",
     },
   );
+  const { data: personTagStats } = useQuery({
+    queryKey: tagsKeys.statsBatch("person"),
+    queryFn: () => tagsApi.getStatsBatch("person"),
+    enabled: personTags.length > 0,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const personTagUsageCounts = useMemo(() => {
+    if (!personTagStats) {
+      return null;
+    }
+    return new Map<UUID, number>(
+      personTagStats.tag_stats.map((stat) => [stat.id, stat.usage_count]),
+    );
+  }, [personTagStats]);
 
   const getCategoryDisplayName = useCallback(
     (category: string): string => {
@@ -110,11 +131,18 @@ const PersonsPage: React.FC = () => {
       .sort((a, b) => a.label.localeCompare(b.label));
   }, [sortedPersonTags, getCategoryDisplayName]);
 
-  // Load persons by tag
-  const loadPersonsByTag = useCallback((tag: Tag) => {
-    setFilteredByTag(true);
-    setSelectedTagId(tag.id);
-  }, []);
+  // Toggle person tag filtering.
+  const togglePersonTagFilter = useCallback(
+    (tag: Tag) => {
+      const nextState = getNextPersonTagFilterState(
+        { filteredByTag, selectedTagId },
+        tag.id,
+      );
+      setFilteredByTag(nextState.filteredByTag);
+      setSelectedTagId(nextState.selectedTagId);
+    },
+    [filteredByTag, selectedTagId],
+  );
 
   // Handle search query change from PersonManager
   const handleSearchQueryChange = useCallback(
@@ -188,11 +216,14 @@ const PersonsPage: React.FC = () => {
                 {group.tags.map((tag) => (
                   <ActionButton
                     key={tag.id}
-                    label={tag.name}
+                    label={formatPersonTagFilterLabel(
+                      tag.name,
+                      personTagUsageCounts?.get(tag.id) ?? null,
+                    )}
                     color={selectedTagId === tag.id ? "primary" : "neutral"}
                     variant={selectedTagId === tag.id ? "solid" : "ghost"}
                     size="sm"
-                    onClick={() => loadPersonsByTag(tag)}
+                    onClick={() => togglePersonTagFilter(tag)}
                     className="rounded-full"
                   />
                 ))}

--- a/web/src/pages/PersonsPage.tsx
+++ b/web/src/pages/PersonsPage.tsx
@@ -1,13 +1,14 @@
 import React, { useState, useCallback, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import PersonManager from "@/components/PersonManager";
-import Card from "@/layouts/Card";
+import ExpandableCard from "@/components/ExpandableCard";
 import TagManager from "@/components/TagManagerModal";
 import PersonTimelineModal from "@/components/PersonTimelineModal";
 import { usePageHeader } from "@/contexts/PageHeaderContext";
 import PageLayout from "@/layouts/PageLayout";
 import { usePersonActivitiesPage } from "@/hooks/queries/usePersons";
 import { useTagSelectorSource } from "@/hooks/selectors/useTagSelectorSource";
+import { usePersistentState } from "@/hooks/usePersistentState";
 import ActionButton from "@/components/ActionButton";
 import type { PersonSummary } from "@/services/api";
 import type { Tag } from "@/services/api/tags";
@@ -33,6 +34,12 @@ const PersonsPage: React.FC = () => {
   // Tag filtering state
   const [filteredByTag, setFilteredByTag] = useState(false);
   const [selectedTagId, setSelectedTagId] = useState<UUID | null>(null);
+  const { state: tagFiltersExpanded, setState: setTagFiltersExpanded } =
+    usePersistentState<boolean>({
+      key: "personsPage.tagFiltersExpanded",
+      defaultValue: true,
+      expireInHours: 0,
+    });
 
   // Use the paginated activities hook
   type ActivityFilter = "all" | PersonActivityType;
@@ -80,10 +87,6 @@ const PersonsPage: React.FC = () => {
     [t],
   );
 
-  const getTagDisplayLabel = useCallback((tag: Tag): string => {
-    return tag.name;
-  }, []);
-
   const sortedPersonTags = useMemo(
     () => [...personTags].sort((a, b) => a.name.localeCompare(b.name)),
     [personTags],
@@ -111,12 +114,6 @@ const PersonsPage: React.FC = () => {
   const loadPersonsByTag = useCallback((tag: Tag) => {
     setFilteredByTag(true);
     setSelectedTagId(tag.id);
-  }, []);
-
-  // Reset to show all persons
-  const resetToAllPersons = useCallback(() => {
-    setFilteredByTag(false);
-    setSelectedTagId(null);
   }, []);
 
   // Handle search query change from PersonManager
@@ -168,33 +165,30 @@ const PersonsPage: React.FC = () => {
   return (
     <PageLayout>
       {/* Tags Filter Container */}
-      <Card
-        title={t("personManager.tagFiltersTitle")}
-        size="sm"
+      <ExpandableCard
+        isExpanded={tagFiltersExpanded}
+        onToggleExpansion={() =>
+          setTagFiltersExpanded((isExpanded) => !isExpanded)
+        }
+        title={
+          <h3 className="text-base font-semibold text-base-content">
+            {t("personManager.tagFiltersTitle")}
+          </h3>
+        }
         elevation="moderate"
         className="mb-4"
       >
-        <div className="space-y-3">
-          <div className="flex flex-wrap gap-2">
-            <ActionButton
-              label={t("common.all")}
-              color={!filteredByTag ? "primary" : "neutral"}
-              variant={!filteredByTag ? "solid" : "ghost"}
-              size="sm"
-              onClick={resetToAllPersons}
-              className="rounded-full"
-            />
-          </div>
+        <div className="space-y-3 px-5 pb-5">
           {tagsByCategory.map((group) => (
-            <div key={group.category}>
-              <div className="text-xs font-semibold uppercase tracking-wide text-base-content/70 mb-2">
+            <div key={group.category} className="space-y-2">
+              <div className="rounded-sm bg-base-200/60 px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-base-content/70">
                 {group.label}
               </div>
-              <div className="flex flex-wrap gap-2">
+              <div className="flex flex-wrap gap-2 px-3">
                 {group.tags.map((tag) => (
                   <ActionButton
                     key={tag.id}
-                    label={getTagDisplayLabel(tag)}
+                    label={tag.name}
                     color={selectedTagId === tag.id ? "primary" : "neutral"}
                     variant={selectedTagId === tag.id ? "solid" : "ghost"}
                     size="sm"
@@ -206,7 +200,7 @@ const PersonsPage: React.FC = () => {
             </div>
           ))}
         </div>
-      </Card>
+      </ExpandableCard>
 
       {/* Persons List Container */}
       <PersonManager

--- a/web/src/pages/PersonsPage.tsx
+++ b/web/src/pages/PersonsPage.tsx
@@ -14,6 +14,7 @@ import ActionButton from "@/components/ActionButton";
 import {
   formatPersonTagFilterLabel,
   getNextPersonTagFilterState,
+  getPersonTagUsageCount,
 } from "@/features/people/tagFilters";
 import type { PersonSummary } from "@/services/api";
 import { tagsApi, type Tag } from "@/services/api/tags";
@@ -218,7 +219,7 @@ const PersonsPage: React.FC = () => {
                     key={tag.id}
                     label={formatPersonTagFilterLabel(
                       tag.name,
-                      personTagUsageCounts?.get(tag.id) ?? null,
+                      getPersonTagUsageCount(personTagUsageCounts, tag.id),
                     )}
                     color={selectedTagId === tag.id ? "primary" : "neutral"}
                     variant={selectedTagId === tag.id ? "solid" : "ghost"}

--- a/web/src/pages/__tests__/personTagFilters.test.ts
+++ b/web/src/pages/__tests__/personTagFilters.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   formatPersonTagFilterLabel,
   getNextPersonTagFilterState,
+  getPersonTagUsageCount,
 } from "@/features/people/tagFilters";
 import type { UUID } from "@/types/primitive";
 
@@ -44,5 +45,13 @@ describe("person tag filters", () => {
 
   it("keeps tag labels unchanged before counts are loaded", () => {
     expect(formatPersonTagFilterLabel("Friends", null)).toBe("Friends");
+  });
+
+  it("returns zero for tags missing from loaded usage counts", () => {
+    const usageCounts = new Map<UUID, number>([[otherTagId, 3]]);
+
+    expect(getPersonTagUsageCount(null, tagId)).toBeNull();
+    expect(getPersonTagUsageCount(usageCounts, otherTagId)).toBe(3);
+    expect(getPersonTagUsageCount(usageCounts, tagId)).toBe(0);
   });
 });

--- a/web/src/pages/__tests__/personTagFilters.test.ts
+++ b/web/src/pages/__tests__/personTagFilters.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatPersonTagFilterLabel,
+  getNextPersonTagFilterState,
+} from "@/features/people/tagFilters";
+import type { UUID } from "@/types/primitive";
+
+const tagId = "11111111-1111-1111-1111-111111111111" as UUID;
+const otherTagId = "22222222-2222-2222-2222-222222222222" as UUID;
+
+describe("person tag filters", () => {
+  it("selects a tag when no tag filter is active", () => {
+    expect(
+      getNextPersonTagFilterState(
+        { filteredByTag: false, selectedTagId: null },
+        tagId,
+      ),
+    ).toEqual({ filteredByTag: true, selectedTagId: tagId });
+  });
+
+  it("clears the filter when the active tag is clicked again", () => {
+    expect(
+      getNextPersonTagFilterState(
+        { filteredByTag: true, selectedTagId: tagId },
+        tagId,
+      ),
+    ).toEqual({ filteredByTag: false, selectedTagId: null });
+  });
+
+  it("switches directly to another tag", () => {
+    expect(
+      getNextPersonTagFilterState(
+        { filteredByTag: true, selectedTagId: tagId },
+        otherTagId,
+      ),
+    ).toEqual({ filteredByTag: true, selectedTagId: otherTagId });
+  });
+
+  it("formats tag labels with loaded person counts", () => {
+    expect(formatPersonTagFilterLabel("Friends", 0)).toBe("Friends (0)");
+    expect(formatPersonTagFilterLabel("Friends", 12)).toBe("Friends (12)");
+  });
+
+  it("keeps tag labels unchanged before counts are loaded", () => {
+    expect(formatPersonTagFilterLabel("Friends", null)).toBe("Friends");
+  });
+});


### PR DESCRIPTION
## 变更概述

- 将 Web 偏好设置接入 CLI config `[preferences]` 持久化读写，覆盖语言、导航可见模块、日历偏好、Notes 折叠行数、规划/任务/TimeLog 相关偏好和默认 inbox vision。
- 修复 People 页编辑已有 person 保存原名时误判为重名的问题。
- People 页标签筛选复用已有 `ExpandableCard`，支持收起或完全展开；移除“全部”按钮与滚动容器，并以轻量分组标题区分标签分类，避免多分类场景下界面过重。
- People 标签筛选支持再次点击已选 tag 来取消筛选，并复用现有批量 tag usage stats 显示每个 person tag 的关联人数；统计已加载但无关联人员的 tag 显示为 `0`。
- 修复 People 列表及 person 表单/详情中姓名字段缺失翻译导致显示 `AUTH.NAME` 的问题。
- 清理本分支引入的高确信薄壳代码，移除无必要的纯转发 helper；本轮全仓死代码复查未发现新的高确信可删项。
- 审查过程中修复 `build_preferences_settings()` 未保留新增 Web 偏好的问题，避免重新运行 init 时重置这些偏好；并统一 config-backed Web preference 同步时的 payload 序列化。

## 相关 commits

- `502dac7` Persist web preferences and fix people editing
- `0791eb5` Improve people tag filtering
- `3608e16` Polish people tag filter counts

## 需求关系

Closes #190

## 验证

- `bash ./scripts/dead_code_check.sh`
- `npm --prefix web run test -- personTagFilters`
- `npm --prefix web run lint`
- `uv run pytest tests/test_web_cli.py tests/test_config.py tests/test_domain_services_core.py`
- `bash ./scripts/web_validate.sh`
- `bash ./scripts/doctor.sh`
