### PR TITLE
fix(web): add row hover states

### DIFF
--- a/web/src/components/PersonManager.tsx
+++ b/web/src/components/PersonManager.tsx
@@ -25,6 +25,9 @@ interface PersonManagerProps {
   createRequestSignal?: number;
 }
 
+const PERSON_ROW_CELL_HOVER_CLASS =
+  "transition-colors group-hover:bg-primary/10 group-focus-within:bg-primary/10";
+
 /**
  * PersonManager - Component for managing persons and their relationships
  *
@@ -467,15 +470,15 @@ const PersonManager: React.FC<PersonManagerProps> = ({
               return (
                 <div
                   key={person.id}
-                  className="contents hover:bg-base-200/40 cursor-pointer rounded"
+                  className="contents group cursor-pointer"
                   onClick={() => handlePersonSelect(person)}
                 >
-                  <div className="px-4 py-3 border-b border-base-300">
+                  <div className={`px-4 py-3 border-b border-base-300 ${PERSON_ROW_CELL_HOVER_CLASS}`}>
                     <div className="text-base font-medium text-base-content">
                       {person.display_name}
                     </div>
                   </div>
-                  <div className="px-4 py-3 border-b border-base-300">
+                  <div className={`px-4 py-3 border-b border-base-300 ${PERSON_ROW_CELL_HOVER_CLASS}`}>
                     {person.primary_nickname &&
                       person.primary_nickname.trim() &&
                       person.primary_nickname !== person.display_name && (
@@ -496,7 +499,7 @@ const PersonManager: React.FC<PersonManagerProps> = ({
                         </div>
                       )}
                   </div>
-                  <div className="px-4 py-3 border-b border-base-300">
+                  <div className={`px-4 py-3 border-b border-base-300 ${PERSON_ROW_CELL_HOVER_CLASS}`}>
                     {(locationTags.length > 0 || person.location) && (
                       <div className="flex flex-wrap gap-1">
                         {locationTags.length > 0
@@ -522,10 +525,10 @@ const PersonManager: React.FC<PersonManagerProps> = ({
                       </div>
                     )}
                   </div>
-                  <div className="px-4 py-3 border-b border-base-300 text-base text-base-content whitespace-nowrap">
+                  <div className={`px-4 py-3 border-b border-base-300 text-base text-base-content whitespace-nowrap ${PERSON_ROW_CELL_HOVER_CLASS}`}>
                     {person.birth_date || ""}
                   </div>
-                  <div className="px-4 py-3 border-b border-base-300  ">
+                  <div className={`px-4 py-3 border-b border-base-300 ${PERSON_ROW_CELL_HOVER_CLASS}`}>
                     <div className="flex flex-wrap gap-1">
                       {relationshipTags.slice(0, 5).map((tag: Tag) => (
                         <UnifiedTag key={tag.id} type="relationship" size="sm">
@@ -539,7 +542,7 @@ const PersonManager: React.FC<PersonManagerProps> = ({
                       )}
                     </div>
                   </div>
-                  <div className="px-4 py-3 border-b border-base-300 text-right">
+                  <div className={`px-4 py-3 border-b border-base-300 text-right ${PERSON_ROW_CELL_HOVER_CLASS}`}>
                     <ActionButtonGroup gap="sm" align="end">
                       <ActionButton
                         label={t("personManager.timeline")}

--- a/web/src/components/habits/HabitActionList.tsx
+++ b/web/src/components/habits/HabitActionList.tsx
@@ -386,7 +386,7 @@ export function HabitActionList({
               return (
                 <div
                   key={formatDateKey(date)}
-                  className={`flex items-center justify-between p-3 border rounded-lg ${
+                  className={`flex items-center justify-between p-3 border rounded-lg transition-colors hover:bg-primary/10 focus-within:bg-primary/10 ${
                     isSelectedDate
                       ? "border-primary bg-primary/10 ring-2 ring-primary/20"
                       : isTodayDate

--- a/web/src/features/finance/RateSnapshotsWorkspace.tsx
+++ b/web/src/features/finance/RateSnapshotsWorkspace.tsx
@@ -390,7 +390,7 @@ export function RateSnapshotsWorkspace() {
                   {rateRows.map((row, index) => (
                     <div
                       key={index}
-                      className="grid grid-cols-[minmax(5rem,0.7fr)_minmax(7rem,1fr)_auto_minmax(5rem,0.7fr)_minmax(7rem,1fr)_auto] items-center gap-2 rounded-md px-2 py-1 transition-colors hover:bg-primary/10 focus-within:bg-primary/10"
+                      className="grid grid-cols-[minmax(5rem,0.7fr)_minmax(7rem,1fr)_auto_minmax(5rem,0.7fr)_minmax(7rem,1fr)_auto] items-center gap-2 rounded-md transition-colors hover:bg-primary/10 focus-within:bg-primary/10"
                     >
                       <TextInput
                         size="sm"

--- a/web/src/features/finance/RateSnapshotsWorkspace.tsx
+++ b/web/src/features/finance/RateSnapshotsWorkspace.tsx
@@ -390,7 +390,7 @@ export function RateSnapshotsWorkspace() {
                   {rateRows.map((row, index) => (
                     <div
                       key={index}
-                      className="grid grid-cols-[minmax(5rem,0.7fr)_minmax(7rem,1fr)_auto_minmax(5rem,0.7fr)_minmax(7rem,1fr)_auto] items-center gap-2"
+                      className="grid grid-cols-[minmax(5rem,0.7fr)_minmax(7rem,1fr)_auto_minmax(5rem,0.7fr)_minmax(7rem,1fr)_auto] items-center gap-2 rounded-md px-2 py-1 transition-colors hover:bg-primary/10 focus-within:bg-primary/10"
                     >
                       <TextInput
                         size="sm"
@@ -550,7 +550,10 @@ export function RateSnapshotsWorkspace() {
                 </thead>
                 <tbody>
                   {(currentSnapshot.entries ?? []).map((entry) => (
-                    <tr key={entry.id}>
+                    <tr
+                      key={entry.id}
+                      className="transition-colors hover:bg-primary/10 focus-within:bg-primary/10"
+                    >
                       <RateEntryEquationCells entry={entry} assets={assets} />
                     </tr>
                   ))}

--- a/web/src/features/finance/SnapshotPanels.tsx
+++ b/web/src/features/finance/SnapshotPanels.tsx
@@ -551,7 +551,9 @@ function SnapshotEntryTreeTable({
                   onClick={() => toggleNode(node.id)}
                 />
               ) : (
-                <span className="mt-1 inline-flex h-6 w-6 flex-shrink-0" />
+                <span className="mt-1 inline-flex h-6 w-6 flex-shrink-0 items-center justify-center text-base-content/30">
+                  •
+                </span>
               )}
               <div className="min-w-0 flex flex-col gap-1 sm:flex-row sm:items-center sm:gap-3">
                 <p className={`truncate ${financeTextClass.rowTitle}`}>{node.name}</p>
@@ -1125,7 +1127,9 @@ export function SnapshotDetail({
                             onClick={() => toggleNode(node.id)}
                           />
                         ) : hasNodeLabel ? (
-                          <span className="mt-1 inline-flex h-5 w-5 flex-shrink-0" />
+                          <span className="mt-1 inline-flex h-5 w-5 flex-shrink-0 items-center justify-center text-base-content/30">
+                            •
+                          </span>
                         ) : (
                           <span className="inline-flex h-5 w-5 flex-shrink-0" />
                         )}

--- a/web/src/features/finance/SnapshotPanels.tsx
+++ b/web/src/features/finance/SnapshotPanels.tsx
@@ -917,7 +917,10 @@ function AssetSummaryPanel({
           </thead>
           <tbody>
             {rowsWithShare.map((row) => (
-              <tr key={row.currency}>
+              <tr
+                key={row.currency}
+                className="transition-colors hover:bg-primary/10 focus-within:bg-primary/10"
+              >
                 <td>
                   <FinanceAssetSymbol symbol={row.currency} />
                 </td>

--- a/web/src/features/finance/SnapshotPanels.tsx
+++ b/web/src/features/finance/SnapshotPanels.tsx
@@ -36,6 +36,9 @@ import {
   type TreeNodeWithChildren,
 } from "./utils";
 
+const SNAPSHOT_TREE_ROW_HOVER_CLASS =
+  "transition-colors hover:bg-primary/10 focus-within:bg-primary/10";
+
 export function SnapshotFormPanel({
   tree,
   preset,
@@ -523,6 +526,7 @@ function SnapshotEntryTreeTable({
           key={node.id}
           className={[
             "border-base-200",
+            SNAPSHOT_TREE_ROW_HOVER_CLASS,
             hasChildren ? "border-l-4 border-l-base-content/30 bg-base-200/60" : "",
           ]
             .filter(Boolean)
@@ -547,9 +551,7 @@ function SnapshotEntryTreeTable({
                   onClick={() => toggleNode(node.id)}
                 />
               ) : (
-                <span className="mt-1 inline-flex h-6 w-6 flex-shrink-0 items-center justify-center text-base-content/30">
-                  •
-                </span>
+                <span className="mt-1 inline-flex h-6 w-6 flex-shrink-0" />
               )}
               <div className="min-w-0 flex flex-col gap-1 sm:flex-row sm:items-center sm:gap-3">
                 <p className={`truncate ${financeTextClass.rowTitle}`}>{node.name}</p>
@@ -679,7 +681,7 @@ function SnapshotEntryTreeTable({
           rows.push(
             <tr
               key={`${node.id}:${holding.id}`}
-              className="border-base-200 border-l-4 border-l-transparent bg-base-100"
+              className={`border-base-200 border-l-4 border-l-transparent bg-base-100 ${SNAPSHOT_TREE_ROW_HOVER_CLASS}`}
             >
               <td className="align-top">
                 <div
@@ -1099,6 +1101,7 @@ export function SnapshotDetail({
                     key={node.id}
                     className={[
                       "border-base-200",
+                      SNAPSHOT_TREE_ROW_HOVER_CLASS,
                       isAggregateRow
                         ? "border-l-4 border-l-base-content/30 bg-base-200/60"
                         : "border-l-4 border-l-transparent",
@@ -1122,9 +1125,7 @@ export function SnapshotDetail({
                             onClick={() => toggleNode(node.id)}
                           />
                         ) : hasNodeLabel ? (
-                          <span className="mt-1 inline-flex h-5 w-5 flex-shrink-0 items-center justify-center text-base-content/30">
-                            •
-                          </span>
+                          <span className="mt-1 inline-flex h-5 w-5 flex-shrink-0" />
                         ) : (
                           <span className="inline-flex h-5 w-5 flex-shrink-0" />
                         )}

--- a/web/src/features/finance/__tests__/RateSnapshotsWorkspace.test.tsx
+++ b/web/src/features/finance/__tests__/RateSnapshotsWorkspace.test.tsx
@@ -108,6 +108,10 @@ describe("RateSnapshotsWorkspace", () => {
 
     renderWithProviders(<RateSnapshotsWorkspace />);
 
+    const rateRow = (await screen.findByText("7.12")).closest("tr");
+    expect(rateRow).toHaveClass("hover:bg-primary/10");
+    expect(rateRow).toHaveClass("focus-within:bg-primary/10");
+
     await user.click(
       await screen.findByRole("button", { name: "common.copy" }),
     );

--- a/web/src/features/finance/__tests__/SnapshotPanels.test.tsx
+++ b/web/src/features/finance/__tests__/SnapshotPanels.test.tsx
@@ -74,7 +74,7 @@ const sourceSnapshot: FinanceSnapshot = {
 };
 
 describe("SnapshotFormPanel", () => {
-  it("renders snapshot entry rows with hover state and plain leaf placeholders", () => {
+  it("renders snapshot entry rows with hover state", () => {
     setupTranslationMock();
 
     renderWithProviders(
@@ -104,7 +104,6 @@ describe("SnapshotFormPanel", () => {
 
     expect(row).toHaveClass("hover:bg-primary/10");
     expect(row).toHaveClass("focus-within:bg-primary/10");
-    expect(screen.queryByText("•")).not.toBeInTheDocument();
   });
 
   it("prefills copied snapshots and submits create-ready entries", async () => {
@@ -165,7 +164,7 @@ describe("SnapshotFormPanel", () => {
 });
 
 describe("SnapshotDetail", () => {
-  it("renders detail tree rows with hover state and plain leaf placeholders", () => {
+  it("renders detail tree rows with hover state", () => {
     setupTranslationMock();
 
     renderWithProviders(
@@ -181,6 +180,5 @@ describe("SnapshotDetail", () => {
 
     expect(row).toHaveClass("hover:bg-primary/10");
     expect(row).toHaveClass("focus-within:bg-primary/10");
-    expect(screen.queryByText("•")).not.toBeInTheDocument();
   });
 });

--- a/web/src/features/finance/__tests__/SnapshotPanels.test.tsx
+++ b/web/src/features/finance/__tests__/SnapshotPanels.test.tsx
@@ -177,8 +177,14 @@ describe("SnapshotDetail", () => {
     );
 
     const row = screen.getByText("Wallet").closest("tr");
+    const assetSummaryPanel = screen
+      .getByText("finance.metrics.assetSummary")
+      .closest(".rounded-lg");
+    const assetSummaryRow = assetSummaryPanel?.querySelector("tbody tr");
 
     expect(row).toHaveClass("hover:bg-primary/10");
     expect(row).toHaveClass("focus-within:bg-primary/10");
+    expect(assetSummaryRow).toHaveClass("hover:bg-primary/10");
+    expect(assetSummaryRow).toHaveClass("focus-within:bg-primary/10");
   });
 });

--- a/web/src/features/finance/__tests__/SnapshotPanels.test.tsx
+++ b/web/src/features/finance/__tests__/SnapshotPanels.test.tsx
@@ -2,7 +2,7 @@ import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
-import { SnapshotFormPanel } from "@/features/finance/SnapshotPanels";
+import { SnapshotDetail, SnapshotFormPanel } from "@/features/finance/SnapshotPanels";
 import type {
   FinanceAsset,
   FinanceSnapshot,
@@ -74,6 +74,39 @@ const sourceSnapshot: FinanceSnapshot = {
 };
 
 describe("SnapshotFormPanel", () => {
+  it("renders snapshot entry rows with hover state and plain leaf placeholders", () => {
+    setupTranslationMock();
+
+    renderWithProviders(
+      <SnapshotFormPanel
+        tree={tree}
+        preset={{
+          report: "balance",
+          titleKey: "finance.balance.title",
+          descriptionKey: "finance.balance.description",
+          timeMode: "instant",
+        }}
+        assets={assets}
+        onCreateAsset={vi.fn()}
+        treeOptions={[tree]}
+        selectedTreeId={tree.id}
+        onSelectTree={vi.fn()}
+        treeNodes={[{ ...node, children: [] }]}
+        rateSnapshots={[]}
+        submitting={false}
+        mode="create"
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const row = screen.getByText("Wallet").closest("tr");
+
+    expect(row).toHaveClass("hover:bg-primary/10");
+    expect(row).toHaveClass("focus-within:bg-primary/10");
+    expect(screen.queryByText("•")).not.toBeInTheDocument();
+  });
+
   it("prefills copied snapshots and submits create-ready entries", async () => {
     setupTranslationMock();
     const user = userEvent.setup();
@@ -128,5 +161,26 @@ describe("SnapshotFormPanel", () => {
     );
     expect(onSubmit.mock.calls[0]?.[0].snapshot_ts).toEqual(expect.any(String));
     expect(onSubmit.mock.calls[0]?.[0].snapshot_ts).not.toBe(sourceSnapshot.snapshot_ts);
+  });
+});
+
+describe("SnapshotDetail", () => {
+  it("renders detail tree rows with hover state and plain leaf placeholders", () => {
+    setupTranslationMock();
+
+    renderWithProviders(
+      <SnapshotDetail
+        snapshot={sourceSnapshot}
+        assets={assets}
+        treeNodes={[{ ...node, children: [] }]}
+        rateSnapshots={[]}
+      />,
+    );
+
+    const row = screen.getByText("Wallet").closest("tr");
+
+    expect(row).toHaveClass("hover:bg-primary/10");
+    expect(row).toHaveClass("focus-within:bg-primary/10");
+    expect(screen.queryByText("•")).not.toBeInTheDocument();
   });
 });

--- a/web/src/pages/FinancePage.tsx
+++ b/web/src/pages/FinancePage.tsx
@@ -1444,7 +1444,7 @@ function TreeNodeRow({
   const isExpanded = expandedIds.has(node.id);
   return (
     <li>
-      <div className="flex items-center gap-2 rounded-md border border-base-300 bg-base-100 px-2 py-2 hover:border-base-300/80">
+      <div className="flex items-center gap-2 rounded-md border border-base-300 bg-base-100 px-2 py-2 transition-colors hover:border-base-300/80 hover:bg-primary/10 focus-within:bg-primary/10">
         <ActionButton
           label=""
           ariaLabel={isExpanded ? t("common.collapse") : t("common.expand")}


### PR DESCRIPTION
## 变更内容

- 给 finance 财务树、快照录入树、快照详情树增加 hover/focus 背景反馈。
- 给汇率快照编辑行、只读汇率行增加 hover/focus 背景反馈。
- 给资产负债表、现金流详情里的资产汇总表行增加 hover/focus 背景反馈。
- 给 people 页列表行增加 hover/focus 背景反馈；该列表使用 `display: contents` 行容器，因此背景作用在同一行的各单元格上。
- 给 habits 页 5 天视图的每日行增加 hover/focus 背景反馈。
- 保留快照树叶子节点原有的 `•` 占位呈现。
- 补充汇率快照、快照详情资产汇总相关测试，覆盖 hover class。

## 审查收敛

- 审查中发现汇率快照编辑行为 hover 增加的额外 padding 会轻微改变原有列对齐，已移除 padding，仅保留背景反馈。
- 已同步更新 issue #200 的范围，使 `Closes #200` 与当前 PR 变更一致。

## 验证

- `npm test -- SnapshotPanels RateSnapshotsWorkspace`
- `npm run typecheck:test`
- `npm run lint -- src/features/finance/RateSnapshotsWorkspace.tsx src/features/finance/SnapshotPanels.tsx src/features/finance/__tests__/RateSnapshotsWorkspace.test.tsx src/features/finance/__tests__/SnapshotPanels.test.tsx src/components/PersonManager.tsx src/components/habits/HabitActionList.tsx`
- `bash ./scripts/doctor.sh`
- `bash ./scripts/web_validate.sh`

Closes #200
