### PR TITLE
feat: support anchored seven-year planning cycles

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -181,28 +181,28 @@
         "filename": "web/src/locales/en/common.json",
         "hashed_secret": "cf678cab87dc1f7d1b95b964f15375e088461679",
         "is_verified": false,
-        "line_number": 751
+        "line_number": 755
       },
       {
         "type": "Secret Keyword",
         "filename": "web/src/locales/en/common.json",
         "hashed_secret": "61dcf34e70921088cddc6b8a5de3610727725562",
         "is_verified": false,
-        "line_number": 773
+        "line_number": 777
       },
       {
         "type": "Secret Keyword",
         "filename": "web/src/locales/en/common.json",
         "hashed_secret": "6a4a692690883237aac65dfe5bfcc9651a7a1a21",
         "is_verified": false,
-        "line_number": 774
+        "line_number": 778
       },
       {
         "type": "Secret Keyword",
         "filename": "web/src/locales/en/common.json",
         "hashed_secret": "80d729e6b50b92ea93d864d8c1931d905e87ae27",
         "is_verified": false,
-        "line_number": 775
+        "line_number": 779
       }
     ],
     "web/src/locales/zh/common.json": [
@@ -211,7 +211,7 @@
         "filename": "web/src/locales/zh/common.json",
         "hashed_secret": "731c458c5b55d44c8bdeeca8cb70b998bf0f8bfe",
         "is_verified": false,
-        "line_number": 751
+        "line_number": 755
       }
     ],
     "web/src/pages/__tests__/LoginPage.test.tsx": [
@@ -233,5 +233,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-01T10:24:34Z"
+  "generated_at": "2026-07-01T11:08:14Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -181,28 +181,28 @@
         "filename": "web/src/locales/en/common.json",
         "hashed_secret": "cf678cab87dc1f7d1b95b964f15375e088461679",
         "is_verified": false,
-        "line_number": 750
+        "line_number": 751
       },
       {
         "type": "Secret Keyword",
         "filename": "web/src/locales/en/common.json",
         "hashed_secret": "61dcf34e70921088cddc6b8a5de3610727725562",
         "is_verified": false,
-        "line_number": 772
+        "line_number": 773
       },
       {
         "type": "Secret Keyword",
         "filename": "web/src/locales/en/common.json",
         "hashed_secret": "6a4a692690883237aac65dfe5bfcc9651a7a1a21",
         "is_verified": false,
-        "line_number": 773
+        "line_number": 774
       },
       {
         "type": "Secret Keyword",
         "filename": "web/src/locales/en/common.json",
         "hashed_secret": "80d729e6b50b92ea93d864d8c1931d905e87ae27",
         "is_verified": false,
-        "line_number": 774
+        "line_number": 775
       }
     ],
     "web/src/locales/zh/common.json": [
@@ -211,7 +211,7 @@
         "filename": "web/src/locales/zh/common.json",
         "hashed_secret": "731c458c5b55d44c8bdeeca8cb70b998bf0f8bfe",
         "is_verified": false,
-        "line_number": 750
+        "line_number": 751
       }
     ],
     "web/src/pages/__tests__/LoginPage.test.tsx": [
@@ -233,5 +233,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-01T09:09:14Z"
+  "generated_at": "2026-07-01T10:24:34Z"
 }

--- a/src/lifeos_cli/application/calendar_adapter.py
+++ b/src/lifeos_cli/application/calendar_adapter.py
@@ -13,7 +13,7 @@ from lifeos_cli.config import (
     validate_calendar_system,
 )
 
-CalendarGranularity = Literal["day", "week", "month", "year"]
+CalendarGranularity = Literal["day", "week", "month", "year", "7years"]
 
 
 class CalendarAdapter(Protocol):
@@ -27,6 +27,9 @@ class CalendarAdapter(Protocol):
 
     def year_range(self, target: date) -> tuple[date, date]:
         """Return inclusive year boundaries for the target date."""
+
+    def seven_year_range(self, target: date) -> tuple[date, date]:
+        """Return inclusive seven-year boundaries starting with the target year."""
 
 
 @dataclass(frozen=True)
@@ -49,6 +52,11 @@ class GregorianCalendarAdapter:
 
     def year_range(self, target: date) -> tuple[date, date]:
         return date(target.year, 1, 1), date(target.year, 12, 31)
+
+    def seven_year_range(self, target: date) -> tuple[date, date]:
+        start = date(target.year, 1, 1)
+        end = date(target.year + 7, 1, 1) - timedelta(days=1)
+        return start, end
 
 
 @dataclass(frozen=True)
@@ -92,6 +100,10 @@ class MayanCalendarAdapter:
         start = self.year_start(target)
         return start, start.replace(year=start.year + 1) - timedelta(days=1)
 
+    def seven_year_range(self, target: date) -> tuple[date, date]:
+        start = self.year_start(target)
+        return start, start.replace(year=start.year + 7) - timedelta(days=1)
+
 
 def get_calendar_adapter(system: str | None = None) -> CalendarAdapter:
     """Return the adapter for a validated calendar system."""
