### PR TITLE
feat(web): copy finance snapshots

### DIFF
--- a/web/src/components/ActionButton.tsx
+++ b/web/src/components/ActionButton.tsx
@@ -192,18 +192,18 @@ const ActionButton = React.forwardRef<HTMLButtonElement, ActionButtonProps>(
       .filter(Boolean)
       .join(" ");
 
-    // 增强的点击处理函数，避免多余全局 DOM 查询
+    // Keep click handling local and avoid extra global DOM lookups.
     const handleClick = useCallback(
       (e: React.MouseEvent<HTMLButtonElement>) => {
-        // 防止重复点击
+        // Prevent duplicate clicks.
         if (disabled) return;
 
-        // 执行原始点击处理
+        // Run the original click handler.
         if (onClick) {
           onClick(e);
         }
 
-        // 去除当前按钮激活态与焦点，保持与 DaisyUI 行为一致
+        // Clear DaisyUI active/focus state from the current button.
         const current = e.currentTarget;
         current.classList.remove("active");
         current.blur();

--- a/web/src/features/finance/AmountText.tsx
+++ b/web/src/features/finance/AmountText.tsx
@@ -28,8 +28,8 @@ export function FinanceAmountText({
   showCurrency = true,
   className = "",
 }: FinanceAmountTextProps) {
-  const text = amount.trim();
-  if (!text) {
+  const rawText = amount.trim();
+  if (!rawText) {
     return (
       <span className={[financeTextClass.placeholder, className].filter(Boolean).join(" ")}>
         -
@@ -37,6 +37,7 @@ export function FinanceAmountText({
     );
   }
 
+  const text = trimInsignificantFractionZeroes(rawText);
   const numericValue = typeof value === "number" ? value : parseNumericAmount(text);
   const toneClass =
     Number.isFinite(numericValue) && numericValue < 0 ? "text-warning" : "text-base-content";
@@ -113,6 +114,20 @@ export function FinanceAssetSymbol({
 
 function parseNumericAmount(value: string): number {
   return Number(value.trim().replace(",", "."));
+}
+
+function trimInsignificantFractionZeroes(value: string): string {
+  const normalized = value.trim();
+  if (!/^[+-]?\d+(?:[.,]\d+)?$/.test(normalized)) {
+    return value;
+  }
+  const separator = normalized.includes(".") ? "." : ",";
+  const [integerPart, fractionPart] = normalized.split(separator);
+  if (!fractionPart) {
+    return normalized;
+  }
+  const trimmedFraction = fractionPart.replace(/0+$/, "");
+  return trimmedFraction ? `${integerPart}${separator}${trimmedFraction}` : integerPart;
 }
 
 function parseAmountList(value: string): Array<{ amount: string; currencyCode: string }> {

--- a/web/src/features/finance/RateSnapshotsWorkspace.tsx
+++ b/web/src/features/finance/RateSnapshotsWorkspace.tsx
@@ -41,6 +41,7 @@ import {
   localDateTimeToIso,
   nowDateTimeLocal,
   formatAmountForAsset,
+  formatCompactAmountForAsset,
   rateSnapshotLabel,
   type RateRowState,
   type RateSnapshotFormMode,
@@ -260,7 +261,7 @@ export function RateSnapshotsWorkspace() {
       (currentSnapshot.entries ?? []).map((entry) => ({
         baseAmount: "1",
         baseCurrency: entry.base_currency,
-        quoteAmount: entry.rate,
+        quoteAmount: formatCompactAmountForAsset(entry.rate, entry.quote_currency, assets),
         quoteCurrency: entry.quote_currency,
       })),
     );
@@ -277,7 +278,7 @@ export function RateSnapshotsWorkspace() {
       (currentSnapshot.entries ?? []).map((entry) => ({
         baseAmount: "1",
         baseCurrency: entry.base_currency,
-        quoteAmount: entry.rate,
+        quoteAmount: formatCompactAmountForAsset(entry.rate, entry.quote_currency, assets),
         quoteCurrency: entry.quote_currency,
       })),
     );
@@ -326,36 +327,38 @@ export function RateSnapshotsWorkspace() {
                     ? t("finance.rates.copySnapshot")
                   : t("finance.rates.createSnapshot")
               }
-              rightSlot={
-                <div className="flex justify-end gap-2">
-                  <ActionButton
-                    label={t("common.cancel")}
-                    iconName="x-mark"
-                    onClick={closeRateSnapshotForm}
-                    size="sm"
-                    variant="ghost"
-                    disabled={
-                      createRateSnapshotMutation.isPending || updateRateSnapshotMutation.isPending
-                    }
-                  />
-                  <ActionButton
-                    type="submit"
-                    form={rateSnapshotFormId}
-                    label={
-                      createRateSnapshotMutation.isPending || updateRateSnapshotMutation.isPending
-                        ? t("common.saving")
-                        : t("common.save")
-                    }
-                    iconName="check"
-                    color="primary"
-                    variant="solid"
-                    disabled={
-                      createRateSnapshotMutation.isPending || updateRateSnapshotMutation.isPending
-                    }
-                  />
-                </div>
-              }
             />
+            <div
+              className={`mt-4 flex gap-2 ${
+                rateFormMode === "create" ? "justify-end" : "justify-center"
+              }`}
+            >
+              <ActionButton
+                label={t("common.cancel")}
+                iconName="x-mark"
+                onClick={closeRateSnapshotForm}
+                size="sm"
+                variant="ghost"
+                disabled={
+                  createRateSnapshotMutation.isPending || updateRateSnapshotMutation.isPending
+                }
+              />
+              <ActionButton
+                type="submit"
+                form={rateSnapshotFormId}
+                label={
+                  createRateSnapshotMutation.isPending || updateRateSnapshotMutation.isPending
+                    ? t("common.saving")
+                    : t("common.save")
+                }
+                iconName="check"
+                color="primary"
+                variant="solid"
+                disabled={
+                  createRateSnapshotMutation.isPending || updateRateSnapshotMutation.isPending
+                }
+              />
+            </div>
             <form id={rateSnapshotFormId} className="mt-4 space-y-4" onSubmit={submitRateSnapshot}>
               <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
                 <FormField label={t("finance.rates.capturedAt")}>
@@ -498,9 +501,9 @@ export function RateSnapshotsWorkspace() {
               title={rateSnapshotLabel(currentSnapshot)}
               rightSlot={
                 <SnapshotActionButtons
-                  editLabel={t("finance.rates.editSnapshot")}
-                  copyLabel={t("finance.rates.copySnapshot")}
-                  deleteLabel={t("finance.rates.deleteSnapshot")}
+                  editLabel={t("common.edit")}
+                  copyLabel={t("common.copy")}
+                  deleteLabel={t("common.delete")}
                   disabled={deleteRateSnapshotMutation.isPending}
                   deleteDisabled={deleteRateSnapshotMutation.isPending}
                   onEdit={openEditRateSnapshotForm}

--- a/web/src/features/finance/RateSnapshotsWorkspace.tsx
+++ b/web/src/features/finance/RateSnapshotsWorkspace.tsx
@@ -162,8 +162,10 @@ export function RateSnapshotsWorkspace() {
     event.preventDefault();
     const entries = rateRows
       .map((row) => {
-        const baseAmount = Number(row.baseAmount);
-        const quoteAmount = Number(row.quoteAmount);
+        const baseAmountValue = row.baseAmount.trim();
+        const quoteAmountValue = row.quoteAmount.trim();
+        const baseAmount = Number(baseAmountValue);
+        const quoteAmount = Number(quoteAmountValue);
         const baseCurrency = row.baseCurrency.trim().toUpperCase();
         const quoteCurrency = row.quoteCurrency.trim().toUpperCase();
         return {
@@ -171,7 +173,9 @@ export function RateSnapshotsWorkspace() {
           quote_currency: quoteCurrency,
           rate:
             Number.isFinite(baseAmount) && baseAmount > 0 && Number.isFinite(quoteAmount)
-              ? String(quoteAmount / baseAmount)
+              ? baseAmount === 1
+                ? quoteAmountValue
+                : String(quoteAmount / baseAmount)
               : "",
           source: source.trim() || "manual",
         };
@@ -264,6 +268,23 @@ export function RateSnapshotsWorkspace() {
     setRateFormVisible(true);
   };
 
+  const openCopyRateSnapshotForm = () => {
+    if (!currentSnapshot) return;
+    setCapturedAt(nowDateTimeLocal());
+    setSource(currentSnapshot.source || "manual");
+    setNote(currentSnapshot.note ?? "");
+    setRateRows(
+      (currentSnapshot.entries ?? []).map((entry) => ({
+        baseAmount: "1",
+        baseCurrency: entry.base_currency,
+        quoteAmount: entry.rate,
+        quoteCurrency: entry.quote_currency,
+      })),
+    );
+    setRateFormMode("copy");
+    setRateFormVisible(true);
+  };
+
   const closeRateSnapshotForm = () => {
     setRateFormVisible(false);
     setRateFormMode("create");
@@ -301,6 +322,8 @@ export function RateSnapshotsWorkspace() {
               title={
                 rateFormMode === "edit"
                   ? t("finance.rates.editSnapshot")
+                  : rateFormMode === "copy"
+                    ? t("finance.rates.copySnapshot")
                   : t("finance.rates.createSnapshot")
               }
               rightSlot={
@@ -476,10 +499,12 @@ export function RateSnapshotsWorkspace() {
               rightSlot={
                 <SnapshotActionButtons
                   editLabel={t("finance.rates.editSnapshot")}
+                  copyLabel={t("finance.rates.copySnapshot")}
                   deleteLabel={t("finance.rates.deleteSnapshot")}
                   disabled={deleteRateSnapshotMutation.isPending}
                   deleteDisabled={deleteRateSnapshotMutation.isPending}
                   onEdit={openEditRateSnapshotForm}
+                  onCopy={openCopyRateSnapshotForm}
                   onDelete={() => setPendingDeleteRateSnapshot(currentSnapshot)}
                 />
               }

--- a/web/src/features/finance/RateSnapshotsWorkspace.tsx
+++ b/web/src/features/finance/RateSnapshotsWorkspace.tsx
@@ -41,7 +41,6 @@ import {
   localDateTimeToIso,
   nowDateTimeLocal,
   formatAmountForAsset,
-  formatCompactAmountForAsset,
   rateSnapshotLabel,
   type RateRowState,
   type RateSnapshotFormMode,
@@ -261,7 +260,7 @@ export function RateSnapshotsWorkspace() {
       (currentSnapshot.entries ?? []).map((entry) => ({
         baseAmount: "1",
         baseCurrency: entry.base_currency,
-        quoteAmount: formatCompactAmountForAsset(entry.rate, entry.quote_currency, assets),
+        quoteAmount: formatAmountForAsset(entry.rate, entry.quote_currency, assets),
         quoteCurrency: entry.quote_currency,
       })),
     );
@@ -278,7 +277,7 @@ export function RateSnapshotsWorkspace() {
       (currentSnapshot.entries ?? []).map((entry) => ({
         baseAmount: "1",
         baseCurrency: entry.base_currency,
-        quoteAmount: formatCompactAmountForAsset(entry.rate, entry.quote_currency, assets),
+        quoteAmount: formatAmountForAsset(entry.rate, entry.quote_currency, assets),
         quoteCurrency: entry.quote_currency,
       })),
     );

--- a/web/src/features/finance/SnapshotChrome.tsx
+++ b/web/src/features/finance/SnapshotChrome.tsx
@@ -102,17 +102,21 @@ export function SnapshotSelectorToolbar({
 
 export function SnapshotActionButtons({
   editLabel,
+  copyLabel,
   deleteLabel,
   disabled,
   deleteDisabled,
   onEdit,
+  onCopy,
   onDelete,
 }: {
   editLabel: string;
+  copyLabel?: string;
   deleteLabel: string;
   disabled?: boolean;
   deleteDisabled?: boolean;
   onEdit: () => void;
+  onCopy?: () => void;
   onDelete: () => void;
 }) {
   return (
@@ -126,6 +130,17 @@ export function SnapshotActionButtons({
         ariaLabel={editLabel}
         disabled={disabled}
       />
+      {copyLabel && onCopy ? (
+        <ActionButton
+          label={copyLabel}
+          iconName="clipboard"
+          onClick={onCopy}
+          size="sm"
+          variant="ghost"
+          ariaLabel={copyLabel}
+          disabled={disabled}
+        />
+      ) : null}
       <ActionButton
         label={deleteLabel}
         iconName="trash"

--- a/web/src/features/finance/SnapshotPanels.tsx
+++ b/web/src/features/finance/SnapshotPanels.tsx
@@ -32,6 +32,7 @@ import {
   todayDate,
   type PresetConfig,
   type SnapshotAmountState,
+  type SnapshotFormMode,
   type TreeNodeWithChildren,
 } from "./utils";
 
@@ -61,7 +62,7 @@ export function SnapshotFormPanel({
   treeNodes: TreeNodeWithChildren[];
   rateSnapshots: FinanceRateSnapshot[];
   submitting: boolean;
-  mode: "create" | "edit";
+  mode: SnapshotFormMode;
   initialSnapshot?: FinanceSnapshot | null;
   onSubmit: (payload: {
     title?: string | null;
@@ -131,7 +132,7 @@ export function SnapshotFormPanel({
     Boolean(selectedRateSnapshotId) && missingRateCurrencies.length === 0;
 
   useEffect(() => {
-    if (mode !== "edit" || !initialSnapshot) {
+    if (!initialSnapshot || mode === "create") {
       setSnapshotTs(nowDateTimeLocal());
       setPeriodStart(todayDate().slice(0, 8) + "01");
       setPeriodEnd(todayDate());
@@ -143,7 +144,9 @@ export function SnapshotFormPanel({
       return;
     }
 
-    setSnapshotTs(isoToDateTimeLocal(initialSnapshot.snapshot_ts));
+    setSnapshotTs(
+      mode === "copy" ? nowDateTimeLocal() : isoToDateTimeLocal(initialSnapshot.snapshot_ts),
+    );
     setPeriodStart(isoToDateInput(initialSnapshot.period_start));
     setPeriodEnd(isoToDateInput(initialSnapshot.period_end));
     setTitle(initialSnapshot.title ?? "");
@@ -159,13 +162,13 @@ export function SnapshotFormPanel({
           {
             id: entry.id,
             currencyCode: entry.currency_code,
-            amount: entry.amount,
+            amount: formatAmountForAsset(entry.amount, entry.currency_code, assets),
             note: entry.note ?? "",
           },
         ];
       });
     setAmounts(nextAmounts);
-  }, [initialSnapshot, mode, tree.primary_currency]);
+  }, [assets, initialSnapshot, mode, tree.primary_currency]);
 
   useEffect(() => {
     if (mode === "create") {
@@ -218,7 +221,7 @@ export function SnapshotFormPanel({
       note: snapshotNote || null,
       entries,
     });
-    if (mode === "create") {
+    if (mode !== "edit") {
       setTitle("");
       setAmounts({});
       setSnapshotNote("");
@@ -230,7 +233,7 @@ export function SnapshotFormPanel({
     <form className="space-y-4" onSubmit={handleSubmit}>
       <div
         className={
-          mode === "edit"
+          mode !== "create"
             ? "grid grid-cols-1 items-center gap-3 lg:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)]"
             : "flex flex-wrap items-center justify-between gap-3"
         }
@@ -243,7 +246,7 @@ export function SnapshotFormPanel({
           aria-label={t("finance.snapshot.title")}
           className={`max-w-xl ${financeTextClass.moduleTitle}`}
         />
-        <div className={`flex gap-2 ${mode === "edit" ? "justify-center" : "justify-end"}`}>
+        <div className={`flex gap-2 ${mode !== "create" ? "justify-center" : "justify-end"}`}>
           <ActionButton
             type="button"
             label={t("common.cancel")}
@@ -262,7 +265,7 @@ export function SnapshotFormPanel({
             disabled={submitting || !flatNodes.length}
           />
         </div>
-        {mode === "edit" ? <span className="hidden lg:block" aria-hidden="true" /> : null}
+        {mode !== "create" ? <span className="hidden lg:block" aria-hidden="true" /> : null}
       </div>
 
       <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">

--- a/web/src/features/finance/SnapshotPanels.tsx
+++ b/web/src/features/finance/SnapshotPanels.tsx
@@ -228,7 +228,13 @@ export function SnapshotFormPanel({
 
   return (
     <form className="space-y-4" onSubmit={handleSubmit}>
-      <div className="flex flex-wrap items-center justify-between gap-3">
+      <div
+        className={
+          mode === "edit"
+            ? "grid grid-cols-1 items-center gap-3 lg:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)]"
+            : "flex flex-wrap items-center justify-between gap-3"
+        }
+      >
         <TextInput
           type="text"
           value={title}
@@ -237,7 +243,7 @@ export function SnapshotFormPanel({
           aria-label={t("finance.snapshot.title")}
           className={`max-w-xl ${financeTextClass.moduleTitle}`}
         />
-        <div className="flex justify-end gap-2">
+        <div className={`flex gap-2 ${mode === "edit" ? "justify-center" : "justify-end"}`}>
           <ActionButton
             type="button"
             label={t("common.cancel")}
@@ -256,6 +262,7 @@ export function SnapshotFormPanel({
             disabled={submitting || !flatNodes.length}
           />
         </div>
+        {mode === "edit" ? <span className="hidden lg:block" aria-hidden="true" /> : null}
       </div>
 
       <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">

--- a/web/src/features/finance/__tests__/AmountText.test.tsx
+++ b/web/src/features/finance/__tests__/AmountText.test.tsx
@@ -4,22 +4,22 @@ import { describe, expect, it } from "vitest";
 import { FinanceAmountListText, FinanceAmountText } from "@/features/finance/AmountText";
 
 describe("FinanceAmountText", () => {
-  it("keeps the full numeric text visually continuous and subdues only symbols", () => {
+  it("keeps numeric text visually continuous and trims insignificant zeroes", () => {
     render(<FinanceAmountText amount="123.4500" currencyCode="USD" />);
 
-    expect(screen.getByText("123.4500").className).toContain("font-medium");
+    expect(screen.getByText("123.45").className).toContain("font-medium");
     expect(screen.queryByText(".4500")).toBeNull();
     expect(screen.getByText("USD").className).toContain("opacity-65");
-    expect(screen.getByText("123.4500").parentElement?.className).toContain(
+    expect(screen.getByText("123.45").parentElement?.className).toContain(
       "text-base-content",
     );
-    expect(screen.getByText("123.4500").parentElement?.className).not.toContain("text-warning");
+    expect(screen.getByText("123.45").parentElement?.className).not.toContain("text-warning");
   });
 
   it("uses warning text color for negative values", () => {
     render(<FinanceAmountText amount="-42.50" currencyCode="CNY" />);
 
-    expect(screen.getByText("-42.50").parentElement?.className).toContain("text-warning");
+    expect(screen.getByText("-42.5").parentElement?.className).toContain("text-warning");
     expect(screen.getByText("CNY").className).not.toContain("text-base-content");
   });
 });
@@ -31,11 +31,11 @@ describe("FinanceAmountListText", () => {
     const usd = screen.getByText("USD");
     const btc = screen.getByText("BTC");
 
-    expect(within(usd.parentElement as HTMLElement).getByText("10.00").className).toContain(
+    expect(within(usd.parentElement as HTMLElement).getByText("10").className).toContain(
       "font-medium",
     );
     expect(
-      within(btc.parentElement as HTMLElement).getByText("-2.50").parentElement?.className,
+      within(btc.parentElement as HTMLElement).getByText("-2.5").parentElement?.className,
     ).toContain("text-warning");
   });
 });

--- a/web/src/features/finance/__tests__/RateSnapshotsWorkspace.test.tsx
+++ b/web/src/features/finance/__tests__/RateSnapshotsWorkspace.test.tsx
@@ -109,7 +109,7 @@ describe("RateSnapshotsWorkspace", () => {
     renderWithProviders(<RateSnapshotsWorkspace />);
 
     await user.click(
-      await screen.findByRole("button", { name: "finance.rates.copySnapshot" }),
+      await screen.findByRole("button", { name: "common.copy" }),
     );
     await user.click(screen.getByRole("button", { name: "common.save" }));
 
@@ -125,7 +125,7 @@ describe("RateSnapshotsWorkspace", () => {
         {
           base_currency: "USD",
           quote_currency: "CNY",
-          rate: "7.120000000000",
+          rate: "7.12",
           source: "wise",
         },
       ],

--- a/web/src/features/finance/__tests__/RateSnapshotsWorkspace.test.tsx
+++ b/web/src/features/finance/__tests__/RateSnapshotsWorkspace.test.tsx
@@ -1,0 +1,136 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RateSnapshotsWorkspace } from "@/features/finance/RateSnapshotsWorkspace";
+import type {
+  FinanceAsset,
+  FinanceAssetListResponse,
+  FinanceRateSnapshot,
+  FinanceRateSnapshotCreate,
+  FinanceRateSnapshotListResponse,
+} from "@/services/api/finance";
+import { renderWithProviders, setupTranslationMock } from "@test/utils";
+
+const financeApiMocks = vi.hoisted(() => ({
+  listAssets: vi.fn(),
+  createAsset: vi.fn(),
+  listRateSnapshots: vi.fn(),
+  createRateSnapshot: vi.fn(),
+  updateRateSnapshot: vi.fn(),
+  deleteRateSnapshot: vi.fn(),
+}));
+
+vi.mock("@/services/api/finance", () => ({
+  financeApi: financeApiMocks,
+}));
+
+const assetListResponse = (items: FinanceAsset[]): FinanceAssetListResponse => ({
+  items,
+  pagination: { page: 1, size: 200, total: items.length, pages: 1 },
+  meta: {},
+});
+
+const rateSnapshotListResponse = (
+  items: FinanceRateSnapshot[],
+): FinanceRateSnapshotListResponse => ({
+  items,
+  pagination: { page: 1, size: 50, total: items.length, pages: 1 },
+  meta: {},
+});
+
+describe("RateSnapshotsWorkspace", () => {
+  const sourceSnapshot: FinanceRateSnapshot = {
+    id: "rate-source",
+    captured_at: "2026-06-30T01:02:00.000Z",
+    source: "wise",
+    note: "Month-end rates",
+    entries: [
+      {
+        id: "rate-entry-usd-cny",
+        base_currency: "USD",
+        quote_currency: "CNY",
+        rate: "7.120000000000",
+        source: "wise",
+        captured_at: null,
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    setupTranslationMock();
+    financeApiMocks.listAssets.mockResolvedValue(
+      assetListResponse([
+        {
+          id: "asset-usd",
+          code: "USD",
+          name: "US Dollar",
+          decimal_places: 2,
+          is_default: true,
+        },
+        {
+          id: "asset-cny",
+          code: "CNY",
+          name: "Chinese Yuan",
+          decimal_places: 2,
+          is_default: true,
+        },
+      ]),
+    );
+    financeApiMocks.listRateSnapshots.mockResolvedValue(
+      rateSnapshotListResponse([sourceSnapshot]),
+    );
+    financeApiMocks.createRateSnapshot.mockImplementation(
+      async (payload: FinanceRateSnapshotCreate): Promise<FinanceRateSnapshot> => ({
+        ...sourceSnapshot,
+        id: "rate-copy",
+        captured_at: payload.captured_at ?? "2026-07-01T12:34:00.000Z",
+        source: payload.source ?? "manual",
+        note: payload.note,
+        entries: payload.entries.map((entry, index) => ({
+          id: `rate-copy-entry-${index}`,
+          base_currency: entry.base_currency,
+          quote_currency: entry.quote_currency,
+          rate: entry.rate,
+          source: entry.source,
+          captured_at: entry.captured_at ?? null,
+        })),
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("copies an existing rate snapshot into a new saved snapshot", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(<RateSnapshotsWorkspace />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "finance.rates.copySnapshot" }),
+    );
+    await user.click(screen.getByRole("button", { name: "common.save" }));
+
+    await waitFor(() => {
+      expect(financeApiMocks.createRateSnapshot).toHaveBeenCalledTimes(1);
+    });
+    expect(financeApiMocks.updateRateSnapshot).not.toHaveBeenCalled();
+    const payload = financeApiMocks.createRateSnapshot.mock.calls[0]?.[0];
+    expect(payload).toMatchObject({
+      source: "wise",
+      note: "Month-end rates",
+      entries: [
+        {
+          base_currency: "USD",
+          quote_currency: "CNY",
+          rate: "7.120000000000",
+          source: "wise",
+        },
+      ],
+    });
+    expect(payload.captured_at).toEqual(expect.any(String));
+    expect(payload.captured_at).not.toBe(sourceSnapshot.captured_at);
+  });
+});

--- a/web/src/features/finance/__tests__/SnapshotPanels.test.tsx
+++ b/web/src/features/finance/__tests__/SnapshotPanels.test.tsx
@@ -1,0 +1,132 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { SnapshotFormPanel } from "@/features/finance/SnapshotPanels";
+import type {
+  FinanceAsset,
+  FinanceSnapshot,
+  FinanceTree,
+  FinanceTreeNode,
+} from "@/services/api/finance";
+import { renderWithProviders, setupTranslationMock } from "@test/utils";
+
+const assets: FinanceAsset[] = [
+  {
+    id: "asset-usd",
+    code: "USD",
+    name: "US Dollar",
+    decimal_places: 2,
+    is_default: true,
+  },
+  {
+    id: "asset-eth",
+    code: "ETH",
+    name: "Ethereum",
+    decimal_places: 8,
+    is_default: true,
+  },
+];
+
+const node: FinanceTreeNode = {
+  id: "node-wallet",
+  parent_id: null,
+  name: "Wallet",
+  currency_code: "ETH",
+  path: "Wallet",
+  depth: 0,
+  display_order: 1,
+};
+
+const tree: FinanceTree = {
+  id: "tree-balance",
+  name: "Balance",
+  primary_currency: "USD",
+  display_order: 1,
+  is_default: true,
+  nodes: [node],
+};
+
+const sourceSnapshot: FinanceSnapshot = {
+  id: "snapshot-source",
+  tree_id: tree.id,
+  tree_name: tree.name,
+  title: "June balance",
+  snapshot_ts: "2026-06-30T20:00:00.000Z",
+  period_start: null,
+  period_end: null,
+  primary_currency: "USD",
+  rate_snapshot_id: "rate-june",
+  note: "Source note",
+  entries: [
+    {
+      id: "entry-wallet",
+      node_id: node.id,
+      node_name: node.name,
+      amount: "1.00000000",
+      currency_code: "ETH",
+      amount_converted: "1573.8800",
+      note: "Main wallet",
+      is_auto_generated: false,
+    },
+  ],
+  created_at: "2026-06-30T20:01:00.000Z",
+};
+
+describe("SnapshotFormPanel", () => {
+  it("prefills copied snapshots and submits create-ready entries", async () => {
+    setupTranslationMock();
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    renderWithProviders(
+      <SnapshotFormPanel
+        tree={tree}
+        preset={{
+          report: "balance",
+          titleKey: "finance.balance.title",
+          descriptionKey: "finance.balance.description",
+          timeMode: "instant",
+        }}
+        assets={assets}
+        onCreateAsset={vi.fn()}
+        treeOptions={[tree]}
+        selectedTreeId={tree.id}
+        onSelectTree={vi.fn()}
+        treeNodes={[{ ...node, children: [] }]}
+        rateSnapshots={[]}
+        submitting={false}
+        mode="copy"
+        initialSnapshot={sourceSnapshot}
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByDisplayValue("June balance")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("1")).toBeInTheDocument();
+    expect(screen.queryByDisplayValue("1.00000000")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "common.save" }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "June balance",
+        primary_currency: "USD",
+        rate_snapshot_id: "rate-june",
+        note: "Source note",
+        entries: [
+          {
+            node_id: node.id,
+            amount: "1",
+            currency_code: "ETH",
+            note: "Main wallet",
+          },
+        ],
+      }),
+    );
+    expect(onSubmit.mock.calls[0]?.[0].snapshot_ts).toEqual(expect.any(String));
+    expect(onSubmit.mock.calls[0]?.[0].snapshot_ts).not.toBe(sourceSnapshot.snapshot_ts);
+  });
+});

--- a/web/src/features/finance/__tests__/utils.test.ts
+++ b/web/src/features/finance/__tests__/utils.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { rateSnapshotLabel, snapshotLabel } from "@/features/finance/utils";
+import {
+  formatCompactAmountForAsset,
+  rateSnapshotLabel,
+  snapshotLabel,
+} from "@/features/finance/utils";
 import type { FinanceRateSnapshot, FinanceSnapshot } from "@/services/api/finance";
 
 const baseSnapshot = {
@@ -50,5 +54,27 @@ describe("finance rate snapshot labels", () => {
     } as FinanceRateSnapshot);
 
     expect(label).not.toContain("BTC/USDT");
+  });
+});
+
+describe("finance asset amount formatting", () => {
+  it("limits editable values to asset precision and trims trailing zeroes", () => {
+    expect(
+      formatCompactAmountForAsset(
+        "2.340000",
+        "USDT",
+        [{ id: "asset-usdt", code: "USDT", decimal_places: 6, is_default: true }],
+      ),
+    ).toBe("2.34");
+  });
+
+  it("rounds editable values to the selected asset precision", () => {
+    expect(
+      formatCompactAmountForAsset(
+        "7.129",
+        "CNY",
+        [{ id: "asset-cny", code: "CNY", decimal_places: 2, is_default: true }],
+      ),
+    ).toBe("7.13");
   });
 });

--- a/web/src/features/finance/__tests__/utils.test.ts
+++ b/web/src/features/finance/__tests__/utils.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  formatCompactAmountForAsset,
+  formatAmountForAsset,
+  formatNumberForAsset,
   rateSnapshotLabel,
   snapshotLabel,
 } from "@/features/finance/utils";
@@ -60,7 +61,7 @@ describe("finance rate snapshot labels", () => {
 describe("finance asset amount formatting", () => {
   it("limits editable values to asset precision and trims trailing zeroes", () => {
     expect(
-      formatCompactAmountForAsset(
+      formatAmountForAsset(
         "2.340000",
         "USDT",
         [{ id: "asset-usdt", code: "USDT", decimal_places: 6, is_default: true }],
@@ -70,11 +71,21 @@ describe("finance asset amount formatting", () => {
 
   it("rounds editable values to the selected asset precision", () => {
     expect(
-      formatCompactAmountForAsset(
+      formatAmountForAsset(
         "7.129",
         "CNY",
         [{ id: "asset-cny", code: "CNY", decimal_places: 2, is_default: true }],
       ),
     ).toBe("7.13");
+  });
+
+  it("does not pad formatted display values to asset precision", () => {
+    expect(
+      formatNumberForAsset(
+        1,
+        "ETH",
+        [{ id: "asset-eth", code: "ETH", decimal_places: 8, is_default: true }],
+      ),
+    ).toBe("1");
   });
 });

--- a/web/src/features/finance/utils.ts
+++ b/web/src/features/finance/utils.ts
@@ -122,6 +122,25 @@ export const formatAmountForAsset = (
   return formatNumberForAsset(numeric, currency, assets);
 };
 
+export const formatCompactAmountForAsset = (
+  value: string,
+  currency: string,
+  assets: FinanceAsset[] = [],
+) => {
+  if (!value.trim()) {
+    return value;
+  }
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return value;
+  }
+  return numeric.toLocaleString(undefined, {
+    useGrouping: false,
+    minimumFractionDigits: 0,
+    maximumFractionDigits: assetDecimalPlaces(assets, currency),
+  });
+};
+
 export const formatMoney = (
   value?: string | null,
   currency = "",

--- a/web/src/features/finance/utils.ts
+++ b/web/src/features/finance/utils.ts
@@ -103,7 +103,7 @@ export const formatNumberForAsset = (
 ) =>
   value.toLocaleString(undefined, {
     useGrouping: false,
-    minimumFractionDigits: assetDecimalPlaces(assets, currency),
+    minimumFractionDigits: 0,
     maximumFractionDigits: assetDecimalPlaces(assets, currency),
   });
 
@@ -120,25 +120,6 @@ export const formatAmountForAsset = (
     return value;
   }
   return formatNumberForAsset(numeric, currency, assets);
-};
-
-export const formatCompactAmountForAsset = (
-  value: string,
-  currency: string,
-  assets: FinanceAsset[] = [],
-) => {
-  if (!value.trim()) {
-    return value;
-  }
-  const numeric = Number(value);
-  if (!Number.isFinite(numeric)) {
-    return value;
-  }
-  return numeric.toLocaleString(undefined, {
-    useGrouping: false,
-    minimumFractionDigits: 0,
-    maximumFractionDigits: assetDecimalPlaces(assets, currency),
-  });
 };
 
 export const formatMoney = (

--- a/web/src/features/finance/utils.ts
+++ b/web/src/features/finance/utils.ts
@@ -40,6 +40,8 @@ export type SnapshotHoldingState = {
 
 export type SnapshotAmountState = Record<UUID, SnapshotHoldingState[]>;
 
+export type SnapshotFormMode = "create" | "edit" | "copy";
+
 export type RateSnapshotFormMode = "create" | "edit" | "copy";
 
 export type RateRowState = {

--- a/web/src/features/finance/utils.ts
+++ b/web/src/features/finance/utils.ts
@@ -40,7 +40,7 @@ export type SnapshotHoldingState = {
 
 export type SnapshotAmountState = Record<UUID, SnapshotHoldingState[]>;
 
-export type RateSnapshotFormMode = "create" | "edit";
+export type RateSnapshotFormMode = "create" | "edit" | "copy";
 
 export type RateRowState = {
   baseAmount: string;

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -1538,6 +1538,7 @@
       "addRate": "Add rate",
       "createSnapshot": "Create rates",
       "editSnapshot": "Edit rate snapshot",
+      "copySnapshot": "Copy rate snapshot",
       "saveSnapshot": "Save rate snapshot",
       "deleteSnapshot": "Delete rate snapshot",
       "deleteTitle": "Delete rate snapshot",

--- a/web/src/locales/zh/common.json
+++ b/web/src/locales/zh/common.json
@@ -1538,6 +1538,7 @@
       "addRate": "添加汇率",
       "createSnapshot": "创建汇率",
       "editSnapshot": "编辑汇率快照",
+      "copySnapshot": "复制汇率快照",
       "saveSnapshot": "保存汇率快照",
       "deleteSnapshot": "删除汇率快照",
       "deleteTitle": "删除汇率快照",

--- a/web/src/pages/FinancePage.tsx
+++ b/web/src/pages/FinancePage.tsx
@@ -717,35 +717,37 @@ function FinanceTreesWorkspace() {
                   ? t("finance.tree.editTree")
                   : t("finance.tree.createTree")
               }
-              rightSlot={
-                <div className="flex justify-end gap-2">
-                  <ActionButton
-                    label={t("common.cancel")}
-                    iconName="x-mark"
-                    onClick={() => {
-                      setTreeFormVisible(false);
-                      setTreeFormMode("create");
-                    }}
-                    size="sm"
-                    variant="ghost"
-                    disabled={createTreeMutation.isPending || updateTreeMutation.isPending}
-                  />
-                  <ActionButton
-                    type="submit"
-                    form={treeFormId}
-                    label={
-                      createTreeMutation.isPending || updateTreeMutation.isPending
-                        ? t("common.saving")
-                        : t("common.save")
-                    }
-                    iconName="check"
-                    color="primary"
-                    variant="solid"
-                    disabled={createTreeMutation.isPending || updateTreeMutation.isPending}
-                  />
-                </div>
-              }
             />
+            <div
+              className={`mt-4 flex gap-2 ${
+                treeFormMode === "create" ? "justify-end" : "justify-center"
+              }`}
+            >
+              <ActionButton
+                label={t("common.cancel")}
+                iconName="x-mark"
+                onClick={() => {
+                  setTreeFormVisible(false);
+                  setTreeFormMode("create");
+                }}
+                size="sm"
+                variant="ghost"
+                disabled={createTreeMutation.isPending || updateTreeMutation.isPending}
+              />
+              <ActionButton
+                type="submit"
+                form={treeFormId}
+                label={
+                  createTreeMutation.isPending || updateTreeMutation.isPending
+                    ? t("common.saving")
+                    : t("common.save")
+                }
+                iconName="check"
+                color="primary"
+                variant="solid"
+                disabled={createTreeMutation.isPending || updateTreeMutation.isPending}
+              />
+            </div>
             <FinanceTreeFormPanel
               formId={treeFormId}
               mode={treeFormMode}
@@ -776,8 +778,8 @@ function FinanceTreesWorkspace() {
               title={tree.name}
               rightSlot={
                 <SnapshotActionButtons
-                  editLabel={t("finance.tree.editTree")}
-                  deleteLabel={t("finance.tree.deleteTree")}
+                  editLabel={t("common.edit")}
+                  deleteLabel={t("common.delete")}
                   disabled={deleteTreeMutation.isPending}
                   deleteDisabled={deleteTreeMutation.isPending}
                   onEdit={() => {
@@ -1109,8 +1111,8 @@ function SnapshotModule({
             rightSlot={
               currentSnapshot ? (
                 <SnapshotActionButtons
-                  editLabel={t("finance.snapshot.edit")}
-                  deleteLabel={t("finance.snapshot.delete")}
+                  editLabel={t("common.edit")}
+                  deleteLabel={t("common.delete")}
                   disabled={snapshotDetailLoading || snapshotDeleting}
                   deleteDisabled={snapshotDeleting}
                   onEdit={onEditSnapshot}

--- a/web/src/pages/FinancePage.tsx
+++ b/web/src/pages/FinancePage.tsx
@@ -48,6 +48,7 @@ import {
   type FinanceTab,
   type FinanceToolbarTab,
   type PresetConfig,
+  type SnapshotFormMode,
   type TreeNodeWithChildren,
 } from "@/features/finance/utils";
 import {
@@ -167,7 +168,7 @@ function FinancePresetWorkspace({ preset }: { preset: PresetConfig }) {
   const { assets, createAsset } = useFinanceAssetSource();
   const [selectedSnapshotId, setSelectedSnapshotId] = useState<UUID | null>(null);
   const [snapshotFormVisible, setSnapshotFormVisible] = useState(false);
-  const [snapshotFormMode, setSnapshotFormMode] = useState<"create" | "edit">("create");
+  const [snapshotFormMode, setSnapshotFormMode] = useState<SnapshotFormMode>("create");
   const [selectedTreeId, setSelectedTreeId] = useState<UUID | null>(null);
   const [pendingDeleteSnapshot, setPendingDeleteSnapshot] = useState<FinanceSnapshot | null>(null);
   const [deletedSnapshotIds, setDeletedSnapshotIds] = useState<Set<UUID>>(() => new Set());
@@ -395,6 +396,14 @@ function FinancePresetWorkspace({ preset }: { preset: PresetConfig }) {
     setSnapshotFormVisible(true);
   };
 
+  const openCopySnapshotForm = () => {
+    if (currentSnapshot) {
+      setSelectedTreeId(currentSnapshot.tree_id);
+    }
+    setSnapshotFormMode("copy");
+    setSnapshotFormVisible(true);
+  };
+
   const closeSnapshotForm = () => {
     setSnapshotFormVisible(false);
     setSnapshotFormMode("create");
@@ -444,6 +453,7 @@ function FinancePresetWorkspace({ preset }: { preset: PresetConfig }) {
         snapshotDeleting={deleteSnapshotMutation.isPending}
         onOpenSnapshotForm={openCreateSnapshotForm}
         onEditSnapshot={openEditSnapshotForm}
+        onCopySnapshot={openCopySnapshotForm}
         onDeleteSnapshot={setPendingDeleteSnapshot}
         onCloseSnapshotForm={closeSnapshotForm}
         treeOptions={trees}
@@ -972,6 +982,7 @@ function SnapshotModule({
   snapshotDeleting,
   onOpenSnapshotForm,
   onEditSnapshot,
+  onCopySnapshot,
   onDeleteSnapshot,
   onCloseSnapshotForm,
   treeOptions,
@@ -991,12 +1002,13 @@ function SnapshotModule({
   snapshotDetail: FinanceSnapshot | null;
   snapshotDetailLoading: boolean;
   snapshotFormVisible: boolean;
-  snapshotFormMode: "create" | "edit";
+  snapshotFormMode: SnapshotFormMode;
   snapshotSubmitting: boolean;
   snapshotUpdating: boolean;
   snapshotDeleting: boolean;
   onOpenSnapshotForm: () => void;
   onEditSnapshot: () => void;
+  onCopySnapshot: () => void;
   onDeleteSnapshot: (snapshot: FinanceSnapshot) => void;
   onCloseSnapshotForm: () => void;
   treeOptions: FinanceTree[];
@@ -1074,7 +1086,7 @@ function SnapshotModule({
   return (
     <section className="rounded-2xl border border-base-200 bg-base-100 p-4 shadow-sm">
       {snapshotFormVisible ? (
-        snapshotFormMode === "edit" && snapshotDetailLoading ? (
+        snapshotFormMode !== "create" && snapshotDetailLoading ? (
             <div className="py-6">
               <LoadingSpinner />
             </div>
@@ -1093,7 +1105,7 @@ function SnapshotModule({
                 snapshotFormMode === "edit" ? snapshotUpdating : snapshotSubmitting
               }
               mode={snapshotFormMode}
-              initialSnapshot={snapshotFormMode === "edit" ? snapshotDetail : null}
+              initialSnapshot={snapshotFormMode !== "create" ? snapshotDetail : null}
               onSubmit={(payload) => {
                 if (snapshotFormMode === "edit" && snapshotDetail) {
                   onUpdateSnapshot(snapshotDetail.id, payload);
@@ -1112,10 +1124,12 @@ function SnapshotModule({
               currentSnapshot ? (
                 <SnapshotActionButtons
                   editLabel={t("common.edit")}
+                  copyLabel={t("common.copy")}
                   deleteLabel={t("common.delete")}
-                  disabled={snapshotDetailLoading || snapshotDeleting}
+                  disabled={snapshotDetailLoading || !snapshotDetail || snapshotDeleting}
                   deleteDisabled={snapshotDeleting}
                   onEdit={onEditSnapshot}
+                  onCopy={onCopySnapshot}
                   onDelete={() => onDeleteSnapshot(currentSnapshot)}
                 />
               ) : null


### PR DESCRIPTION
## 背景

当前新建汇率快照时需要从空表单开始录入。对于定期更新汇率的场景，用户需要重复填写来源、备注和相同的汇率行。

后续 UX 复查发现：编辑保存按钮位于右上角时，保存后详情态右上角的删除按钮会刷新到相近位置，容易造成误点；同时 finance 页面详情态操作按钮文案偏长，汇率与金额展示补齐尾零也降低了可读性。

本次会话进一步将复制能力扩展到资产负债表和现金流表快照：复制应等价于基于现有快照创建新快照，保留来源数据和金额，允许用户手动调整新的时间点或期间。

## 变更

- 在汇率快照详情动作区增加复制入口。
- 汇率快照复制时打开新的创建表单，采集时间使用当前时间，来源、备注和汇率行沿用原快照。
- 在资产负债表、现金流表快照详情动作区增加复制入口。
- 财务快照复制时复用现有快照明细预填表单，保存时调用创建接口，避免修改原快照。
- 资产负债表复制时将快照时间重置为当前时间；现金流表复制时保留原期间起止日期，供用户手动调整。
- 将 finance 页面详情态操作按钮统一缩短为“编辑 / 复制 / 删除”。
- 编辑/复制态表单的取消/保存按钮改为居中动作行，避免保存后与详情态右上角操作按钮重叠。
- finance 金额显示统一改为遵守资产最大精度但不补齐尾零，包括 API 返回的已格式化金额字符串。
- 汇率快照和财务快照复制/编辑时，金额输入按对应 asset 最大精度格式化，并精简无意义尾零。
- 补充中英文文案和前端组件/工具测试。
- 基于 PR 自审清理本分支引入的冗余透传参数、不必要刷新和重复格式化薄壳。

## 审查结论

- 需求仍然有效，复制功能符合当前最新代码的最佳实践：前端复用已有创建接口和共享表单，不引入新的后端契约或数据库结构。
- 资产负债表、现金流表与汇率快照的复制语义一致：新建一份可编辑快照，原快照不被修改。
- “按资产精度限制但精简尾零”的显示策略合理：它保留数值精度约束，同时避免 `1.00000000 ETH = 1573.8800 USDT` 这类低可读性展示。
- 未发现需要保留的兼容别名、薄壳函数或纯转发函数。
- `Closes #196` 关系准确，本 PR 完整解决该 issue 描述的复制汇率快照需求，并在同一 finance 快照体验中扩展支持资产负债表和现金流表复制。

## 验证

- npm run test -- src/features/finance/__tests__/SnapshotPanels.test.tsx src/features/finance/__tests__/RateSnapshotsWorkspace.test.tsx src/features/finance/__tests__/utils.test.ts src/features/finance/__tests__/AmountText.test.tsx
- bash ./scripts/web_validate.sh
- bash ./scripts/doctor.sh

Closes #196