@@ -122,6 +134,8 @@ def get_calendar_period_range(
         return adapter.month_range(target)
     if granularity == "year":
         return adapter.year_range(target)
+    if granularity == "7years":
+        return adapter.seven_year_range(target)
     raise ValueError(f"Unsupported calendar granularity: {granularity}")
 
 

--- a/src/lifeos_cli/application/configuration.py
+++ b/src/lifeos_cli/application/configuration.py
@@ -26,6 +26,7 @@ from lifeos_cli.config import (
     parse_boolean_value,
     resolve_config_path,
     validate_calendar_first_day_of_week,
+    validate_calendar_seven_year_anchor_date,
     validate_calendar_system,
     validate_database_url,
     validate_day_starts_at,
@@ -80,6 +81,7 @@ SUPPORTED_CONFIG_KEYS = (
     "preferences.theme",
     "preferences.calendar_first_day_of_week",
     "preferences.calendar_system",
+    "preferences.calendar_seven_year_anchor_date",
     "preferences.navigation_visible_modules",
     "preferences.notes_card_min_collapsed_lines",
     "preferences.notes_export_planning_include_cycle_notes",
@@ -202,6 +204,7 @@ def build_preferences_settings(request: InitializationRequest) -> PreferencesSet
         theme=validate_theme(current.theme),
         calendar_first_day_of_week=current.calendar_first_day_of_week,
         calendar_system=current.calendar_system,
+        calendar_seven_year_anchor_date=current.calendar_seven_year_anchor_date,
         navigation_visible_modules=current.navigation_visible_modules,
         notes_card_min_collapsed_lines=current.notes_card_min_collapsed_lines,
         notes_export_planning_include_cycle_notes=(
@@ -314,6 +317,11 @@ def set_runtime_config_value(
         preferences_settings = replace(
             preferences_settings,
             calendar_system=validate_calendar_system(value),
+        )
+    elif normalized_key == "preferences.calendar_seven_year_anchor_date":
+        preferences_settings = replace(
+            preferences_settings,
+            calendar_seven_year_anchor_date=validate_calendar_seven_year_anchor_date(value),
         )
     elif normalized_key == "preferences.navigation_visible_modules":
         preferences_settings = replace(

--- a/src/lifeos_cli/config.py
+++ b/src/lifeos_cli/config.py
@@ -6,7 +6,7 @@ import os
 import re
 from collections.abc import Mapping
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import date, datetime
 from functools import lru_cache
 from importlib import import_module
 from pathlib import Path
@@ -38,6 +38,7 @@ DEFAULT_VISION_EXPERIENCE_RATE_PER_HOUR = 60
 DEFAULT_THEME = "system"
 DEFAULT_CALENDAR_FIRST_DAY_OF_WEEK = 1
 DEFAULT_CALENDAR_SYSTEM = "gregorian"
+DEFAULT_CALENDAR_SEVEN_YEAR_ANCHOR_DATE = "2025-07-26"
 DEFAULT_NAVIGATION_VISIBLE_MODULES = (
     "visions",
     "habits",
@@ -368,6 +369,17 @@ def validate_calendar_system(value: str) -> str:
     return normalized
 
 
+def validate_calendar_seven_year_anchor_date(value: str) -> str:
+    """Validate the date used to anchor seven-year calendar periods."""
+    normalized = value.strip()
+    try:
+        return date.fromisoformat(normalized).isoformat()
+    except ValueError as exc:
+        raise ConfigurationError(
+            "Preference `calendar_seven_year_anchor_date` must be a YYYY-MM-DD date."
+        ) from exc
+
+
 def validate_navigation_visible_modules(value: object) -> tuple[str, ...]:
     """Validate the Web navigation module visibility preference."""
     modules = _parse_string_list(value, field_name="navigation_visible_modules")
@@ -469,6 +481,8 @@ def _render_preferences_table(settings: PreferencesSettings) -> str:
         f"theme = {_serialize_toml_string(settings.theme)}",
         f"calendar_first_day_of_week = {settings.calendar_first_day_of_week}",
         f"calendar_system = {_serialize_toml_string(settings.calendar_system)}",
+        "calendar_seven_year_anchor_date = "
+        f"{_serialize_toml_string(settings.calendar_seven_year_anchor_date)}",
         "navigation_visible_modules = "
         f"{_serialize_toml_string_list(settings.navigation_visible_modules)}",
         f"notes_card_min_collapsed_lines = {settings.notes_card_min_collapsed_lines}",
@@ -673,6 +687,7 @@ class PreferencesSettings:
     theme: str = DEFAULT_THEME
     calendar_first_day_of_week: int = DEFAULT_CALENDAR_FIRST_DAY_OF_WEEK
     calendar_system: str = DEFAULT_CALENDAR_SYSTEM
+    calendar_seven_year_anchor_date: str = DEFAULT_CALENDAR_SEVEN_YEAR_ANCHOR_DATE
     navigation_visible_modules: tuple[str, ...] = DEFAULT_NAVIGATION_VISIBLE_MODULES
     notes_card_min_collapsed_lines: int = DEFAULT_NOTES_CARD_MIN_COLLAPSED_LINES
     notes_export_planning_include_cycle_notes: bool = (
@@ -711,6 +726,9 @@ class PreferencesSettings:
         file_theme = preference_values.get("theme")
         file_calendar_first_day_of_week = preference_values.get("calendar_first_day_of_week")
         file_calendar_system = preference_values.get("calendar_system")
+        file_calendar_seven_year_anchor_date = preference_values.get(
+            "calendar_seven_year_anchor_date"
+        )
         file_navigation_visible_modules = preference_values.get("navigation_visible_modules")
         file_notes_card_min_collapsed_lines = preference_values.get(
             "notes_card_min_collapsed_lines"
@@ -780,6 +798,15 @@ class PreferencesSettings:
         )
         calendar_system = validate_calendar_system(calendar_system_value)
 
+        calendar_seven_year_anchor_date_value = (
+            file_calendar_seven_year_anchor_date
+            if isinstance(file_calendar_seven_year_anchor_date, str)
+            else DEFAULT_CALENDAR_SEVEN_YEAR_ANCHOR_DATE
+        )
+        calendar_seven_year_anchor_date = validate_calendar_seven_year_anchor_date(
+            calendar_seven_year_anchor_date_value
+        )
+
         navigation_visible_modules_value = (
             file_navigation_visible_modules
             if file_navigation_visible_modules is not None
@@ -847,6 +874,7 @@ class PreferencesSettings:
             theme=theme,
             calendar_first_day_of_week=calendar_first_day_of_week,
             calendar_system=calendar_system,
+            calendar_seven_year_anchor_date=calendar_seven_year_anchor_date,
             navigation_visible_modules=navigation_visible_modules,
             notes_card_min_collapsed_lines=notes_card_min_collapsed_lines,
             notes_export_planning_include_cycle_notes=notes_export_include_cycle_notes,

--- a/src/lifeos_cli/db/services/task_queries.py
+++ b/src/lifeos_cli/db/services/task_queries.py
@@ -162,7 +162,7 @@ def _planning_cycle_date_filter_range(
     """Return a calendar-aware planning-cycle filter range when requested."""
     if calendar_system is None and first_day_of_week is None:
         return None
-    if planning_cycle_type not in {"day", "week", "month", "year"}:
+    if planning_cycle_type not in {"day", "week", "month", "year", "7years"}:
         return None
     try:
         return get_calendar_period_range(

--- a/src/lifeos_cli/db/services/task_support.py
+++ b/src/lifeos_cli/db/services/task_support.py
@@ -13,7 +13,7 @@ from lifeos_cli.db.models.task import Task
 from lifeos_cli.db.models.vision import Vision
 
 VALID_TASK_STATUSES = {"todo", "in_progress", "done", "cancelled", "paused"}
-VALID_PLANNING_CYCLE_TYPES = {"year", "month", "week", "day"}
+VALID_PLANNING_CYCLE_TYPES = {"7years", "year", "month", "week", "day"}
 MAX_TASK_DEPTH = 8
 
 

--- a/src/lifeos_cli/locales/en/cli_messages.json
+++ b/src/lifeos_cli/locales/en/cli_messages.json
@@ -668,7 +668,7 @@
         "planning_cycle_duration_in_days_for_enclosing_timebox": "Planning cycle duration in days for the enclosing timebox",
         "planning_cycle_fields_describe_enclosing_timebox_for_task_not_clock_time_execution": "Planning-cycle fields describe the enclosing timebox for the task, not a clock-time execution slot.",
         "planning_cycle_flags_must_be_supplied_as_complete_set_when_used": "Planning-cycle flags must be supplied as a complete set when used.",
-        "planning_cycle_type_year_month_week_or_day": "Planning cycle type: year, month, week, or day",
+        "planning_cycle_type_year_month_week_or_day": "Planning cycle type: 7years, year, month, week, or day",
         "start_date_of_enclosing_planning_cycle_window_in_yyyy_mm_dd_format": "Start date of the enclosing planning cycle window in YYYY-MM-DD format",
         "task_content": "Task content",
         "task_priority": "Task priority",
@@ -680,7 +680,7 @@
         "updated_parent_task_identifier": "Updated parent task identifier",
         "updated_planning_cycle_duration_in_days_for_enclosing_timebox": "Updated planning cycle duration in days for the enclosing timebox",
         "updated_planning_cycle_fields_still_describe_enclosing_timebox_not_specific_scheduled_timestamp": "Updated planning-cycle fields still describe the enclosing timebox, not a specific scheduled timestamp.",
-        "updated_planning_cycle_type_year_month_week_or_day": "Updated planning cycle type: year, month, week, or day",
+        "updated_planning_cycle_type_year_month_week_or_day": "Updated planning cycle type: 7years, year, month, week, or day",
         "updated_priority": "Updated priority",
         "updated_start_date_of_enclosing_planning_cycle_window_in_yyyy_mm_dd": "Updated start date of the enclosing planning cycle window in YYYY-MM-DD format",
         "updated_task_content": "Updated task content",
@@ -688,7 +688,7 @@
         "use_clear_flags_to_remove_optional_values_such_as_descriptions_or_planning": "Use `--clear-*` flags to remove optional values such as descriptions or planning cycles.",
         "use_clear_parent_to_move_child_task_back_to_root_level": "Use `--clear-parent` to move a child task back to the root level.",
         "use_lifeos_event_add_task_id_task_id_if_task_also_needs": "Use `lifeos event add --task-id <task-id>` if the task also needs a specific time block on a calendar day.",
-        "use_planning_cycle_fields_for_broader_year_month_week_or_day_window": "Use planning-cycle fields for the broader year, month, week, or day window that the task belongs to.",
+        "use_planning_cycle_fields_for_broader_year_month_week_or_day_window": "Use planning-cycle fields for the broader 7-year, year, month, week, or day window that the task belongs to.",
         "use_repeated_person_id_to_keep_human_only_agent_only_and_shared": "Use repeated `--person-id` to keep human-only, agent-only, and shared task ownership explicit.",
         "when_agent_creates_tasks_on_behalf_of_human_use_person_id_to": "When an agent creates tasks on behalf of a human, use `--person-id` to mark whether the task belongs to the human, the agent, or both."
       }

--- a/src/lifeos_cli/locales/zh_Hans/cli_messages.json
+++ b/src/lifeos_cli/locales/zh_Hans/cli_messages.json
@@ -668,7 +668,7 @@
         "planning_cycle_duration_in_days_for_enclosing_timebox": "所属时间窗口的 planning-cycle 时长（天）",
         "planning_cycle_fields_describe_enclosing_timebox_for_task_not_clock_time_execution": "`planning-cycle` 字段描述的是 `task` 所属的时间窗口，而不是具体的时钟时间段。",
         "planning_cycle_flags_must_be_supplied_as_complete_set_when_used": "使用时必须成组提供完整的 planning-cycle 参数。",
-        "planning_cycle_type_year_month_week_or_day": "planning-cycle 类型：year、month、week 或 day",
+        "planning_cycle_type_year_month_week_or_day": "planning-cycle 类型：7years、year、month、week 或 day",
         "start_date_of_enclosing_planning_cycle_window_in_yyyy_mm_dd_format": "所属 planning-cycle 窗口的开始日期（YYYY-MM-DD）",
         "task_content": "`task` 内容",
         "task_priority": "`task` 优先级",
@@ -680,7 +680,7 @@
         "updated_parent_task_identifier": "更新了父 `task` 标识符",
         "updated_planning_cycle_duration_in_days_for_enclosing_timebox": "更新所属时间窗口的 planning-cycle 时长（天）",
         "updated_planning_cycle_fields_still_describe_enclosing_timebox_not_specific_scheduled_timestamp": "更新后的 planning-cycle 字段仍描述所属时间窗口，而不是具体的计划时间戳。",
-        "updated_planning_cycle_type_year_month_week_or_day": "更新后的 planning-cycle 类型：year、month、week 或 day",
+        "updated_planning_cycle_type_year_month_week_or_day": "更新后的 planning-cycle 类型：7years、year、month、week 或 day",
         "updated_priority": "更新优先级",
         "updated_start_date_of_enclosing_planning_cycle_window_in_yyyy_mm_dd": "更新所属 planning-cycle 窗口的开始日期（YYYY-MM-DD）",
         "updated_task_content": "更新了 `task` 内容",
@@ -688,7 +688,7 @@
         "use_clear_flags_to_remove_optional_values_such_as_descriptions_or_planning": "使用 `--clear-*` 标志清除描述或 planning-cycle 等可选值。",
         "use_clear_parent_to_move_child_task_back_to_root_level": "使用 `--clear-parent` 将子 `task` 移回根级别。",
         "use_lifeos_event_add_task_id_task_id_if_task_also_needs": "如果 `task` 还需要日历日的特定时间块，请使用 `lifeos event add --task-id <task-id>`。",
-        "use_planning_cycle_fields_for_broader_year_month_week_or_day_window": "使用 planning-cycle 字段描述 `task` 所属的 year、month、week 或 day 窗口。",
+        "use_planning_cycle_fields_for_broader_year_month_week_or_day_window": "使用 planning-cycle 字段描述 `task` 所属的 7years、year、month、week 或 day 窗口。",
         "use_repeated_person_id_to_keep_human_only_agent_only_and_shared": "重复使用 `--person-id`，以明确区分仅人类、仅代理和共享的 `task` 归属。",
         "when_agent_creates_tasks_on_behalf_of_human_use_person_id_to": "当代理代表人类创建 `task` 时，使用 `--person-id` 标记 `task` 属于人类、代理或两者。"
       }

--- a/src/lifeos_web/routers/preferences.py
+++ b/src/lifeos_web/routers/preferences.py
@@ -36,6 +36,7 @@ _CONFIG_KEY_MAP = {
     "appearance.theme": "preferences.theme",
     "calendar.first_day_of_week": "preferences.calendar_first_day_of_week",
     "calendar.system": "preferences.calendar_system",
+    "calendar.seven_year_anchor_date": "preferences.calendar_seven_year_anchor_date",
     "navigation.visible_modules": "preferences.navigation_visible_modules",
     "notes.card_min_collapsed_lines": "preferences.notes_card_min_collapsed_lines",
     "notes.export_planning.include_cycle_notes": (
@@ -79,6 +80,10 @@ _META: dict[str, dict[str, Any]] = {
         "description": "First weekday used in calendar views.",
         "module": "calendar",
     },
+    "calendar.seven_year_anchor_date": {
+        "description": "Anchor date used to derive seven-year calendar periods.",
+        "module": "calendar",
+    },
     "navigation.visible_modules": {
         "allowed_values": _VISIBLE_MODULES,
         "description": "Visible LifeOS modules in the navigation rail.",
@@ -103,6 +108,8 @@ def _extract_config_preference_value(preferences: PreferencesSettings, key: str)
         return preferences.calendar_first_day_of_week
     if key == "calendar.system":
         return preferences.calendar_system
+    if key == "calendar.seven_year_anchor_date":
+        return preferences.calendar_seven_year_anchor_date
     if key == "navigation.visible_modules":
         return list(preferences.navigation_visible_modules)
     if key == "notes.card_min_collapsed_lines":

--- a/tests/test_calendar_adapter.py
+++ b/tests/test_calendar_adapter.py
@@ -66,6 +66,12 @@ def test_calendar_period_helpers_validate_calendar_system() -> None:
         get_calendar_adapter("martian")
 
     assert get_calendar_period_range(
+        "7years",
+        date(2026, 4, 10),
+        calendar_system="gregorian",
+    ) == (date(2026, 1, 1), date(2032, 12, 31))
+
+    assert get_calendar_period_range(
         "month",
         date(2026, 8, 23),
         calendar_system="mayan_13_moon",
@@ -106,6 +112,13 @@ def test_task_planning_cycle_filter_range_uses_mayan_periods() -> None:
         calendar_system="mayan_13_moon",
         first_day_of_week=1,
     ) == (date(2026, 7, 26), date(2026, 8, 22))
+
+    assert _planning_cycle_date_filter_range(
+        planning_cycle_type="7years",
+        planning_cycle_start_date=date(2026, 7, 26),
+        calendar_system="mayan_13_moon",
+        first_day_of_week=1,
+    ) == (date(2026, 7, 26), date(2033, 7, 25))
 
     assert _planning_cycle_date_filter_range(
         planning_cycle_type="week",

--- a/tests/test_cli_help_content.py
+++ b/tests/test_cli_help_content.py
@@ -127,8 +127,9 @@ def test_cli_task_add_help_describes_planning_cycle_semantics(capsys) -> None:
         parser.parse_args(["task", "add", "--help"])
 
     captured = capsys.readouterr()
+    normalized_output = " ".join(captured.out.split())
 
-    assert "Planning cycle type: year, month, week, or day" in captured.out
+    assert "Planning cycle type: 7years, year, month, week, or day" in normalized_output
     assert "Start date of the enclosing planning cycle window" in captured.out
     assert "not a clock-time execution slot" in captured.out
     assert "--planning-cycle-type week --planning-cycle-days 7" in captured.out

--- a/tests/test_cli_help_zh_hans.py
+++ b/tests/test_cli_help_zh_hans.py
@@ -126,7 +126,7 @@ def test_cli_task_add_help_keeps_long_option_invocation_with_summary(
 
     assert any(
         "--planning-cycle-type PLANNING_CYCLE_TYPE" in line
-        and "planning-cycle 类型：year、month、week 或 day" in line
+        and "planning-cycle 类型：7years、year、month、week 或 day" in line
         for line in captured.out.splitlines()
     )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,6 +21,7 @@ from lifeos_cli.config import (
     parse_boolean_value,
     resolve_config_path,
     validate_calendar_first_day_of_week,
+    validate_calendar_seven_year_anchor_date,
     validate_calendar_system,
     validate_database_schema_name,
     validate_database_url,
@@ -169,6 +170,7 @@ def test_preferences_settings_read_config_file(tmp_path: Path) -> None:
                 'theme = "night"',
                 "calendar_first_day_of_week = 7",
                 'calendar_system = "mayan_13_moon"',
+                'calendar_seven_year_anchor_date = "2026-07-20"',
                 'navigation_visible_modules = ["visions", "notes", "settings"]',
                 "notes_card_min_collapsed_lines = 9",
                 "notes_export_planning_include_cycle_notes = true",
@@ -193,6 +195,7 @@ def test_preferences_settings_read_config_file(tmp_path: Path) -> None:
     assert settings.theme == "night"
     assert settings.calendar_first_day_of_week == 7
     assert settings.calendar_system == "mayan_13_moon"
+    assert settings.calendar_seven_year_anchor_date == "2026-07-20"
     assert settings.navigation_visible_modules == ("visions", "notes", "settings")
     assert settings.notes_card_min_collapsed_lines == 9
     assert settings.notes_export_planning_include_cycle_notes is True
@@ -485,6 +488,7 @@ def test_validate_language_accepts_bcp47_like_values() -> None:
 def test_validate_web_preferences_reject_invalid_values() -> None:
     assert validate_calendar_first_day_of_week("7") == 7
     assert validate_calendar_system("mayan_13_moon") == "mayan_13_moon"
+    assert validate_calendar_seven_year_anchor_date("2026-07-20") == "2026-07-20"
     assert validate_navigation_visible_modules(["visions", "notes", "visions"]) == (
         "visions",
         "notes",
@@ -499,6 +503,7 @@ def test_validate_web_preferences_reject_invalid_values() -> None:
     invalid_cases = (
         lambda: validate_calendar_first_day_of_week("8"),
         lambda: validate_calendar_system("julian"),
+        lambda: validate_calendar_seven_year_anchor_date("2026-02-31"),
         lambda: validate_navigation_visible_modules(["visions", "unknown"]),
         lambda: validate_notes_card_min_collapsed_lines("4"),
         lambda: validate_tasks_default_planning_preset("tomorrow"),
@@ -931,6 +936,7 @@ def test_build_preferences_settings_preserves_existing_web_preferences(
                 'theme = "night"',
                 "calendar_first_day_of_week = 7",
                 'calendar_system = "mayan_13_moon"',
+                'calendar_seven_year_anchor_date = "2026-07-20"',
                 'navigation_visible_modules = ["visions", "notes", "settings"]',
                 "notes_card_min_collapsed_lines = 11",
                 "notes_export_planning_include_cycle_notes = true",
@@ -964,6 +970,7 @@ def test_build_preferences_settings_preserves_existing_web_preferences(
     assert settings.theme == "night"
     assert settings.calendar_first_day_of_week == 7
     assert settings.calendar_system == "mayan_13_moon"
+    assert settings.calendar_seven_year_anchor_date == "2026-07-20"
     assert settings.navigation_visible_modules == ("visions", "notes", "settings")
     assert settings.notes_card_min_collapsed_lines == 11
     assert settings.notes_export_planning_include_cycle_notes is True

--- a/tests/test_domain_services_tasks_and_habits.py
+++ b/tests/test_domain_services_tasks_and_habits.py
@@ -34,6 +34,14 @@ def test_validate_planning_cycle_requires_complete_fields() -> None:
         )
 
 
+def test_validate_planning_cycle_accepts_seven_year_cycle() -> None:
+    assert tasks.validate_planning_cycle(
+        planning_cycle_type="7years",
+        planning_cycle_days=365 * 7,
+        planning_cycle_start_date=date(2026, 1, 1),
+    ) == ("7years", 365 * 7, date(2026, 1, 1))
+
+
 def test_create_task_flushes_without_committing(monkeypatch: pytest.MonkeyPatch) -> None:
     session = SimpleNamespace(
         add=None,

--- a/tests/test_web_cli.py
+++ b/tests/test_web_cli.py
@@ -2572,16 +2572,25 @@ def test_web_calendar_preferences_persist_to_cli_config(
             PreferenceUpdate(value=7, module="calendar"),
         )
     )
+    updated_anchor_date = asyncio.run(
+        set_preference(
+            "calendar.seven_year_anchor_date",
+            PreferenceUpdate(value="2026-07-20", module="calendar"),
+        )
+    )
 
     assert updated_system["value"] == "mayan_13_moon"
     assert updated_first_day["value"] == 7
+    assert updated_anchor_date["value"] == "2026-07-20"
     clear_config_cache()
     assert asyncio.run(get_preference("calendar.system"))["value"] == "mayan_13_moon"
     assert asyncio.run(get_preference("calendar.first_day_of_week"))["value"] == 7
+    assert asyncio.run(get_preference("calendar.seven_year_anchor_date"))["value"] == "2026-07-20"
 
     content = config_path.read_text(encoding="utf-8")
     assert 'calendar_system = "mayan_13_moon"' in content
     assert "calendar_first_day_of_week = 7" in content
+    assert 'calendar_seven_year_anchor_date = "2026-07-20"' in content
 
 
 def test_web_note_collapse_preference_persists_to_cli_config(

--- a/web/src/components/DraggableTaskList.tsx
+++ b/web/src/components/DraggableTaskList.tsx
@@ -272,6 +272,7 @@ const SortableTaskItem: React.FC<SortableTaskItemProps> = ({
         week: t("draggableTaskList.planningCycle.week"),
         month: t("draggableTaskList.planningCycle.month"),
         year: t("draggableTaskList.planningCycle.year"),
+        "7years": t("draggableTaskList.planningCycle.7years"),
       };
       const periodText =
         cycleTypeMap[task.planning_cycle_type] || task.planning_cycle_type;
@@ -480,6 +481,9 @@ const SortableTaskItem: React.FC<SortableTaskItemProps> = ({
                             week: t("draggableTaskList.planningCycle.week"),
                             month: t("draggableTaskList.planningCycle.month"),
                             year: t("draggableTaskList.planningCycle.year"),
+                            "7years": t(
+                              "draggableTaskList.planningCycle.7years",
+                            ),
                           };
 
                           if (task.planning_cycle_start_date) {

--- a/web/src/components/PeriodNavigation.tsx
+++ b/web/src/components/PeriodNavigation.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/utils/datetime";
 import { TextInput } from "./forms";
 
-type PeriodType = "day" | "week" | "month" | "year" | "sevenYear";
+type PeriodType = "day" | "week" | "month" | "year" | "7years" | "sevenYear";
 
 interface PeriodNavigationProps {
   // 周期类型
@@ -241,6 +241,7 @@ const PeriodNavigation: React.FC<PeriodNavigationProps> = ({
 
       case "year":
         return isSamePeriod(calendarAdapter, "year", selectedDate, now);
+      case "7years":
       case "sevenYear": {
         return isSamePeriod(calendarAdapter, "sevenYear", selectedDate, now);
       }
@@ -308,14 +309,13 @@ const PeriodNavigation: React.FC<PeriodNavigationProps> = ({
         return addCurrentIndicator(label);
       }
 
+      case "7years":
       case "sevenYear": {
-        // 如果提供了 startDate 和 endDate，优先使用它们来生成准确的标签
         if (startDate && endDate) {
           const label = `${startDate}-${endDate}`;
           return addCurrentIndicator(label);
         }
-        // 否则回退到基于 selectedDate 的计算
-        const range = calendarAdapter.getPeriodRange("sevenYear", selectedDate);
+        const range = calendarAdapter.getPeriodRange(periodType, selectedDate);
         const label = `${range.start}-${range.end}`;
         return addCurrentIndicator(label);
       }

--- a/web/src/components/PlanningCycleDateInput.tsx
+++ b/web/src/components/PlanningCycleDateInput.tsx
@@ -78,8 +78,8 @@ export const PlanningCycleDateInput: React.FC<PlanningCycleDateInputProps> = ({
     }
   }
 
-  // Handle year selection via EnumSelect with configurable range
-  if (cycleType === "year") {
+  // Handle year-based cycle selection via EnumSelect with configurable range
+  if (cycleType === "year" || cycleType === "7years") {
     // Use adapter's display year logic for consistent behavior across calendar systems
     let currentYear = "";
     if (startDate && adapter && adapter.getDisplayYear) {
@@ -128,6 +128,7 @@ export const PlanningCycleDateInput: React.FC<PlanningCycleDateInputProps> = ({
   const getInputType = () => {
     switch (cycleType) {
       case "year":
+      case "7years":
         return "number";
       case "month":
         return "month";
@@ -144,6 +145,7 @@ export const PlanningCycleDateInput: React.FC<PlanningCycleDateInputProps> = ({
 
     switch (cycleType) {
       case "year":
+      case "7years":
         // Use adapter's display year logic for consistent behavior
         if (adapter && adapter.getDisplayYear) {
           return adapter.getDisplayYear(startDate);

--- a/web/src/components/PlanningTaskList.tsx
+++ b/web/src/components/PlanningTaskList.tsx
@@ -1,6 +1,10 @@
 import React from "react";
 import type { Vision } from "@/services/api";
-import type { CalendarAdapter, PlanningGroup } from "@/utils/calendar";
+import type {
+  CalendarAdapter,
+  PlanningGroup,
+  PlanningViewType,
+} from "@/utils/calendar";
 import type { UUID } from "@/types/primitive";
 import { usePlanningTaskGroup } from "@/hooks/planning/usePlanningTaskGroup";
 import { TaskGroupCard } from "./planning/TaskGroupCard";
@@ -10,7 +14,7 @@ interface PlanningTaskListProps {
   visions: Vision[];
   onTaskUpdate?: () => void;
   onTaskStatusUpdate?: (taskId: UUID, newStatus: string) => Promise<void>;
-  planningCycleType?: "year" | "month" | "week" | "day";
+  planningCycleType?: PlanningViewType;
   calendarAdapter?: CalendarAdapter;
 }
 

--- a/web/src/components/__tests__/PeriodNavigation.test.tsx
+++ b/web/src/components/__tests__/PeriodNavigation.test.tsx
@@ -85,6 +85,8 @@ const calendarAdapterMock = {
 
 vi.mock("@/utils/calendar", () => ({
   DEFAULT_SEVEN_YEAR_ANCHOR_DATE: "2025-07-26",
+  isLocalDateString: (value: unknown) =>
+    typeof value === "string" && /^\d{4}-\d{2}-\d{2}$/.test(value),
   parseLocalDateString: (value: string) => new Date(`${value}T00:00:00`),
   CalendarAdapterFactory: {
     create: vi.fn(() => calendarAdapterMock),

--- a/web/src/components/__tests__/PeriodNavigation.test.tsx
+++ b/web/src/components/__tests__/PeriodNavigation.test.tsx
@@ -84,6 +84,8 @@ const calendarAdapterMock = {
 };
 
 vi.mock("@/utils/calendar", () => ({
+  DEFAULT_SEVEN_YEAR_ANCHOR_DATE: "2025-07-26",
+  parseLocalDateString: (value: string) => new Date(`${value}T00:00:00`),
   CalendarAdapterFactory: {
     create: vi.fn(() => calendarAdapterMock),
   },

--- a/web/src/components/planning/TaskGroupCard.tsx
+++ b/web/src/components/planning/TaskGroupCard.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import type { PlanningGroup } from "@/utils/calendar";
+import type { PlanningGroup, PlanningViewType } from "@/utils/calendar";
 import type { TaskWithSubtasks, Vision } from "@/services/api";
 import type { HabitActionWithHabit } from "@/services/api/habits";
 import type { UUID } from "@/types/primitive";
@@ -17,7 +17,7 @@ import { TaskListSection } from "./TaskListSection";
 interface TaskGroupCardProps {
   group: PlanningGroup;
   visions: Vision[];
-  planningCycleType?: "year" | "month" | "week" | "day";
+  planningCycleType?: PlanningViewType;
   statusFilter: string;
   statusFilterOptions: StatusFilterOption[];
   visionFilter: string;

--- a/web/src/components/planning/TaskGroupHeader.tsx
+++ b/web/src/components/planning/TaskGroupHeader.tsx
@@ -4,6 +4,7 @@ import Container from "@/layouts/Container";
 import ActionButton from "@/components/ActionButton";
 import EnumSelect from "@/components/selects/EnumSelect";
 import { Icon } from "@/components/icons";
+import type { PlanningViewType } from "@/utils/calendar";
 
 import type { StatusFilterOption } from "@/hooks/planning/usePlanningTaskGroup";
 
@@ -11,7 +12,7 @@ interface TaskGroupHeaderProps {
   groupId: string;
   groupLabel: string;
   periodRangeLabel?: string;
-  planningCycleType?: "year" | "month" | "week" | "day";
+  planningCycleType?: PlanningViewType;
   totalTimeSpent: string;
   statusFilter: string;
   statusFilterOptions: StatusFilterOption[];

--- a/web/src/components/settings/SettingItem.tsx
+++ b/web/src/components/settings/SettingItem.tsx
@@ -137,6 +137,22 @@ const SettingItem: React.FC<SettingItemProps> = ({
         );
       }
 
+      case "date":
+        return (
+          <TextInput
+            id={getControlId()}
+            type="date"
+            value={typeof value === "string" ? value : ""}
+            onChange={(event) => {
+              void commitValue(event.target.value);
+            }}
+            disabled={isControlDisabled}
+            aria-describedby={
+              config.description ? `${getControlId()}-description` : undefined
+            }
+          />
+        );
+
       case "checkbox":
         return (
           <Checkbox
@@ -218,6 +234,8 @@ const SettingItem: React.FC<SettingItemProps> = ({
         return `${config.key}-select`;
       case "number":
         return `${config.key}-input`;
+      case "date":
+        return `${config.key}-date`;
       case "checkbox":
         return config.key;
       case "multiselect":

--- a/web/src/components/settings/types.ts
+++ b/web/src/components/settings/types.ts
@@ -4,6 +4,7 @@ type SettingItemType =
   | "select"
   | "checkbox"
   | "multiselect"
+  | "date"
   | "number"
   | "custom";
 

--- a/web/src/components/tasks/TaskEditModalView.tsx
+++ b/web/src/components/tasks/TaskEditModalView.tsx
@@ -314,6 +314,7 @@ export const TaskEditModalView: React.FC<TaskEditModalViewProps> = ({
                   { value: "week", label: t("target.week") },
                   { value: "month", label: t("target.month") },
                   { value: "year", label: t("target.year") },
+                  { value: "7years", label: t("target.sevenYears") },
                 ]}
                 disabled={loading}
                 id="planning-cycle-type-select"
@@ -330,6 +331,8 @@ export const TaskEditModalView: React.FC<TaskEditModalViewProps> = ({
                   >
                     {formData.planning_cycle_type === "year" &&
                       t("taskForm.planning.startLabels.year")}
+                    {formData.planning_cycle_type === "7years" &&
+                      t("taskForm.planning.startLabels.sevenYears")}
                     {formData.planning_cycle_type === "month" &&
                       t("taskForm.planning.startLabels.month")}
                     {formData.planning_cycle_type === "week" &&

--- a/web/src/components/tasks/TaskEditModalView.tsx
+++ b/web/src/components/tasks/TaskEditModalView.tsx
@@ -180,6 +180,7 @@ export const TaskEditModalView: React.FC<TaskEditModalViewProps> = ({
           label={t("taskForm.fields.content")}
           htmlFor={taskContentId}
           required
+          labelClassName="text-sm sm:text-sm mb-1 sm:mb-1"
           description={
             isBulkMode ? t("taskForm.tips.bulkContentDescription") : undefined
           }
@@ -198,6 +199,7 @@ export const TaskEditModalView: React.FC<TaskEditModalViewProps> = ({
                 disabled={loading}
                 rows={8}
                 resize="vertical"
+                className="text-sm sm:text-sm"
               />
               <p className="text-xs sm:text-sm mt-2 text-primary font-medium">
                 {t("taskForm.tips.bulkContentHelper")}
@@ -216,6 +218,8 @@ export const TaskEditModalView: React.FC<TaskEditModalViewProps> = ({
               placeholder={t("taskForm.placeholders.content")}
               required
               disabled={loading}
+              size="sm"
+              className="text-sm"
             />
           )}
         </FormField>
@@ -312,8 +316,14 @@ export const TaskEditModalView: React.FC<TaskEditModalViewProps> = ({
                   { value: "", label: t("common.none") },
                   { value: "day", label: t("target.day") },
                   { value: "week", label: t("target.week") },
-                  { value: "month", label: t("target.month") },
-                  { value: "year", label: t("target.year") },
+                  {
+                    value: "month",
+                    label: t("taskForm.planning.cycleTypes.month"),
+                  },
+                  {
+                    value: "year",
+                    label: t("taskForm.planning.cycleTypes.year"),
+                  },
                   { value: "7years", label: t("target.sevenYears") },
                 ]}
                 disabled={loading}
@@ -327,7 +337,7 @@ export const TaskEditModalView: React.FC<TaskEditModalViewProps> = ({
                 <div className="mt-0 sm:mt-2">
                   <label
                     htmlFor={planningCycleStartDateId}
-                    className="block text-sm sm:text-base font-medium mb-1"
+                    className="block text-sm font-medium text-base-content mb-1"
                   >
                     {formData.planning_cycle_type === "year" &&
                       t("taskForm.planning.startLabels.year")}

--- a/web/src/components/tooltips/TaskTooltipContent.tsx
+++ b/web/src/components/tooltips/TaskTooltipContent.tsx
@@ -61,6 +61,7 @@ const TaskTooltipContent: React.FC<TaskTooltipContentProps> = ({
       week: t("draggableTaskList.planningCycle.week"),
       month: t("draggableTaskList.planningCycle.month"),
       year: t("draggableTaskList.planningCycle.year"),
+      "7years": t("draggableTaskList.planningCycle.7years"),
     };
     const periodText =
       cycleTypeMap[task.planning_cycle_type] || task.planning_cycle_type;

--- a/web/src/config/__tests__/settingsConfig.test.tsx
+++ b/web/src/config/__tests__/settingsConfig.test.tsx
@@ -49,6 +49,10 @@ describe("useSettingsConfig", () => {
           ]),
         }),
         expect.objectContaining({
+          key: "sevenYearAnchorDate",
+          type: "date",
+        }),
+        expect.objectContaining({
           key: "firstDayOfWeek",
           type: "select",
           options: expect.arrayContaining([
@@ -69,7 +73,15 @@ describe("useSettingsConfig", () => {
     const firstDayItem = calendarGroup?.items.find(
       (item) => item.key === "firstDayOfWeek",
     );
+    const anchorDateItem = calendarGroup?.items.find(
+      (item) => item.key === "sevenYearAnchorDate",
+    );
 
     expect(firstDayItem).toBeUndefined();
+    expect(anchorDateItem).toEqual(
+      expect.objectContaining({
+        type: "date",
+      }),
+    );
   });
 });

--- a/web/src/config/settingsConfig.tsx
+++ b/web/src/config/settingsConfig.tsx
@@ -132,6 +132,12 @@ export const useSettingsConfig = (
             },
           ],
         },
+        {
+          key: "sevenYearAnchorDate",
+          type: "date",
+          label: t("settings.calendar.sevenYearAnchorDate.label"),
+          description: t("settings.calendar.sevenYearAnchorDate.description"),
+        },
         ...(context.calendarSystem === "mayan_13_moon"
           ? []
           : [

--- a/web/src/hooks/planning/usePlanningTaskGroup.ts
+++ b/web/src/hooks/planning/usePlanningTaskGroup.ts
@@ -13,7 +13,11 @@ import { useMultipleTaskTimelogs } from "@/hooks/queries/useTaskTimelogs";
 import { useHabitActionsByDate } from "@/hooks/queries/useHabitActionsByDate";
 import { useTaskExpansionState } from "@/hooks/useTaskExpansionState";
 import { usePersistentState } from "@/hooks/usePersistentState";
-import type { CalendarAdapter, PlanningGroup } from "@/utils/calendar";
+import type {
+  CalendarAdapter,
+  PlanningGroup,
+  PlanningViewType,
+} from "@/utils/calendar";
 import { formatDateInTimezone, formatDuration } from "@/utils/datetime";
 import { ACTIVE_TASK_STATUSES, TASK_STATUS_LABELS } from "@/utils/constants";
 
@@ -43,7 +47,7 @@ interface PlanningTaskGroupHookParams {
   group: PlanningGroup;
   visions: Vision[];
   onTaskUpdate?: () => void;
-  planningCycleType?: "year" | "month" | "week" | "day";
+  planningCycleType?: PlanningViewType;
   calendarAdapter?: CalendarAdapter;
 }
 

--- a/web/src/hooks/queries/__tests__/usePlanningTasks.test.tsx
+++ b/web/src/hooks/queries/__tests__/usePlanningTasks.test.tsx
@@ -128,4 +128,24 @@ describe("usePlanningTasks", () => {
       first_day_of_week: 7,
     });
   });
+
+  it("uses 7years as the planning cycle query value", async () => {
+    tasksGetAllMock.mockResolvedValue({
+      items: [],
+      pagination: { page: 1, size: 100, total: 0, pages: 0 },
+      meta: {},
+    });
+
+    renderHook(
+      () => usePlanningTasks("7years", new Date("2026-01-01T00:00:00Z")),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(tasksGetAllMock).toHaveBeenCalled());
+    const [, , filters] = tasksGetAllMock.mock.calls[0];
+    expect(filters).toMatchObject({
+      planning_cycle_type: "7years",
+      planning_cycle_start_date: "2026-01-01",
+    });
+  });
 });

--- a/web/src/hooks/queries/usePlanningTasks.ts
+++ b/web/src/hooks/queries/usePlanningTasks.ts
@@ -9,7 +9,7 @@ import {
 import { tasksKeys } from "@/services/api/queryKeys";
 import type { UUID } from "@/types/primitive";
 
-type PlanningCycleType = "year" | "month" | "week" | "day";
+type PlanningCycleType = "7years" | "year" | "month" | "week" | "day";
 type CalendarSystem = "gregorian" | "mayan_13_moon";
 
 function buildTaskHierarchy(flatTasks: Task[]): TaskWithSubtasks[] {

--- a/web/src/hooks/tasks/useTaskEditor.ts
+++ b/web/src/hooks/tasks/useTaskEditor.ts
@@ -14,7 +14,7 @@ import { useToast } from "@/contexts/ToastContext";
 import { usePlanningCycle } from "@/hooks/useCalendarAdapter";
 import { usePreferenceWithBootstrap } from "@/hooks/queries/usePreferenceWithBootstrap";
 import { ALL_TASK_STATUSES, ALL_VISION_STATUSES } from "@/utils/constants";
-import type { PlanningViewType } from "@/utils/calendar";
+import type { ExtendedPlanningViewType } from "@/utils/calendar";
 import type { UUID } from "@/types/primitive";
 import { logger } from "@/utils/core";
 import { invalidateTasksByIds, updateTaskCaches } from "@/utils/query";
@@ -350,7 +350,7 @@ export function useTaskEditor(
       const options = getQuickSetOptions(now);
       const presetSettings = options[presetKey];
 
-      const cycleType: PlanningViewType =
+      const cycleType: ExtendedPlanningViewType =
         presetKey === "thisWeek"
           ? "week"
           : presetKey === "thisMonth"
@@ -486,7 +486,7 @@ export function useTaskEditor(
       if (resolvedType) {
         const now = new Date();
         const settings = getDefaultCycleSettings(
-          resolvedType as PlanningViewType,
+          resolvedType as ExtendedPlanningViewType,
           now,
         );
         defaultStartDate = settings.startDate;
@@ -503,12 +503,27 @@ export function useTaskEditor(
     [getDefaultCycleSettings],
   );
 
-  const handlePlanningStartDateChange = useCallback((startDate?: string) => {
-    setFormData((prev) => ({
-      ...prev,
-      planning_cycle_start_date: startDate,
-    }));
-  }, []);
+  const handlePlanningStartDateChange = useCallback(
+    (startDate?: string) => {
+      setFormData((prev) => {
+        const cycleType = prev.planning_cycle_type;
+        const planningCycleDays =
+          cycleType && startDate
+            ? getDefaultCycleSettings(
+                cycleType as ExtendedPlanningViewType,
+                new Date(`${startDate}T00:00:00`),
+              ).days
+            : prev.planning_cycle_days;
+
+        return {
+          ...prev,
+          planning_cycle_days: planningCycleDays,
+          planning_cycle_start_date: startDate,
+        };
+      });
+    },
+    [getDefaultCycleSettings],
+  );
 
   const handleSubmit = useCallback(
     async (event: React.FormEvent<HTMLFormElement>) => {

--- a/web/src/hooks/useCalendarAdapter.ts
+++ b/web/src/hooks/useCalendarAdapter.ts
@@ -4,7 +4,7 @@ import { CalendarAdapterFactory } from "@/utils/calendar";
 import type {
   CalendarAdapter,
   CalendarSystem,
-  PlanningViewType,
+  ExtendedPlanningViewType,
 } from "@/utils/calendar";
 
 interface CalendarAdapterState {
@@ -64,7 +64,7 @@ export function usePlanningCycle() {
    * Get default planning cycle settings for a given cycle type
    */
   const getDefaultCycleSettings = (
-    cycleType: PlanningViewType,
+    cycleType: ExtendedPlanningViewType,
     baseDate: Date = new Date(),
   ) => {
     const yearStart = adapter.getYearStart(baseDate);
@@ -75,6 +75,10 @@ export function usePlanningCycle() {
     // Override start date based on cycle type
     switch (cycleType) {
       case "year":
+        startDate.setTime(yearStart.getTime());
+        break;
+      case "7years":
+      case "sevenYear":
         startDate.setTime(yearStart.getTime());
         break;
       case "month":

--- a/web/src/hooks/useCalendarAdapter.ts
+++ b/web/src/hooks/useCalendarAdapter.ts
@@ -1,11 +1,30 @@
 import { useMemo } from "react";
 import { usePreferenceWithBootstrap } from "./queries/usePreferenceWithBootstrap";
-import { CalendarAdapterFactory } from "@/utils/calendar";
+import {
+  CalendarAdapterFactory,
+  DEFAULT_SEVEN_YEAR_ANCHOR_DATE,
+  parseLocalDateString,
+} from "@/utils/calendar";
 import type {
   CalendarAdapter,
   CalendarSystem,
   ExtendedPlanningViewType,
 } from "@/utils/calendar";
+
+function isIsoDate(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) return false;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const date = new Date(year, month - 1, day);
+  return (
+    date.getFullYear() === year &&
+    date.getMonth() === month - 1 &&
+    date.getDate() === day
+  );
+}
 
 interface CalendarAdapterState {
   adapter: CalendarAdapter;
@@ -32,6 +51,12 @@ export function useCalendarAdapter(): CalendarAdapterState {
     module: "calendar",
     validator: (value) => Number.isFinite(value) && value >= 1 && value <= 7,
   });
+  const sevenYearAnchorPreference = usePreferenceWithBootstrap<string>({
+    key: "calendar.seven_year_anchor_date",
+    defaultValue: DEFAULT_SEVEN_YEAR_ANCHOR_DATE,
+    module: "calendar",
+    validator: isIsoDate,
+  });
 
   const calendarSystem: CalendarSystem =
     calendarSystemPreference.value === "mayan_13_moon"
@@ -40,16 +65,26 @@ export function useCalendarAdapter(): CalendarAdapterState {
   const firstDayOfWeek = Number.isFinite(firstDayPreference.value)
     ? firstDayPreference.value
     : 1;
+  const sevenYearAnchorDate = isIsoDate(sevenYearAnchorPreference.value)
+    ? sevenYearAnchorPreference.value
+    : DEFAULT_SEVEN_YEAR_ANCHOR_DATE;
 
   const adapter = useMemo(() => {
-    return CalendarAdapterFactory.create(calendarSystem, firstDayOfWeek);
-  }, [calendarSystem, firstDayOfWeek]);
+    return CalendarAdapterFactory.create(
+      calendarSystem,
+      firstDayOfWeek,
+      sevenYearAnchorDate,
+    );
+  }, [calendarSystem, firstDayOfWeek, sevenYearAnchorDate]);
 
   return {
     adapter,
     calendarSystem,
     firstDayOfWeek,
-    loading: calendarSystemPreference.loading || firstDayPreference.loading,
+    loading:
+      calendarSystemPreference.loading ||
+      firstDayPreference.loading ||
+      sevenYearAnchorPreference.loading,
   };
 }
 
@@ -79,7 +114,11 @@ export function usePlanningCycle() {
         break;
       case "7years":
       case "sevenYear":
-        startDate.setTime(yearStart.getTime());
+        startDate.setTime(
+          parseLocalDateString(
+            adapter.getPeriodRange("7years", baseDate).start,
+          ).getTime(),
+        );
         break;
       case "month":
         if (monthInfo.monthStart) {

--- a/web/src/hooks/useCalendarAdapter.ts
+++ b/web/src/hooks/useCalendarAdapter.ts
@@ -3,6 +3,7 @@ import { usePreferenceWithBootstrap } from "./queries/usePreferenceWithBootstrap
 import {
   CalendarAdapterFactory,
   DEFAULT_SEVEN_YEAR_ANCHOR_DATE,
+  isLocalDateString,
   parseLocalDateString,
 } from "@/utils/calendar";
 import type {
@@ -10,21 +11,6 @@ import type {
   CalendarSystem,
   ExtendedPlanningViewType,
 } from "@/utils/calendar";
-
-function isIsoDate(value: unknown): value is string {
-  if (typeof value !== "string") return false;
-  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
-  if (!match) return false;
-  const year = Number(match[1]);
-  const month = Number(match[2]);
-  const day = Number(match[3]);
-  const date = new Date(year, month - 1, day);
-  return (
-    date.getFullYear() === year &&
-    date.getMonth() === month - 1 &&
-    date.getDate() === day
-  );
-}
 
 interface CalendarAdapterState {
   adapter: CalendarAdapter;
@@ -55,7 +41,7 @@ export function useCalendarAdapter(): CalendarAdapterState {
     key: "calendar.seven_year_anchor_date",
     defaultValue: DEFAULT_SEVEN_YEAR_ANCHOR_DATE,
     module: "calendar",
-    validator: isIsoDate,
+    validator: isLocalDateString,
   });
 
   const calendarSystem: CalendarSystem =
@@ -65,7 +51,7 @@ export function useCalendarAdapter(): CalendarAdapterState {
   const firstDayOfWeek = Number.isFinite(firstDayPreference.value)
     ? firstDayPreference.value
     : 1;
-  const sevenYearAnchorDate = isIsoDate(sevenYearAnchorPreference.value)
+  const sevenYearAnchorDate = isLocalDateString(sevenYearAnchorPreference.value)
     ? sevenYearAnchorPreference.value
     : DEFAULT_SEVEN_YEAR_ANCHOR_DATE;
 

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -629,6 +629,10 @@
       "firstDay": {
         "label": "First Day of Week",
         "description": "Default Monday. This setting controls Gregorian week boundaries."
+      },
+      "sevenYearAnchorDate": {
+        "label": "Seven-Year Start Date",
+        "description": "Choose a date whose calendar year anchors seven-year periods. Gregorian uses the selected date's year; Mayan 13 Moon uses the Mayan year containing that date."
       }
     },
     "planningSettings": {

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -56,6 +56,7 @@
     "priority": "Priority",
     "tag": "Tag",
     "year": "Year",
+    "sevenYears": "7 Years",
     "month": "Month",
     "week": "Week",
     "day": "Day",
@@ -873,7 +874,15 @@
       "goToCurrent": "Go to Current",
       "pickDateButton": "Pick date",
       "pickDateLabel": "Select date",
-      "pickDatePlaceholder": "YYYY-MM-DD"
+      "pickDatePlaceholder": "YYYY-MM-DD",
+      "periodTypes": {
+        "day": "Day",
+        "week": "Week",
+        "month": "Month",
+        "year": "Year",
+        "7years": "7 Years",
+        "sevenYear": "7 Years"
+      }
     },
     "emptyState": {
       "title": "No Planned Tasks",
@@ -980,6 +989,7 @@
       "description": "Planned tasks will appear on the planning page; after choosing a period, the start date will be the first day of that period.",
       "startLabels": {
         "year": "Start Year",
+        "sevenYears": "Start Year",
         "month": "Start Month",
         "week": "Start Week",
         "day": "Start Date"
@@ -1575,7 +1585,7 @@
     "planning": {
       "displayName": "Planning",
       "navLabel": "Planning",
-      "description": "Place tasks on a day, week, month, or year planning cycle."
+      "description": "Place tasks on a day, week, month, year, or 7-year planning cycle."
     },
     "timelog": {
       "displayName": "Timelog",
@@ -1889,6 +1899,7 @@
       "week": "Week",
       "month": "Month",
       "year": "Year",
+      "7years": "7 Years",
       "from": "From {{date}}",
       "within": " within"
     },

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -987,6 +987,10 @@
     "planning": {
       "title": "Planning Settings",
       "description": "Planned tasks will appear on the planning page; after choosing a period, the start date will be the first day of that period.",
+      "cycleTypes": {
+        "month": "Month",
+        "year": "Year"
+      },
       "startLabels": {
         "year": "Start Year",
         "sevenYears": "Start Year",

--- a/web/src/locales/zh/common.json
+++ b/web/src/locales/zh/common.json
@@ -629,6 +629,10 @@
       "firstDay": {
         "label": "每周第一天",
         "description": "默认周一。该设置控制公历周边界。"
+      },
+      "sevenYearAnchorDate": {
+        "label": "七年起始日期",
+        "description": "选择一个日期，用它所在的历法年份锚定七年周期。公历使用该日期所在年份；玛雅13月亮历使用该日期所在的玛雅年。"
       }
     },
     "planningSettings": {

--- a/web/src/locales/zh/common.json
+++ b/web/src/locales/zh/common.json
@@ -987,6 +987,10 @@
     "planning": {
       "title": "规划周期设置",
       "description": "被规划的任务将展示在规划页；选择周期后，开始日期将为该周期的第一天。",
+      "cycleTypes": {
+        "month": "月",
+        "year": "年"
+      },
       "startLabels": {
         "year": "开始年份",
         "sevenYears": "起始年份",

--- a/web/src/locales/zh/common.json
+++ b/web/src/locales/zh/common.json
@@ -56,6 +56,7 @@
     "priority": "优先级",
     "tag": "标签",
     "year": "年份",
+    "sevenYears": "七年",
     "month": "月份",
     "week": "周",
     "day": "日",
@@ -864,7 +865,7 @@
       "label": "视图",
       "year": "年",
       "month": "月",
-      "sevenYear": "7年"
+      "sevenYear": "七年"
     },
     "periodNavigation": {
       "previous": "前一",
@@ -873,7 +874,15 @@
       "goToCurrent": "回到当前",
       "pickDateButton": "选择日期",
       "pickDateLabel": "选择日期",
-      "pickDatePlaceholder": "YYYY-MM-DD"
+      "pickDatePlaceholder": "YYYY-MM-DD",
+      "periodTypes": {
+        "day": "日",
+        "week": "周",
+        "month": "月",
+        "year": "年",
+        "7years": "七年",
+        "sevenYear": "七年"
+      }
     },
     "emptyState": {
       "title": "暂无规划任务",
@@ -980,6 +989,7 @@
       "description": "被规划的任务将展示在规划页；选择周期后，开始日期将为该周期的第一天。",
       "startLabels": {
         "year": "开始年份",
+        "sevenYears": "起始年份",
         "month": "开始月份",
         "week": "开始周起始日",
         "day": "开始日期"
@@ -1575,7 +1585,7 @@
     "planning": {
       "displayName": "任务规划",
       "navLabel": "任务规划",
-      "description": "以日、周、月等视图规划愿景的实现，聚焦当下任务并捕获相关想法。"
+      "description": "以日、周、月、年和七年视图规划愿景的实现，聚焦当下任务并捕获相关想法。"
     },
     "timelog": {
       "displayName": "时间日志",
@@ -1889,6 +1899,7 @@
       "week": "周",
       "month": "月",
       "year": "年",
+      "7years": "七年",
       "from": "{{date}}起",
       "within": "内"
     },

--- a/web/src/pages/PlanningPage.tsx
+++ b/web/src/pages/PlanningPage.tsx
@@ -38,6 +38,8 @@ const PlanningPage: React.FC = () => {
   const normalizedDate = useMemo(() => {
     if (!calendarAdapter) return selectedDate;
     switch (viewType) {
+      case "7years":
+        return calendarAdapter.getYearStart(selectedDate);
       case "year":
         return calendarAdapter.getYearStart(selectedDate);
       case "month": {
@@ -66,12 +68,18 @@ const PlanningPage: React.FC = () => {
   });
 
   useEffect(() => {
-    const others: PlanningViewType[] = ["year", "month", "week", "day"].filter(
-      (vt) => vt !== viewType,
-    ) as PlanningViewType[];
+    const others: PlanningViewType[] = [
+      "7years",
+      "year",
+      "month",
+      "week",
+      "day",
+    ].filter((vt) => vt !== viewType) as PlanningViewType[];
     others.forEach((vt) => {
       const dateForPrefetch = (() => {
         switch (vt) {
+          case "7years":
+            return calendarAdapter.getYearStart(selectedDate);
           case "year":
             return calendarAdapter.getYearStart(selectedDate);
           case "month": {
@@ -161,6 +169,7 @@ const PlanningPage: React.FC = () => {
               <SegmentedControl
                 value={viewType}
                 options={[
+                  { value: "7years", label: t("planning.viewType.sevenYear") },
                   { value: "year", label: t("planning.viewType.year") },
                   { value: "month", label: t("planning.viewType.month") },
                   { value: "week", label: t("target.week") },

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -24,6 +24,23 @@ import {
   useNoteCollapsePreference,
 } from "@/hooks/notes/useNoteCollapsePreference";
 
+const DEFAULT_SEVEN_YEAR_ANCHOR_DATE = "2025-07-26";
+
+function isIsoDate(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) return false;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const date = new Date(year, month - 1, day);
+  return (
+    date.getFullYear() === year &&
+    date.getMonth() === month - 1 &&
+    date.getDate() === day
+  );
+}
+
 function SettingsPage() {
   const { t } = useTranslation();
   const toast = useToast();
@@ -49,6 +66,13 @@ function SettingsPage() {
       value >= 1 &&
       value <= 7,
   });
+  const calendarSevenYearAnchorDateSettings =
+    usePreferenceWithBootstrap<string>({
+      key: "calendar.seven_year_anchor_date",
+      defaultValue: DEFAULT_SEVEN_YEAR_ANCHOR_DATE,
+      module: "calendar",
+      validator: isIsoDate,
+    });
 
   const visionExperienceSettings = usePreferenceWithBootstrap<number>({
     key: "visions.experience_rate_per_hour",
@@ -211,6 +235,17 @@ function SettingsPage() {
         updateValue: (value: unknown) =>
           calendarFirstDaySettings.updateValue(Number(value)),
       },
+      "calendar.sevenYearAnchorDate": {
+        ...calendarSevenYearAnchorDateSettings,
+        saveValue: async (value: unknown) =>
+          await calendarSevenYearAnchorDateSettings.saveValue(
+            isIsoDate(value) ? value : DEFAULT_SEVEN_YEAR_ANCHOR_DATE,
+          ),
+        updateValue: (value: unknown) =>
+          calendarSevenYearAnchorDateSettings.updateValue(
+            isIsoDate(value) ? value : DEFAULT_SEVEN_YEAR_ANCHOR_DATE,
+          ),
+      },
       "visions.experienceRatePerHour": {
         ...visionExperiencePreference,
         saveValue: async (value: unknown) =>
@@ -297,6 +332,7 @@ function SettingsPage() {
       visibleModulesSettings,
       calendarSystemSettings,
       calendarFirstDaySettings,
+      calendarSevenYearAnchorDateSettings,
       visionExperiencePreference,
       noteCollapseSettings,
       areaOrderSettings,

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -23,23 +23,10 @@ import {
   coerceNoteCollapseValue,
   useNoteCollapsePreference,
 } from "@/hooks/notes/useNoteCollapsePreference";
-
-const DEFAULT_SEVEN_YEAR_ANCHOR_DATE = "2025-07-26";
-
-function isIsoDate(value: unknown): value is string {
-  if (typeof value !== "string") return false;
-  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
-  if (!match) return false;
-  const year = Number(match[1]);
-  const month = Number(match[2]);
-  const day = Number(match[3]);
-  const date = new Date(year, month - 1, day);
-  return (
-    date.getFullYear() === year &&
-    date.getMonth() === month - 1 &&
-    date.getDate() === day
-  );
-}
+import {
+  DEFAULT_SEVEN_YEAR_ANCHOR_DATE,
+  isLocalDateString,
+} from "@/utils/calendar";
 
 function SettingsPage() {
   const { t } = useTranslation();
@@ -71,7 +58,7 @@ function SettingsPage() {
       key: "calendar.seven_year_anchor_date",
       defaultValue: DEFAULT_SEVEN_YEAR_ANCHOR_DATE,
       module: "calendar",
-      validator: isIsoDate,
+      validator: isLocalDateString,
     });
 
   const visionExperienceSettings = usePreferenceWithBootstrap<number>({
@@ -239,11 +226,11 @@ function SettingsPage() {
         ...calendarSevenYearAnchorDateSettings,
         saveValue: async (value: unknown) =>
           await calendarSevenYearAnchorDateSettings.saveValue(
-            isIsoDate(value) ? value : DEFAULT_SEVEN_YEAR_ANCHOR_DATE,
+            isLocalDateString(value) ? value : DEFAULT_SEVEN_YEAR_ANCHOR_DATE,
           ),
         updateValue: (value: unknown) =>
           calendarSevenYearAnchorDateSettings.updateValue(
-            isIsoDate(value) ? value : DEFAULT_SEVEN_YEAR_ANCHOR_DATE,
+            isLocalDateString(value) ? value : DEFAULT_SEVEN_YEAR_ANCHOR_DATE,
           ),
       },
       "visions.experienceRatePerHour": {

--- a/web/src/pages/__tests__/PlanningPage.integration.test.tsx
+++ b/web/src/pages/__tests__/PlanningPage.integration.test.tsx
@@ -90,6 +90,8 @@ const calendarAdapter = {
 
 vi.mock("@/utils/calendar", () => ({
   DEFAULT_SEVEN_YEAR_ANCHOR_DATE: "2025-07-26",
+  isLocalDateString: (value: unknown) =>
+    typeof value === "string" && /^\d{4}-\d{2}-\d{2}$/.test(value),
   parseLocalDateString: (value: string) => new Date(`${value}T00:00:00`),
   CalendarAdapterFactory: {
     create: vi.fn(() => calendarAdapter),

--- a/web/src/pages/__tests__/PlanningPage.integration.test.tsx
+++ b/web/src/pages/__tests__/PlanningPage.integration.test.tsx
@@ -89,6 +89,8 @@ const calendarAdapter = {
 };
 
 vi.mock("@/utils/calendar", () => ({
+  DEFAULT_SEVEN_YEAR_ANCHOR_DATE: "2025-07-26",
+  parseLocalDateString: (value: string) => new Date(`${value}T00:00:00`),
   CalendarAdapterFactory: {
     create: vi.fn(() => calendarAdapter),
   },

--- a/web/src/utils/calendar/CalendarAdapter.ts
+++ b/web/src/utils/calendar/CalendarAdapter.ts
@@ -5,11 +5,27 @@ export type ExtendedPlanningViewType = PlanningViewType | "sevenYear";
 
 export const DEFAULT_SEVEN_YEAR_ANCHOR_DATE = "2025-07-26";
 
+export const isLocalDateString = (value: unknown): value is string => {
+  if (typeof value !== "string") return false;
+  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) return false;
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const parsed = new Date(year, month - 1, day);
+  return (
+    parsed.getFullYear() === year &&
+    parsed.getMonth() === month - 1 &&
+    parsed.getDate() === day
+  );
+};
+
 export const parseLocalDateString = (
   dateValue: string,
   fallback: string = DEFAULT_SEVEN_YEAR_ANCHOR_DATE,
 ): Date => {
-  const value = /^\d{4}-\d{2}-\d{2}$/.test(dateValue) ? dateValue : fallback;
+  const value = isLocalDateString(dateValue) ? dateValue : fallback;
   const match = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
   if (!match) {
     return parseLocalDateString(fallback, DEFAULT_SEVEN_YEAR_ANCHOR_DATE);

--- a/web/src/utils/calendar/CalendarAdapter.ts
+++ b/web/src/utils/calendar/CalendarAdapter.ts
@@ -3,6 +3,32 @@ import type { TaskWithSubtasks } from "@/services/api";
 export type PlanningViewType = "7years" | "year" | "month" | "week" | "day";
 export type ExtendedPlanningViewType = PlanningViewType | "sevenYear";
 
+export const DEFAULT_SEVEN_YEAR_ANCHOR_DATE = "2025-07-26";
+
+export const parseLocalDateString = (
+  dateValue: string,
+  fallback: string = DEFAULT_SEVEN_YEAR_ANCHOR_DATE,
+): Date => {
+  const value = /^\d{4}-\d{2}-\d{2}$/.test(dateValue) ? dateValue : fallback;
+  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) {
+    return parseLocalDateString(fallback, DEFAULT_SEVEN_YEAR_ANCHOR_DATE);
+  }
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const parsed = new Date(year, month - 1, day);
+  if (
+    parsed.getFullYear() !== year ||
+    parsed.getMonth() !== month - 1 ||
+    parsed.getDate() !== day
+  ) {
+    return parseLocalDateString(fallback, DEFAULT_SEVEN_YEAR_ANCHOR_DATE);
+  }
+  return parsed;
+};
+
 export const normalizePlanningViewType = (
   viewType: ExtendedPlanningViewType,
 ): "sevenYear" | "year" | "month" | "week" | "day" =>

--- a/web/src/utils/calendar/CalendarAdapter.ts
+++ b/web/src/utils/calendar/CalendarAdapter.ts
@@ -1,7 +1,12 @@
 import type { TaskWithSubtasks } from "@/services/api";
 
-export type PlanningViewType = "year" | "month" | "week" | "day";
+export type PlanningViewType = "7years" | "year" | "month" | "week" | "day";
 export type ExtendedPlanningViewType = PlanningViewType | "sevenYear";
+
+export const normalizePlanningViewType = (
+  viewType: ExtendedPlanningViewType,
+): "sevenYear" | "year" | "month" | "week" | "day" =>
+  viewType === "7years" ? "sevenYear" : viewType;
 
 export interface PlanningGroup {
   id: string;
@@ -153,7 +158,7 @@ export interface CalendarAdapter {
 
   /**
    * Get a period range for a given view type and base date
-   * @param viewType - one of year/month/week/day/sevenYear
+   * @param viewType - one of 7years/year/month/week/day/sevenYear
    * @param date - base date
    * @returns start/end in YYYY-MM-DD
    */
@@ -164,7 +169,7 @@ export interface CalendarAdapter {
 
   /**
    * Shift a period range forward/backward by a step
-   * @param viewType - one of year/month/week/day/sevenYear
+   * @param viewType - one of 7years/year/month/week/day/sevenYear
    * @param startDate - current range start (YYYY-MM-DD)
    * @param endDate - current range end (YYYY-MM-DD)
    * @param step - positive for next, negative for previous

--- a/web/src/utils/calendar/CalendarAdapterFactory.ts
+++ b/web/src/utils/calendar/CalendarAdapterFactory.ts
@@ -1,4 +1,5 @@
 import type { CalendarAdapter } from "./CalendarAdapter";
+import { DEFAULT_SEVEN_YEAR_ANCHOR_DATE } from "./CalendarAdapter";
 import { GregorianCalendarAdapter } from "./GregorianCalendarAdapter";
 import { MayanCalendarAdapter } from "./MayanCalendarAdapter";
 
@@ -13,17 +14,19 @@ export class CalendarAdapterFactory {
    * Create a calendar adapter based on the calendar system
    * @param system - The calendar system to use
    * @param firstDayOfWeek - First day of week (1=Monday, 2=Tuesday, ..., 7=Sunday)
+   * @param sevenYearAnchorDate - Date used to anchor seven-year period boundaries
    * @returns Calendar adapter instance
    */
   static create(
     system: CalendarSystem,
     firstDayOfWeek: number = 1,
+    sevenYearAnchorDate: string = DEFAULT_SEVEN_YEAR_ANCHOR_DATE,
   ): CalendarAdapter {
     switch (system) {
       case "gregorian":
-        return new GregorianCalendarAdapter(firstDayOfWeek);
+        return new GregorianCalendarAdapter(firstDayOfWeek, sevenYearAnchorDate);
       case "mayan_13_moon":
-        return new MayanCalendarAdapter(firstDayOfWeek);
+        return new MayanCalendarAdapter(firstDayOfWeek, sevenYearAnchorDate);
       default:
         throw new Error(`Unsupported calendar system: ${system}`);
     }

--- a/web/src/utils/calendar/GregorianCalendarAdapter.ts
+++ b/web/src/utils/calendar/GregorianCalendarAdapter.ts
@@ -2,8 +2,8 @@ import type {
   CalendarAdapter,
   ExtendedPlanningViewType,
   PlanningGroup,
-  PlanningViewType,
 } from "./CalendarAdapter";
+import { normalizePlanningViewType } from "./CalendarAdapter";
 import type { TaskWithSubtasks } from "@/services/api";
 import {
   getDaysInWeek,
@@ -33,8 +33,9 @@ export class GregorianCalendarAdapter implements CalendarAdapter {
 
   getNextPeriod(currentDate: Date, cycleType: ExtendedPlanningViewType): Date {
     const nextDate = new Date(currentDate);
+    const normalizedCycleType = normalizePlanningViewType(cycleType);
 
-    switch (cycleType) {
+    switch (normalizedCycleType) {
       case "year":
         nextDate.setUTCFullYear(nextDate.getUTCFullYear() + 1);
         return this.normalizePeriodDate(nextDate);
@@ -60,8 +61,9 @@ export class GregorianCalendarAdapter implements CalendarAdapter {
     cycleType: ExtendedPlanningViewType,
   ): Date {
     const prevDate = new Date(currentDate);
+    const normalizedCycleType = normalizePlanningViewType(cycleType);
 
-    switch (cycleType) {
+    switch (normalizedCycleType) {
       case "year":
         prevDate.setUTCFullYear(prevDate.getUTCFullYear() - 1);
         return this.normalizePeriodDate(prevDate);
@@ -83,7 +85,9 @@ export class GregorianCalendarAdapter implements CalendarAdapter {
   }
 
   getPlanningCycleDays(cycleType: ExtendedPlanningViewType): number {
-    switch (cycleType) {
+    const normalizedCycleType = normalizePlanningViewType(cycleType);
+
+    switch (normalizedCycleType) {
       case "year":
         return 365;
       case "sevenYear":
@@ -105,24 +109,53 @@ export class GregorianCalendarAdapter implements CalendarAdapter {
   }
 
   buildPlanningGroups(
-    viewType: PlanningViewType,
+    viewType: ExtendedPlanningViewType,
     date: Date,
     tasks: TaskWithSubtasks[],
     firstDayOfWeek: number = this.firstDayOfWeek,
   ): PlanningGroup[] {
     const groups: PlanningGroup[] = [];
+    const normalizedViewType = normalizePlanningViewType(viewType);
 
-    if (viewType === "year") {
+    if (normalizedViewType === "sevenYear") {
+      return this.buildSevenYearGroups(date, tasks);
+    } else if (normalizedViewType === "year") {
       return this.buildYearGroups(date, tasks, firstDayOfWeek);
-    } else if (viewType === "month") {
+    } else if (normalizedViewType === "month") {
       return this.buildMonthGroups(date, tasks, firstDayOfWeek);
-    } else if (viewType === "week") {
+    } else if (normalizedViewType === "week") {
       return this.buildWeekGroups(date, tasks, firstDayOfWeek);
-    } else if (viewType === "day") {
+    } else if (normalizedViewType === "day") {
       return this.buildDayGroups(date, tasks);
     }
 
     return groups;
+  }
+
+  private buildSevenYearGroups(
+    date: Date,
+    tasks: TaskWithSubtasks[],
+  ): PlanningGroup[] {
+    const startYear = date.getFullYear();
+    const endYear = startYear + 6;
+    const sevenYearTasks = this.getTasksByPlanningType(tasks, "7years");
+
+    const tasksInCurrentPeriod = sevenYearTasks.filter((task) => {
+      if (!task.planning_cycle_start_date) return false;
+      const [taskYear] = task.planning_cycle_start_date.split("-");
+      const parsedYear = parseInt(taskYear, 10);
+      return parsedYear >= startYear && parsedYear <= endYear;
+    });
+
+    return [
+      {
+        id: `seven-year-${startYear}-${endYear}`,
+        label: `${startYear}-${endYear}`,
+        date: new Date(startYear, 0, 1),
+        tasks: tasksInCurrentPeriod,
+        children: [],
+      },
+    ];
   }
 
   private buildYearGroups(
@@ -321,7 +354,7 @@ export class GregorianCalendarAdapter implements CalendarAdapter {
 
   private getTasksByPlanningType(
     tasks: TaskWithSubtasks[],
-    type: PlanningViewType,
+    type: ExtendedPlanningViewType,
   ): TaskWithSubtasks[] {
     return tasks.filter((task) => task.planning_cycle_type === type);
   }
@@ -531,7 +564,9 @@ export class GregorianCalendarAdapter implements CalendarAdapter {
     viewType: ExtendedPlanningViewType,
     date: Date,
   ): { start: string; end: string } {
-    switch (viewType) {
+    const normalizedViewType = normalizePlanningViewType(viewType);
+
+    switch (normalizedViewType) {
       case "year": {
         const yearStart = this.getYearStart(date);
         const yearEnd = new Date(yearStart.getFullYear() + 1, 0, 1);
@@ -543,8 +578,8 @@ export class GregorianCalendarAdapter implements CalendarAdapter {
         };
       }
       case "sevenYear": {
-        const endYear = date.getFullYear();
-        const startYear = endYear - 6;
+        const startYear = date.getFullYear();
+        const endYear = startYear + 6;
         const startDate = new Date(startYear, 0, 1);
         const endDateExclusive = new Date(endYear + 1, 0, 1);
         return {
@@ -592,7 +627,9 @@ export class GregorianCalendarAdapter implements CalendarAdapter {
     endDate: string,
     step: number,
   ): { start: string; end: string } {
-    switch (viewType) {
+    const normalizedViewType = normalizePlanningViewType(viewType);
+
+    switch (normalizedViewType) {
       case "year": {
         const s = new Date(startDate + "T00:00:00");
         const e = new Date(endDate + "T00:00:00");

--- a/web/src/utils/calendar/GregorianCalendarAdapter.ts
+++ b/web/src/utils/calendar/GregorianCalendarAdapter.ts
@@ -5,6 +5,7 @@ import type {
 } from "./CalendarAdapter";
 import {
   DEFAULT_SEVEN_YEAR_ANCHOR_DATE,
+  isLocalDateString,
   normalizePlanningViewType,
   parseLocalDateString,
 } from "./CalendarAdapter";
@@ -166,13 +167,14 @@ export class GregorianCalendarAdapter implements CalendarAdapter {
     const periodStart = this.getSevenYearPeriodStart(date);
     const startYear = periodStart.getFullYear();
     const endYear = startYear + 6;
+    const periodEnd = new Date(endYear + 1, 0, 0);
     const sevenYearTasks = this.getTasksByPlanningType(tasks, "7years");
 
     const tasksInCurrentPeriod = sevenYearTasks.filter((task) => {
       if (!task.planning_cycle_start_date) return false;
-      const [taskYear] = task.planning_cycle_start_date.split("-");
-      const parsedYear = parseInt(taskYear, 10);
-      return parsedYear >= startYear && parsedYear <= endYear;
+      if (!isLocalDateString(task.planning_cycle_start_date)) return false;
+      const taskDate = parseLocalDateString(task.planning_cycle_start_date);
+      return taskDate >= periodStart && taskDate <= periodEnd;
     });
 
     return [

--- a/web/src/utils/calendar/GregorianCalendarAdapter.ts
+++ b/web/src/utils/calendar/GregorianCalendarAdapter.ts
@@ -3,7 +3,11 @@ import type {
   ExtendedPlanningViewType,
   PlanningGroup,
 } from "./CalendarAdapter";
-import { normalizePlanningViewType } from "./CalendarAdapter";
+import {
+  DEFAULT_SEVEN_YEAR_ANCHOR_DATE,
+  normalizePlanningViewType,
+  parseLocalDateString,
+} from "./CalendarAdapter";
 import type { TaskWithSubtasks } from "@/services/api";
 import {
   getDaysInWeek,
@@ -18,9 +22,14 @@ import {
  */
 export class GregorianCalendarAdapter implements CalendarAdapter {
   private firstDayOfWeek: number;
+  private sevenYearAnchorDate: string;
 
-  constructor(firstDayOfWeek: number = 1) {
+  constructor(
+    firstDayOfWeek: number = 1,
+    sevenYearAnchorDate: string = DEFAULT_SEVEN_YEAR_ANCHOR_DATE,
+  ) {
     this.firstDayOfWeek = firstDayOfWeek;
+    this.sevenYearAnchorDate = sevenYearAnchorDate;
   }
 
   getYearStart(date: Date): Date {
@@ -40,8 +49,7 @@ export class GregorianCalendarAdapter implements CalendarAdapter {
         nextDate.setUTCFullYear(nextDate.getUTCFullYear() + 1);
         return this.normalizePeriodDate(nextDate);
       case "sevenYear":
-        nextDate.setUTCFullYear(nextDate.getUTCFullYear() + 7);
-        return this.normalizePeriodDate(nextDate);
+        return this.shiftSevenYearPeriodStart(currentDate, 1);
       case "month":
         nextDate.setUTCMonth(nextDate.getUTCMonth() + 1);
         return this.normalizePeriodDate(nextDate);
@@ -68,8 +76,7 @@ export class GregorianCalendarAdapter implements CalendarAdapter {
         prevDate.setUTCFullYear(prevDate.getUTCFullYear() - 1);
         return this.normalizePeriodDate(prevDate);
       case "sevenYear":
-        prevDate.setUTCFullYear(prevDate.getUTCFullYear() - 7);
-        return this.normalizePeriodDate(prevDate);
+        return this.shiftSevenYearPeriodStart(currentDate, -1);
       case "month":
         prevDate.setUTCMonth(prevDate.getUTCMonth() - 1);
         return this.normalizePeriodDate(prevDate);
@@ -108,6 +115,26 @@ export class GregorianCalendarAdapter implements CalendarAdapter {
     return date;
   }
 
+  private getSevenYearAnchorStart(): Date {
+    const anchorDate = parseLocalDateString(this.sevenYearAnchorDate);
+    return new Date(anchorDate.getFullYear(), 0, 1);
+  }
+
+  private getSevenYearPeriodStart(date: Date): Date {
+    const anchorStart = this.getSevenYearAnchorStart();
+    const targetYear = date.getFullYear();
+    const deltaYears = targetYear - anchorStart.getFullYear();
+    const periodOffsetYears = Math.floor(deltaYears / 7) * 7;
+    return new Date(anchorStart.getFullYear() + periodOffsetYears, 0, 1);
+  }
+
+  private shiftSevenYearPeriodStart(date: Date, step: number): Date {
+    const start = this.getSevenYearPeriodStart(date);
+    start.setFullYear(start.getFullYear() + 7 * step);
+    start.setHours(12, 0, 0, 0);
+    return start;
+  }
+
   buildPlanningGroups(
     viewType: ExtendedPlanningViewType,
     date: Date,
@@ -136,7 +163,8 @@ export class GregorianCalendarAdapter implements CalendarAdapter {
     date: Date,
     tasks: TaskWithSubtasks[],
   ): PlanningGroup[] {
-    const startYear = date.getFullYear();
+    const periodStart = this.getSevenYearPeriodStart(date);
+    const startYear = periodStart.getFullYear();
     const endYear = startYear + 6;
     const sevenYearTasks = this.getTasksByPlanningType(tasks, "7years");
 
@@ -151,7 +179,7 @@ export class GregorianCalendarAdapter implements CalendarAdapter {
       {
         id: `seven-year-${startYear}-${endYear}`,
         label: `${startYear}-${endYear}`,
-        date: new Date(startYear, 0, 1),
+        date: periodStart,
         tasks: tasksInCurrentPeriod,
         children: [],
       },
@@ -578,12 +606,12 @@ export class GregorianCalendarAdapter implements CalendarAdapter {
         };
       }
       case "sevenYear": {
-        const startYear = date.getFullYear();
+        const periodStart = this.getSevenYearPeriodStart(date);
+        const startYear = periodStart.getFullYear();
         const endYear = startYear + 6;
-        const startDate = new Date(startYear, 0, 1);
         const endDateExclusive = new Date(endYear + 1, 0, 1);
         return {
-          start: startDate.toLocaleDateString("en-CA"),
+          start: periodStart.toLocaleDateString("en-CA"),
           end: new Date(
             endDateExclusive.getTime() - 24 * 60 * 60 * 1000,
           ).toLocaleDateString("en-CA"),

--- a/web/src/utils/calendar/MayanCalendarAdapter.ts
+++ b/web/src/utils/calendar/MayanCalendarAdapter.ts
@@ -2,8 +2,8 @@ import type {
   CalendarAdapter,
   ExtendedPlanningViewType,
   PlanningGroup,
-  PlanningViewType,
 } from "./CalendarAdapter";
+import { normalizePlanningViewType } from "./CalendarAdapter";
 import type { TaskWithSubtasks } from "@/services/api";
 import { getDaysInWeek } from "@/utils/datetime";
 
@@ -346,8 +346,9 @@ export class MayanCalendarAdapter implements CalendarAdapter {
 
   getNextPeriod(currentDate: Date, cycleType: ExtendedPlanningViewType): Date {
     const nextDate = new Date(currentDate);
+    const normalizedCycleType = normalizePlanningViewType(cycleType);
 
-    switch (cycleType) {
+    switch (normalizedCycleType) {
       case "year": {
         const start = this.getMayanYearStart(currentDate);
         start.setFullYear(start.getFullYear() + 1);
@@ -377,8 +378,9 @@ export class MayanCalendarAdapter implements CalendarAdapter {
     cycleType: ExtendedPlanningViewType,
   ): Date {
     const prevDate = new Date(currentDate);
+    const normalizedCycleType = normalizePlanningViewType(cycleType);
 
-    switch (cycleType) {
+    switch (normalizedCycleType) {
       case "year": {
         const start = this.getMayanYearStart(currentDate);
         start.setFullYear(start.getFullYear() - 1);
@@ -404,7 +406,9 @@ export class MayanCalendarAdapter implements CalendarAdapter {
   }
 
   getPlanningCycleDays(cycleType: ExtendedPlanningViewType): number {
-    switch (cycleType) {
+    const normalizedCycleType = normalizePlanningViewType(cycleType);
+
+    switch (normalizedCycleType) {
       case "year":
         return 365;
       case "sevenYear":
@@ -429,24 +433,54 @@ export class MayanCalendarAdapter implements CalendarAdapter {
   }
 
   buildPlanningGroups(
-    viewType: PlanningViewType,
+    viewType: ExtendedPlanningViewType,
     date: Date,
     tasks: TaskWithSubtasks[],
     _firstDayOfWeek: number = this.firstDayOfWeek,
   ): PlanningGroup[] {
     const groups: PlanningGroup[] = [];
+    const normalizedViewType = normalizePlanningViewType(viewType);
 
-    if (viewType === "year") {
+    if (normalizedViewType === "sevenYear") {
+      return this.buildSevenYearGroups(date, tasks);
+    } else if (normalizedViewType === "year") {
       return this.buildYearGroups(date, tasks);
-    } else if (viewType === "month") {
+    } else if (normalizedViewType === "month") {
       return this.buildMonthGroups(date, tasks);
-    } else if (viewType === "week") {
+    } else if (normalizedViewType === "week") {
       return this.buildWeekGroups(date, tasks);
-    } else if (viewType === "day") {
+    } else if (normalizedViewType === "day") {
       return this.buildDayGroups(date, tasks);
     }
 
     return groups;
+  }
+
+  private buildSevenYearGroups(
+    date: Date,
+    tasks: TaskWithSubtasks[],
+  ): PlanningGroup[] {
+    const start = this.getMayanYearStart(date);
+    const end = new Date(start);
+    end.setFullYear(start.getFullYear() + 7);
+    end.setDate(end.getDate() - 1);
+    const sevenYearTasks = this.getTasksByPlanningType(tasks, "7years");
+
+    const tasksInCurrentPeriod = sevenYearTasks.filter((task) => {
+      if (!task.planning_cycle_start_date) return false;
+      const taskDate = new Date(task.planning_cycle_start_date);
+      return taskDate >= start && taskDate <= end;
+    });
+
+    return [
+      {
+        id: `mayan-seven-year-${start.toLocaleDateString("en-CA")}`,
+        label: `${start.getFullYear()}-${start.getFullYear() + 6}`,
+        date: start,
+        tasks: tasksInCurrentPeriod,
+        children: [],
+      },
+    ];
   }
 
   private buildYearGroups(
@@ -671,7 +705,7 @@ export class MayanCalendarAdapter implements CalendarAdapter {
 
   private getTasksByPlanningType(
     tasks: TaskWithSubtasks[],
-    type: PlanningViewType,
+    type: ExtendedPlanningViewType,
   ): TaskWithSubtasks[] {
     return tasks.filter((task) => task.planning_cycle_type === type);
   }
@@ -735,7 +769,9 @@ export class MayanCalendarAdapter implements CalendarAdapter {
     viewType: ExtendedPlanningViewType,
     date: Date,
   ): { start: string; end: string } {
-    switch (viewType) {
+    const normalizedViewType = normalizePlanningViewType(viewType);
+
+    switch (normalizedViewType) {
       case "year": {
         const start = this.getMayanYearStart(date);
         const end = new Date(start);
@@ -747,14 +783,12 @@ export class MayanCalendarAdapter implements CalendarAdapter {
         };
       }
       case "sevenYear": {
-        const endYearStart = this.getMayanYearStart(date);
-        const startYearStart = new Date(endYearStart);
-        startYearStart.setFullYear(startYearStart.getFullYear() - 6);
-        const end = new Date(endYearStart);
-        end.setFullYear(endYearStart.getFullYear() + 1);
+        const start = this.getMayanYearStart(date);
+        const end = new Date(start);
+        end.setFullYear(start.getFullYear() + 7);
         end.setDate(end.getDate() - 1);
         return {
-          start: startYearStart.toLocaleDateString("en-CA"),
+          start: start.toLocaleDateString("en-CA"),
           end: end.toLocaleDateString("en-CA"),
         };
       }
@@ -793,7 +827,9 @@ export class MayanCalendarAdapter implements CalendarAdapter {
     endDate: string,
     step: number,
   ): { start: string; end: string } {
-    switch (viewType) {
+    const normalizedViewType = normalizePlanningViewType(viewType);
+
+    switch (normalizedViewType) {
       case "year": {
         const s = new Date(startDate + "T00:00:00");
         const e = new Date(endDate + "T00:00:00");

--- a/web/src/utils/calendar/MayanCalendarAdapter.ts
+++ b/web/src/utils/calendar/MayanCalendarAdapter.ts
@@ -3,7 +3,11 @@ import type {
   ExtendedPlanningViewType,
   PlanningGroup,
 } from "./CalendarAdapter";
-import { normalizePlanningViewType } from "./CalendarAdapter";
+import {
+  DEFAULT_SEVEN_YEAR_ANCHOR_DATE,
+  normalizePlanningViewType,
+  parseLocalDateString,
+} from "./CalendarAdapter";
 import type { TaskWithSubtasks } from "@/services/api";
 import { getDaysInWeek } from "@/utils/datetime";
 
@@ -13,9 +17,14 @@ import { getDaysInWeek } from "@/utils/datetime";
  */
 export class MayanCalendarAdapter implements CalendarAdapter {
   private firstDayOfWeek: number;
+  private sevenYearAnchorDate: string;
 
-  constructor(firstDayOfWeek: number = 1) {
+  constructor(
+    firstDayOfWeek: number = 1,
+    sevenYearAnchorDate: string = DEFAULT_SEVEN_YEAR_ANCHOR_DATE,
+  ) {
     this.firstDayOfWeek = firstDayOfWeek;
+    this.sevenYearAnchorDate = sevenYearAnchorDate;
   }
 
   /**
@@ -339,6 +348,20 @@ export class MayanCalendarAdapter implements CalendarAdapter {
     return this.getMayanYearStart(date);
   }
 
+  private getSevenYearAnchorStart(): Date {
+    return this.getMayanYearStart(parseLocalDateString(this.sevenYearAnchorDate));
+  }
+
+  private getSevenYearPeriodStart(date: Date): Date {
+    const anchorStart = this.getSevenYearAnchorStart();
+    const targetStart = this.getMayanYearStart(date);
+    const deltaYears = targetStart.getFullYear() - anchorStart.getFullYear();
+    const periodOffsetYears = Math.floor(deltaYears / 7) * 7;
+    const periodStart = new Date(anchorStart);
+    periodStart.setFullYear(anchorStart.getFullYear() + periodOffsetYears);
+    return periodStart;
+  }
+
   getWeekStart(date: Date): Date {
     const range = this.getMayanWeekRange(date);
     return range.start;
@@ -355,7 +378,7 @@ export class MayanCalendarAdapter implements CalendarAdapter {
         return start;
       }
       case "sevenYear": {
-        const start = this.getMayanYearStart(currentDate);
+        const start = this.getSevenYearPeriodStart(currentDate);
         start.setFullYear(start.getFullYear() + 7);
         return start;
       }
@@ -387,7 +410,7 @@ export class MayanCalendarAdapter implements CalendarAdapter {
         return start;
       }
       case "sevenYear": {
-        const start = this.getMayanYearStart(currentDate);
+        const start = this.getSevenYearPeriodStart(currentDate);
         start.setFullYear(start.getFullYear() - 7);
         return start;
       }
@@ -460,7 +483,7 @@ export class MayanCalendarAdapter implements CalendarAdapter {
     date: Date,
     tasks: TaskWithSubtasks[],
   ): PlanningGroup[] {
-    const start = this.getMayanYearStart(date);
+    const start = this.getSevenYearPeriodStart(date);
     const end = new Date(start);
     end.setFullYear(start.getFullYear() + 7);
     end.setDate(end.getDate() - 1);
@@ -468,7 +491,7 @@ export class MayanCalendarAdapter implements CalendarAdapter {
 
     const tasksInCurrentPeriod = sevenYearTasks.filter((task) => {
       if (!task.planning_cycle_start_date) return false;
-      const taskDate = new Date(task.planning_cycle_start_date);
+      const taskDate = parseLocalDateString(task.planning_cycle_start_date);
       return taskDate >= start && taskDate <= end;
     });
 
@@ -783,7 +806,7 @@ export class MayanCalendarAdapter implements CalendarAdapter {
         };
       }
       case "sevenYear": {
-        const start = this.getMayanYearStart(date);
+        const start = this.getSevenYearPeriodStart(date);
         const end = new Date(start);
         end.setFullYear(start.getFullYear() + 7);
         end.setDate(end.getDate() - 1);

--- a/web/src/utils/calendar/MayanCalendarAdapter.ts
+++ b/web/src/utils/calendar/MayanCalendarAdapter.ts
@@ -5,6 +5,7 @@ import type {
 } from "./CalendarAdapter";
 import {
   DEFAULT_SEVEN_YEAR_ANCHOR_DATE,
+  isLocalDateString,
   normalizePlanningViewType,
   parseLocalDateString,
 } from "./CalendarAdapter";
@@ -491,6 +492,7 @@ export class MayanCalendarAdapter implements CalendarAdapter {
 
     const tasksInCurrentPeriod = sevenYearTasks.filter((task) => {
       if (!task.planning_cycle_start_date) return false;
+      if (!isLocalDateString(task.planning_cycle_start_date)) return false;
       const taskDate = parseLocalDateString(task.planning_cycle_start_date);
       return taskDate >= start && taskDate <= end;
     });

--- a/web/src/utils/calendar/__tests__/GregorianCalendarAdapter.test.ts
+++ b/web/src/utils/calendar/__tests__/GregorianCalendarAdapter.test.ts
@@ -47,8 +47,19 @@ describe("GregorianCalendarAdapter", () => {
 
     expect(adapter.getNextPeriod(base, "year").getFullYear()).toBe(2026);
     expect(adapter.getPreviousPeriod(base, "year").getFullYear()).toBe(2024);
+    expect(adapter.getNextPeriod(base, "7years").getFullYear()).toBe(2032);
+    expect(adapter.getPreviousPeriod(base, "7years").getFullYear()).toBe(2018);
     expect(adapter.getNextPeriod(base, "month").getMonth()).toBe(1);
     expect(adapter.getPreviousPeriod(base, "day").getDate()).toBe(31);
+  });
+
+  it("computes 7-year ranges from the selected start year", () => {
+    const adapter = new GregorianCalendarAdapter();
+
+    expect(adapter.getPeriodRange("7years", new Date(2026, 4, 15))).toEqual({
+      start: "2026-01-01",
+      end: "2032-12-31",
+    });
   });
 
   it("builds week groups with nested day children", () => {
@@ -116,5 +127,32 @@ describe("GregorianCalendarAdapter", () => {
     expect(yearGroup.children).toHaveLength(12);
     const mayGroup = yearGroup.children?.[4];
     expect(mayGroup?.tasks.map((task) => task.id)).toEqual(["month-5"]);
+  });
+
+  it("builds 7-year groups for 7years tasks", () => {
+    const adapter = new GregorianCalendarAdapter();
+    const base = new Date("2026-01-01T00:00:00Z");
+
+    const sevenYearTask = createTask({
+      id: "seven-year-1",
+      planning_cycle_type: "7years",
+      planning_cycle_start_date: "2026-01-01",
+    });
+    const nextPeriodTask = createTask({
+      id: "seven-year-next",
+      planning_cycle_type: "7years",
+      planning_cycle_start_date: "2033-01-01",
+    });
+
+    const groups = adapter.buildPlanningGroups(
+      "7years",
+      base,
+      [sevenYearTask, nextPeriodTask],
+      1,
+    );
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].label).toBe("2026-2032");
+    expect(groups[0].tasks.map((task) => task.id)).toEqual(["seven-year-1"]);
   });
 });

--- a/web/src/utils/calendar/__tests__/GregorianCalendarAdapter.test.ts
+++ b/web/src/utils/calendar/__tests__/GregorianCalendarAdapter.test.ts
@@ -43,22 +43,28 @@ describe("GregorianCalendarAdapter", () => {
 
   it("computes next and previous periods", () => {
     const adapter = new GregorianCalendarAdapter();
-    const base = new Date("2025-01-01T00:00:00Z");
+    const base = new Date("2025-01-01T12:00:00Z");
 
-    expect(adapter.getNextPeriod(base, "year").getFullYear()).toBe(2026);
-    expect(adapter.getPreviousPeriod(base, "year").getFullYear()).toBe(2024);
+    expect(adapter.getNextPeriod(base, "year").getUTCFullYear()).toBe(2026);
+    expect(adapter.getPreviousPeriod(base, "year").getUTCFullYear()).toBe(2024);
     expect(adapter.getNextPeriod(base, "7years").getFullYear()).toBe(2032);
-    expect(adapter.getPreviousPeriod(base, "7years").getFullYear()).toBe(2018);
-    expect(adapter.getNextPeriod(base, "month").getMonth()).toBe(1);
-    expect(adapter.getPreviousPeriod(base, "day").getDate()).toBe(31);
+    expect(adapter.getPreviousPeriod(base, "7years").getFullYear()).toBe(
+      2018,
+    );
+    expect(adapter.getNextPeriod(base, "month").getUTCMonth()).toBe(1);
+    expect(adapter.getPreviousPeriod(base, "day").getUTCDate()).toBe(31);
   });
 
-  it("computes 7-year ranges from the selected start year", () => {
+  it("computes 7-year ranges from the configured anchor year", () => {
     const adapter = new GregorianCalendarAdapter();
 
     expect(adapter.getPeriodRange("7years", new Date(2026, 4, 15))).toEqual({
-      start: "2026-01-01",
-      end: "2032-12-31",
+      start: "2025-01-01",
+      end: "2031-12-31",
+    });
+    expect(adapter.getPeriodRange("7years", new Date(2024, 4, 15))).toEqual({
+      start: "2018-01-01",
+      end: "2024-12-31",
     });
   });
 
@@ -152,7 +158,7 @@ describe("GregorianCalendarAdapter", () => {
     );
 
     expect(groups).toHaveLength(1);
-    expect(groups[0].label).toBe("2026-2032");
+    expect(groups[0].label).toBe("2025-2031");
     expect(groups[0].tasks.map((task) => task.id)).toEqual(["seven-year-1"]);
   });
 });

--- a/web/src/utils/calendar/__tests__/MayanCalendarAdapter.test.ts
+++ b/web/src/utils/calendar/__tests__/MayanCalendarAdapter.test.ts
@@ -14,6 +14,10 @@ describe("MayanCalendarAdapter", () => {
       start: "2025-07-26",
       end: "2026-07-25",
     });
+    expect(adapter.getPeriodRange("7years", new Date(2026, 6, 26))).toEqual({
+      start: "2026-07-26",
+      end: "2033-07-25",
+    });
     expect(adapter.getPeriodRange("month", new Date(2027, 6, 25))).toEqual({
       start: "2027-07-25",
       end: "2027-07-25",

--- a/web/src/utils/calendar/__tests__/MayanCalendarAdapter.test.ts
+++ b/web/src/utils/calendar/__tests__/MayanCalendarAdapter.test.ts
@@ -15,8 +15,8 @@ describe("MayanCalendarAdapter", () => {
       end: "2026-07-25",
     });
     expect(adapter.getPeriodRange("7years", new Date(2026, 6, 26))).toEqual({
-      start: "2026-07-26",
-      end: "2033-07-25",
+      start: "2025-07-26",
+      end: "2032-07-25",
     });
     expect(adapter.getPeriodRange("month", new Date(2027, 6, 25))).toEqual({
       start: "2027-07-25",
@@ -46,6 +46,19 @@ describe("MayanCalendarAdapter", () => {
     expect(options[12]).toEqual({
       index: 13,
       name: "13 2027-06-27",
+    });
+  });
+
+  it("anchors 7-year ranges to the Mayan year containing the configured date", () => {
+    const anchoredAdapter = new MayanCalendarAdapter(1, "2026-07-20");
+
+    expect(anchoredAdapter.getPeriodRange("7years", new Date(2026, 6, 26))).toEqual({
+      start: "2025-07-26",
+      end: "2032-07-25",
+    });
+    expect(anchoredAdapter.getPeriodRange("7years", new Date(2025, 6, 25))).toEqual({
+      start: "2018-07-26",
+      end: "2025-07-25",
     });
   });
 });

--- a/web/src/utils/calendar/index.ts
+++ b/web/src/utils/calendar/index.ts
@@ -5,6 +5,10 @@ export type {
   ExtendedPlanningViewType,
 } from "./CalendarAdapter";
 export {
+  DEFAULT_SEVEN_YEAR_ANCHOR_DATE,
+  parseLocalDateString,
+} from "./CalendarAdapter";
+export {
   CalendarAdapterFactory,
   type CalendarSystem,
 } from "./CalendarAdapterFactory";

--- a/web/src/utils/calendar/index.ts
+++ b/web/src/utils/calendar/index.ts
@@ -6,6 +6,7 @@ export type {
 } from "./CalendarAdapter";
 export {
   DEFAULT_SEVEN_YEAR_ANCHOR_DATE,
+  isLocalDateString,
   parseLocalDateString,
 } from "./CalendarAdapter";
 export {


### PR DESCRIPTION
## 变更说明

- 为 task planning cycle 增加 `7years` 类型，并补齐七年视图、任务查询、任务分组与展示文案。
- 新增日历偏好 `calendar.seven_year_anchor_date`，设置页日历 tab 使用日期选择器存储锚点日期。
- 公历按锚点日期所在公历年计算七年周期；玛雅13月亮历按锚点日期所在玛雅年起点计算七年周期。
- Planning 与 Data Insights 通过同一个 calendar adapter 共享七年锚点算法。
- 调整任务新建/编辑界面文案与字号：`月份`/`年份` 改为 `月`/`年`，统一起始年份与任务内容字段样式。
- 收敛本 PR 引入的重复日期校验逻辑，并避免无效 task start date 被 fallback 到默认七年周期。

## 审查结论

- 本 PR 与 #194 的关系为 `Closes #194`，关系准确。
- 已审查 PR diff：实现路径符合当前代码结构，偏好持久化、Web 设置、Planning 与 Data Insights 均接入同一 adapter 算法。
- 已执行死代码审查：仓库 dead-code 扫描无报告；未发现高确信可删除的历史残留。当前分支引入的重复日期校验已清理。

## 验证

- `bash scripts/dead_code_check.sh`
- `cd web && npm test -- src/utils/calendar/__tests__/GregorianCalendarAdapter.test.ts src/utils/calendar/__tests__/MayanCalendarAdapter.test.ts`
- `bash ./scripts/web_validate.sh`
- `bash ./scripts/doctor.sh`

Closes #194
