### PR TITLE
fix(web): restore task relation actions

### DIFF
--- a/src/lifeos_cli/db/services/notes.py
+++ b/src/lifeos_cli/db/services/notes.py
@@ -91,6 +91,7 @@ def _association_exists_clause(
             Association.target_model == target_model,
             Association.target_id == target_id,
             Association.link_type == link_type,
+            target_table.id == Association.target_id,
             target_table.id == target_id,
             target_table.deleted_at.is_(None),
         )

--- a/src/lifeos_web/routers/persons.py
+++ b/src/lifeos_web/routers/persons.py
@@ -98,8 +98,9 @@ def _activity_payload(
     description: str | None,
     activity_date: date | datetime,
     status: str | None = None,
+    extra: dict[str, object] | None = None,
 ) -> dict[str, object]:
-    return {
+    payload: dict[str, object] = {
         "id": str(entity_id),
         "type": activity_type,
         "title": title,
@@ -107,6 +108,9 @@ def _activity_payload(
         "date": activity_date.isoformat(),
         "status": status,
     }
+    if extra:
+        payload.update(extra)
+    return payload
 
 
 async def _load_person_entity_ids(
@@ -211,9 +215,13 @@ async def _load_activity_items(
                     entity_id=timelog.id,
                     activity_type="timelog",
                     title=timelog.title,
-                    description=timelog.notes,
+                    description=None,
                     activity_date=timelog.start_time,
-                    status=timelog.tracking_method,
+                    extra={
+                        "start_time": timelog.start_time.isoformat(),
+                        "end_time": timelog.end_time.isoformat(),
+                        "area_id": str(timelog.area_id) if timelog.area_id else None,
+                    },
                 )
                 for timelog in timelog_rows.scalars()
             )

--- a/src/lifeos_web/routers/persons.py
+++ b/src/lifeos_web/routers/persons.py
@@ -132,10 +132,13 @@ async def _load_person_entity_ids(
 
 async def _load_person_note_ids(session: AsyncSession, *, person_id: UUID) -> list[UUID]:
     rows = await session.execute(
-        select(Association.source_id).where(
+        select(Association.source_id)
+        .distinct()
+        .where(
             Association.source_model == "note",
             Association.target_model == "person",
             Association.target_id == person_id,
+            Association.link_type == "is_about",
         )
     )
     return list(rows.scalars().all())
@@ -236,8 +239,8 @@ async def _load_activity_items(
                 _activity_payload(
                     entity_id=note.id,
                     activity_type="note",
-                    title=_preview(note.content, limit=80) or "Note",
-                    description=note.content,
+                    title=_preview(note.content) or "Note",
+                    description=None,
                     activity_date=note.updated_at,
                 )
                 for note in note_rows.scalars()

--- a/src/lifeos_web/routers/tasks.py
+++ b/src/lifeos_web/routers/tasks.py
@@ -73,7 +73,7 @@ async def _load_task_relation_counts(
         .where(
             Association.source_model == "note",
             Association.target_model == "task",
-            Association.link_type == "captured_from",
+            Association.link_type == "relates_to",
             Association.target_id.in_(unique_task_ids),
             Note.deleted_at.is_(None),
         )

--- a/src/lifeos_web/routers/tasks.py
+++ b/src/lifeos_web/routers/tasks.py
@@ -8,8 +8,12 @@ from typing import Annotated, Any
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from lifeos_cli.db.models.association import Association
+from lifeos_cli.db.models.note import Note
+from lifeos_cli.db.models.timelog import Timelog
 from lifeos_cli.db.services import tasks as task_services
 from lifeos_web.deps import get_db_session
 from lifeos_web.schemas import (
@@ -37,7 +41,57 @@ TASK_BASIC_FIELDS = (
     "planning_cycle_days",
     "planning_cycle_start_date",
     "people",
+    "notes_count",
+    "timelogs_count",
 )
+
+
+def _collect_task_tree_ids(tasks: list[Any]) -> list[UUID]:
+    task_ids: list[UUID] = []
+
+    def visit(task: Any) -> None:
+        task_ids.append(task.id)
+        for subtask in getattr(task, "subtasks", ()) or ():
+            visit(subtask)
+
+    for task in tasks:
+        visit(task)
+    return task_ids
+
+
+async def _load_task_relation_counts(
+    session: AsyncSession,
+    task_ids: list[UUID],
+) -> tuple[dict[UUID, int], dict[UUID, int]]:
+    unique_task_ids = list(dict.fromkeys(task_ids))
+    if not unique_task_ids:
+        return {}, {}
+
+    note_rows = await session.execute(
+        select(Association.target_id, func.count(Association.id))
+        .join(Note, Note.id == Association.source_id)
+        .where(
+            Association.source_model == "note",
+            Association.target_model == "task",
+            Association.link_type == "captured_from",
+            Association.target_id.in_(unique_task_ids),
+            Note.deleted_at.is_(None),
+        )
+        .group_by(Association.target_id)
+    )
+    timelog_rows = await session.execute(
+        select(Timelog.task_id, func.count(Timelog.id))
+        .where(
+            Timelog.task_id.in_(unique_task_ids),
+            Timelog.deleted_at.is_(None),
+        )
+        .group_by(Timelog.task_id)
+    )
+
+    return (
+        {task_id: count for task_id, count in note_rows.all()},
+        {task_id: count for task_id, count in timelog_rows.all()},
+    )
 
 
 def _page_envelope(
@@ -56,7 +110,12 @@ def _page_envelope(
     )
 
 
-def _task_tree_payload(task: Any) -> dict[str, object]:
+def _task_tree_payload(
+    task: Any,
+    *,
+    notes_count_by_task: dict[UUID, int],
+    timelogs_count_by_task: dict[UUID, int],
+) -> dict[str, object]:
     """Serialize a nested task read model without leaking SQLAlchemy internals."""
     return {
         "id": str(task.id),
@@ -75,19 +134,37 @@ def _task_tree_payload(task: Any) -> dict[str, object]:
         ),
         "actual_effort_self": task.actual_effort_self,
         "actual_effort_total": task.actual_effort_total,
-        "notes_count": 0,
+        "notes_count": notes_count_by_task.get(task.id, 0),
+        "timelogs_count": timelogs_count_by_task.get(task.id, 0),
         "created_at": task.created_at.isoformat(),
         "updated_at": task.updated_at.isoformat(),
         "people": to_jsonable(task.people),
-        "subtasks": [_task_tree_payload(subtask) for subtask in task.subtasks],
+        "subtasks": [
+            _task_tree_payload(
+                subtask,
+                notes_count_by_task=notes_count_by_task,
+                timelogs_count_by_task=timelogs_count_by_task,
+            )
+            for subtask in task.subtasks
+        ],
         "completion_percentage": task.completion_percentage,
         "depth": task.depth,
     }
 
 
-def _task_list_payload(task: object, *, fields: str) -> dict[str, object]:
+def _task_list_payload(
+    task: object,
+    *,
+    fields: str,
+    notes_count_by_task: dict[UUID, int] | None = None,
+    timelogs_count_by_task: dict[UUID, int] | None = None,
+) -> dict[str, object]:
     payload = to_jsonable_dict(task)
     payload.pop("deleted_at", None)
+    task_id = getattr(task, "id", None)
+    if isinstance(task_id, UUID):
+        payload["notes_count"] = (notes_count_by_task or {}).get(task_id, 0)
+        payload["timelogs_count"] = (timelogs_count_by_task or {}).get(task_id, 0)
     if fields == "basic":
         return {field: payload.get(field) for field in TASK_BASIC_FIELDS}
     return payload
@@ -144,8 +221,20 @@ async def list_tasks(
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+    notes_count_by_task, timelogs_count_by_task = await _load_task_relation_counts(
+        session,
+        [row.id for row in rows],
+    )
     return _page_envelope(
-        items=[_task_list_payload(row, fields=fields) for row in rows],
+        items=[
+            _task_list_payload(
+                row,
+                fields=fields,
+                notes_count_by_task=notes_count_by_task,
+                timelogs_count_by_task=timelogs_count_by_task,
+            )
+            for row in rows
+        ],
         page=page,
         size=size,
         total=total_count,
@@ -198,9 +287,21 @@ async def get_vision_hierarchy(vision_id: UUID, session: SessionDep) -> dict[str
         hierarchy = await task_services.get_vision_task_hierarchy(session, vision_id=vision_id)
     except LookupError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+    task_ids = _collect_task_tree_ids(list(hierarchy.root_tasks))
+    notes_count_by_task, timelogs_count_by_task = await _load_task_relation_counts(
+        session,
+        task_ids,
+    )
     return {
         "vision_id": str(hierarchy.vision_id),
-        "root_tasks": [_task_tree_payload(task) for task in hierarchy.root_tasks],
+        "root_tasks": [
+            _task_tree_payload(
+                task,
+                notes_count_by_task=notes_count_by_task,
+                timelogs_count_by_task=timelogs_count_by_task,
+            )
+            for task in hierarchy.root_tasks
+        ],
     }
 
 
@@ -220,7 +321,16 @@ async def get_task(task_id: UUID, session: SessionDep) -> dict[str, object]:
     task = await task_services.get_task(session, task_id=task_id)
     if task is None:
         raise HTTPException(status_code=404, detail=f"Task {task_id} was not found")
-    return to_jsonable_dict(task)
+    notes_count_by_task, timelogs_count_by_task = await _load_task_relation_counts(
+        session,
+        [task.id],
+    )
+    return _task_list_payload(
+        task,
+        fields="full",
+        notes_count_by_task=notes_count_by_task,
+        timelogs_count_by_task=timelogs_count_by_task,
+    )
 
 
 @router.put("/{task_id}")
@@ -303,7 +413,16 @@ async def get_task_with_subtasks(task_id: UUID, session: SessionDep) -> dict[str
     task = await task_services.get_task_with_subtasks(session, task_id=task_id)
     if task is None:
         raise HTTPException(status_code=404, detail=f"Task {task_id} was not found")
-    return _task_tree_payload(task)
+    task_ids = _collect_task_tree_ids([task])
+    notes_count_by_task, timelogs_count_by_task = await _load_task_relation_counts(
+        session,
+        task_ids,
+    )
+    return _task_tree_payload(
+        task,
+        notes_count_by_task=notes_count_by_task,
+        timelogs_count_by_task=timelogs_count_by_task,
+    )
 
 
 @router.get("/{task_id}/stats")

--- a/tests/test_note_services.py
+++ b/tests/test_note_services.py
@@ -17,6 +17,8 @@ from sqlalchemy.ext.asyncio import (
 )
 
 from lifeos_cli.db.base import Base
+from lifeos_cli.db.models.task import Task
+from lifeos_cli.db.models.vision import Vision
 from lifeos_cli.db.services import notes, people, tags
 
 
@@ -82,6 +84,73 @@ def test_list_notes_by_tag_does_not_emit_cartesian_product_warning() -> None:
                     and "cartesian product" in str(item.message)
                     for item in caught
                 )
+        finally:
+            await engine.dispose()
+
+    asyncio.run(run())
+
+
+def test_list_notes_by_task_does_not_emit_cartesian_product_warning() -> None:
+    async def run() -> None:
+        engine, session_factory = await _create_sqlite_session_factory()
+        try:
+            async with session_factory() as session:
+                vision = Vision(name="Planning")
+                session.add(vision)
+                await session.flush()
+                task = Task(vision_id=vision.id, content="Review notes")
+                session.add(task)
+                await session.flush()
+                created_note = await notes.create_note(
+                    session,
+                    content="Task note",
+                    task_ids=[task.id],
+                )
+
+                with warnings.catch_warnings(record=True) as caught:
+                    warnings.simplefilter("always", SAWarning)
+                    rows = await notes.list_notes(session, task_id=task.id)
+
+                assert [row.id for row in rows] == [created_note.id]
+                assert not any(
+                    issubclass(item.category, SAWarning)
+                    and "cartesian product" in str(item.message)
+                    for item in caught
+                )
+        finally:
+            await engine.dispose()
+
+    asyncio.run(run())
+
+
+def test_web_task_relation_counts_include_related_notes() -> None:
+    pytest.importorskip("fastapi")
+
+    from lifeos_web.routers.tasks import _load_task_relation_counts
+
+    async def run() -> None:
+        engine, session_factory = await _create_sqlite_session_factory()
+        try:
+            async with session_factory() as session:
+                vision = Vision(name="Planning")
+                session.add(vision)
+                await session.flush()
+                task = Task(vision_id=vision.id, content="Review notes")
+                session.add(task)
+                await session.flush()
+                await notes.create_note(
+                    session,
+                    content="Task note",
+                    task_ids=[task.id],
+                )
+
+                note_counts, timelog_counts = await _load_task_relation_counts(
+                    session,
+                    [task.id],
+                )
+
+                assert note_counts == {task.id: 1}
+                assert timelog_counts == {}
         finally:
             await engine.dispose()
 

--- a/tests/test_web_cli.py
+++ b/tests/test_web_cli.py
@@ -1415,6 +1415,75 @@ def test_web_timelog_payload_serializes_naive_storage_datetimes_as_utc() -> None
     assert payload["created_at"] == "2026-06-13T21:09:24Z"
 
 
+def test_web_person_note_activity_payload_avoids_duplicate_note_content(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("fastapi")
+
+    from lifeos_web.routers import persons
+
+    note_id = UUID("11111111-1111-1111-1111-111111111111")
+    person_id = UUID("22222222-2222-2222-2222-222222222222")
+    timestamp = datetime(2026, 6, 1, 13, 0, tzinfo=timezone.utc)
+    note = SimpleNamespace(
+        id=note_id,
+        content="Remember the meeting notes",
+        updated_at=timestamp,
+    )
+
+    async def fake_load_person_entity_ids(
+        _session: object,
+        *,
+        person_id: UUID,
+    ) -> dict[str, list[UUID]]:
+        return {}
+
+    async def fake_load_person_note_ids(
+        _session: object,
+        *,
+        person_id: UUID,
+    ) -> list[UUID]:
+        return [note_id]
+
+    class FakeResult:
+        def scalars(self) -> list[object]:
+            return [note]
+
+    class FakeSession:
+        async def execute(self, _statement: object) -> FakeResult:
+            return FakeResult()
+
+    monkeypatch.setattr(
+        persons,
+        "_load_person_entity_ids",
+        fake_load_person_entity_ids,
+    )
+    monkeypatch.setattr(
+        persons,
+        "_load_person_note_ids",
+        fake_load_person_note_ids,
+    )
+
+    activities = asyncio.run(
+        persons._load_activity_items(
+            cast(AsyncSession, FakeSession()),
+            person_id=person_id,
+            activity_filter="note",
+        )
+    )
+
+    assert activities == [
+        {
+            "id": str(note_id),
+            "type": "note",
+            "title": "Remember the meeting notes",
+            "description": None,
+            "date": timestamp.isoformat(),
+            "status": None,
+        }
+    ]
+
+
 def test_web_task_update_null_planning_cycle_translates_to_clear_flag(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_web_cli.py
+++ b/tests/test_web_cli.py
@@ -535,6 +535,30 @@ def test_web_general_payloads_exclude_unconsumed_audit_fields() -> None:
     assert "is_soft_deleted" not in person_payload
 
 
+def test_web_person_timelog_activity_payload_exposes_timeline_fields() -> None:
+    pytest.importorskip("fastapi")
+    from lifeos_web.routers.persons import _activity_payload
+
+    timestamp = datetime(2026, 7, 2, 9, 0, tzinfo=timezone.utc)
+    payload = _activity_payload(
+        entity_id=UUID("11111111-1111-1111-1111-111111111111"),
+        activity_type="timelog",
+        title="Deep work",
+        description=None,
+        activity_date=timestamp,
+        extra={
+            "start_time": "2026-07-02T09:00:00+00:00",
+            "end_time": "2026-07-02T09:30:00+00:00",
+            "area_id": "22222222-2222-2222-2222-222222222222",
+        },
+    )
+
+    assert payload["status"] is None
+    assert payload["start_time"] == "2026-07-02T09:00:00+00:00"
+    assert payload["end_time"] == "2026-07-02T09:30:00+00:00"
+    assert payload["area_id"] == "22222222-2222-2222-2222-222222222222"
+
+
 def test_web_habit_action_payload_uses_slim_habit_summary(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_web_cli.py
+++ b/tests/test_web_cli.py
@@ -357,14 +357,24 @@ def test_web_task_hierarchy_payload_excludes_deleted_at() -> None:
         task_node(
             "11111111-1111-1111-1111-111111111111",
             subtasks=(task_node("33333333-3333-3333-3333-333333333333"),),
-        )
+        ),
+        notes_count_by_task={
+            UUID("11111111-1111-1111-1111-111111111111"): 2,
+        },
+        timelogs_count_by_task={
+            UUID("33333333-3333-3333-3333-333333333333"): 1,
+        },
     )
 
     assert payload["created_at"] == "2026-06-01T13:00:00+00:00"
     assert payload["updated_at"] == "2026-06-01T13:00:00+00:00"
+    assert payload["notes_count"] == 2
+    assert payload["timelogs_count"] == 0
     assert "actual_effort" not in payload
     assert "deleted_at" not in payload
     subtask_payload = cast(list[dict[str, object]], payload["subtasks"])[0]
+    assert subtask_payload["notes_count"] == 0
+    assert subtask_payload["timelogs_count"] == 1
     assert "deleted_at" not in subtask_payload
 
 
@@ -403,8 +413,22 @@ def test_web_task_list_basic_payload_excludes_full_task_fields(
     async def fake_count_tasks(_session: object, **_kwargs: object) -> int:
         return 1
 
+    async def fake_load_task_relation_counts(
+        _session: object,
+        _task_ids: list[UUID],
+    ) -> tuple[dict[UUID, int], dict[UUID, int]]:
+        return (
+            {UUID("11111111-1111-1111-1111-111111111111"): 4},
+            {UUID("11111111-1111-1111-1111-111111111111"): 5},
+        )
+
     monkeypatch.setattr(tasks.task_services, "list_tasks", fake_list_tasks)
     monkeypatch.setattr(tasks.task_services, "count_tasks", fake_count_tasks)
+    monkeypatch.setattr(
+        tasks,
+        "_load_task_relation_counts",
+        fake_load_task_relation_counts,
+    )
 
     response = asyncio.run(
         tasks.list_tasks(
@@ -426,6 +450,8 @@ def test_web_task_list_basic_payload_excludes_full_task_fields(
         "planning_cycle_days": 1,
         "planning_cycle_start_date": "2026-06-30",
         "people": [{"id": "33333333-3333-3333-3333-333333333333", "name": "A"}],
+        "notes_count": 4,
+        "timelogs_count": 5,
     }
     assert "created_at" not in payload
     assert "updated_at" not in payload
@@ -781,8 +807,19 @@ def test_web_tasks_list_uses_count_for_pagination_and_query(
         captured["count_kwargs"] = kwargs
         return 123
 
+    async def fake_load_task_relation_counts(
+        _session: object,
+        _task_ids: list[UUID],
+    ) -> tuple[dict[UUID, int], dict[UUID, int]]:
+        return ({}, {})
+
     monkeypatch.setattr(task_router.task_services, "list_tasks", fake_list_tasks)
     monkeypatch.setattr(task_router.task_services, "count_tasks", fake_count_tasks)
+    monkeypatch.setattr(
+        task_router,
+        "_load_task_relation_counts",
+        fake_load_task_relation_counts,
+    )
 
     response = asyncio.run(
         task_router.list_tasks(

--- a/web/src/components/AreaBadge.tsx
+++ b/web/src/components/AreaBadge.tsx
@@ -15,6 +15,7 @@ interface AreaBadgeProps {
   /** Backward-compat: when true, show unknown label text; prefer `showLabel` */
   showUnknownText?: boolean;
   className?: string;
+  labelClassName?: string;
   /** Control dot size: sm (2), md (3), lg (4) */
   size?: "sm" | "md" | "lg";
   ariaLabel?: string;
@@ -28,6 +29,7 @@ const AreaBadgeComponent: React.FC<AreaBadgeProps> = ({
   showLabel,
   showUnknownText = true,
   className,
+  labelClassName = "text-base",
   size = "md",
   ariaLabel,
 }) => {
@@ -65,7 +67,9 @@ const AreaBadgeComponent: React.FC<AreaBadgeProps> = ({
         aria-label={ariaLabel || resolvedName || "area"}
       />
       {shouldShowLabel ? (
-        <span className="text-base text-base-content truncate max-w-[120px]">
+        <span
+          className={`${labelClassName} text-base-content truncate max-w-[120px]`}
+        >
           {resolvedName}
         </span>
       ) : null}
@@ -83,6 +87,7 @@ const AreaBadge = React.memo(
     prev.showLabel === next.showLabel &&
     prev.showUnknownText === next.showUnknownText &&
     prev.className === next.className &&
+    prev.labelClassName === next.labelClassName &&
     prev.size === next.size &&
     prev.ariaLabel === next.ariaLabel,
 );

--- a/web/src/components/DraggableTaskList.tsx
+++ b/web/src/components/DraggableTaskList.tsx
@@ -7,11 +7,11 @@ import React, {
 } from "react";
 import { useTranslation } from "react-i18next";
 import ActionButton, {
+  ActionButtonGroup,
   EditButton,
   DeleteButton,
   ExpandButton,
 } from "./ActionButton";
-import ResponsiveActionButtonGroup from "./ResponsiveActionButtonGroup";
 import {
   DndContext,
   closestCenter,
@@ -98,6 +98,27 @@ interface TaskDragInfo {
   parentId: UUID | null;
   level: number;
 }
+
+const readTaskRelationshipCount = (
+  task: TaskWithSubtasks,
+  keys: string[],
+): number => {
+  const taskRecord = task as unknown as Record<string, unknown>;
+  let count = 0;
+  for (const key of keys) {
+    const value = taskRecord[key];
+    if (typeof value === "number" && Number.isFinite(value)) {
+      count = Math.max(count, value);
+    }
+    if (typeof value === "string" && value.trim() !== "") {
+      const parsed = Number(value);
+      if (Number.isFinite(parsed)) {
+        count = Math.max(count, parsed);
+      }
+    }
+  }
+  return count;
+};
 
 // Task hierarchy utilities
 class TaskHierarchyManager {
@@ -212,11 +233,11 @@ const SortableTaskItem: React.FC<SortableTaskItemProps> = ({
     transform: CSS.Transform.toString(transform),
     transition,
     opacity: isDragging ? 0.5 : 1,
-    // 强制宽度约束，防止被 transform 覆盖
+    // Keep width constraints stable while dnd transforms are active.
     maxWidth: "100%",
     width: "100%",
     minWidth: "0",
-    // 确保 flex 子元素不会超出容器
+    // Prevent flex children from overflowing the row container.
     flexShrink: 1,
     overflow: "hidden",
   };
@@ -237,9 +258,18 @@ const SortableTaskItem: React.FC<SortableTaskItemProps> = ({
     ? Math.max(0, Math.min(PRIORITY.length - 1, Number(task.priority ?? 0)))
     : 0;
   const priorityInfo = PRIORITY[priorityIndex] ?? PRIORITY[0];
-  const hasNotes = (task.notes_count ?? 0) > 0;
+  const hasNotes =
+    readTaskRelationshipCount(task, [
+      "notes_count",
+      "note_count",
+      "linked_notes_count",
+    ]) > 0;
   const hasTimeLogs =
-    (task.timelogs_count ?? (task.actual_effort_self ?? 0)) > 0;
+    readTaskRelationshipCount(task, [
+      "timelogs_count",
+      "timelog_count",
+      "actual_effort_self",
+    ]) > 0;
   const subduedClass = "opacity-40 hover:opacity-60 transition-opacity";
   const noteButtonClass = hasNotes ? undefined : subduedClass;
   const timeLogButtonClass = hasTimeLogs ? undefined : subduedClass;
@@ -458,7 +488,7 @@ const SortableTaskItem: React.FC<SortableTaskItemProps> = ({
                     </span>
                   </h4>
 
-                  {/* Task Metadata - 响应式布局，支持换行 */}
+                  {/* Task metadata wraps responsively. */}
                   <div className="flex flex-wrap items-center gap-2 sm:gap-3 text-sm text-base-content/50 mt-1 sm:mt-0 sm:ml-3">
                     <span
                       className="flex-shrink-0 inline-flex items-center gap-1"
@@ -533,26 +563,18 @@ const SortableTaskItem: React.FC<SortableTaskItemProps> = ({
                   />
                 </div>
 
-                <ResponsiveActionButtonGroup
+                <ActionButtonGroup
                   gap="sm"
                   align="end"
-                  mobileVisibleCount={1}
-                  mediumVisibleCount={2}
-                  largeVisibleCount={6}
-                  moreButtonText={t("draggableTaskList.actions.more")}
-                  moreButtonIcon={<span>⋯</span>}
                   className="gap-0.1"
                 >
-                  {/* 移动端只显示：编辑 */}
                   <EditButton onClick={() => onEditTask(task)} size="sm" />
-                  {/* 桌面端显示：添加子任务 */}
                   <ActionButton
                     label=""
                     iconName="plus"
                     color="primary"
                     onClick={() => onAddSubtask(task.id)}
                   />
-                  {/* 其他功能按钮 - 都收起到抽屉中 */}
                   <ActionButton
                     label=""
                     iconName="document-plus"
@@ -587,7 +609,7 @@ const SortableTaskItem: React.FC<SortableTaskItemProps> = ({
                       size="sm"
                     />
                   )}
-                </ResponsiveActionButtonGroup>
+                </ActionButtonGroup>
               </div>
             </div>
 

--- a/web/src/components/DraggableTaskList.tsx
+++ b/web/src/components/DraggableTaskList.tsx
@@ -58,6 +58,7 @@ interface DraggableTaskListProps {
   onViewTimeRecords: (task: TaskWithSubtasks) => void;
   onCreateNote: (task: TaskWithSubtasks) => void;
   onViewNotes: (task: TaskWithSubtasks) => void;
+  onCreateTimeRecord: (task: TaskWithSubtasks) => void;
   expandedTasks?: Set<UUID>;
   onToggleExpansion?: (taskId: UUID) => void;
   onTasksReorder?: (reorderedTasks: TaskWithSubtasks[]) => void | Promise<void>;
@@ -82,6 +83,7 @@ interface SortableTaskItemProps {
   onViewTimeRecords: (task: TaskWithSubtasks) => void;
   onCreateNote: (task: TaskWithSubtasks) => void;
   onViewNotes: (task: TaskWithSubtasks) => void;
+  onCreateTimeRecord: (task: TaskWithSubtasks) => void;
   onToggleExpansion: (taskId: UUID) => void;
   habitTaskAssociations?: Record<UUID, Habit[]>;
   // Vision information for planning page
@@ -189,6 +191,7 @@ const SortableTaskItem: React.FC<SortableTaskItemProps> = ({
   onViewTimeRecords,
   onCreateNote,
   onViewNotes,
+  onCreateTimeRecord,
   onToggleExpansion,
   habitTaskAssociations,
   visions,
@@ -235,7 +238,8 @@ const SortableTaskItem: React.FC<SortableTaskItemProps> = ({
     : 0;
   const priorityInfo = PRIORITY[priorityIndex] ?? PRIORITY[0];
   const hasNotes = (task.notes_count ?? 0) > 0;
-  const hasTimeLogs = (task.actual_effort_self ?? 0) > 0;
+  const hasTimeLogs =
+    (task.timelogs_count ?? (task.actual_effort_self ?? 0)) > 0;
   const subduedClass = "opacity-40 hover:opacity-60 transition-opacity";
   const noteButtonClass = hasNotes ? undefined : subduedClass;
   const timeLogButtonClass = hasTimeLogs ? undefined : subduedClass;
@@ -562,6 +566,12 @@ const SortableTaskItem: React.FC<SortableTaskItemProps> = ({
                     className={noteButtonClass}
                     onClick={() => onViewNotes(task)}
                   />
+                  <ActionButton
+                    label=""
+                    iconName="bolt"
+                    color="primary"
+                    onClick={() => onCreateTimeRecord(task)}
+                  />
                   {/* View time records button - only show in vision page */}
                   <ActionButton
                     label=""
@@ -662,6 +672,7 @@ const DraggableTaskList: React.FC<DraggableTaskListProps> = ({
   onViewTimeRecords,
   onCreateNote,
   onViewNotes,
+  onCreateTimeRecord,
   expandedTasks: externalExpandedTasks,
   onToggleExpansion: externalOnToggleExpansion,
   onTasksReorder,
@@ -847,6 +858,7 @@ const DraggableTaskList: React.FC<DraggableTaskListProps> = ({
             onViewTimeRecords={onViewTimeRecords}
             onCreateNote={onCreateNote}
             onViewNotes={onViewNotes}
+            onCreateTimeRecord={onCreateTimeRecord}
             onToggleExpansion={setExpandedTasks}
             habitTaskAssociations={habitTaskAssociations}
             visions={visions}
@@ -884,6 +896,7 @@ const DraggableTaskList: React.FC<DraggableTaskListProps> = ({
       onViewTimeRecords,
       onCreateNote,
       onViewNotes,
+      onCreateTimeRecord,
       habitTaskAssociations,
       isPlanningPage,
       showVisionInfo,

--- a/web/src/components/InlineQuickTimeEntry.tsx
+++ b/web/src/components/InlineQuickTimeEntry.tsx
@@ -120,6 +120,7 @@ interface InlineQuickTimeEntryProps {
   idPrefix?: string;
   sessionId: string;
   timezone?: string;
+  blankInitialEndTime?: boolean;
 }
 
 export default function InlineQuickTimeEntry({
@@ -135,6 +136,7 @@ export default function InlineQuickTimeEntry({
   idPrefix = "quick-time",
   sessionId,
   timezone,
+  blankInitialEndTime = false,
 }: InlineQuickTimeEntryProps) {
   const { t } = useTranslation();
   const [formData, setFormData] = useState<TimelogCreate>({
@@ -432,10 +434,11 @@ export default function InlineQuickTimeEntry({
         : initialEndTime;
 
     const startISO = hhmmToISO(selectedDate, effectiveStartTime);
-    let endISO = hhmmToISO(selectedDate, normalizedEnd);
+    const shouldBlankEndTime = blankInitialEndTime && !initialEndTime;
+    let endISO = shouldBlankEndTime ? "" : hhmmToISO(selectedDate, normalizedEnd);
 
     // Cross-day: if end before start, roll to next day
-    if (new Date(endISO) < new Date(startISO)) {
+    if (endISO && new Date(endISO) < new Date(startISO)) {
       const tmp = new Date(endISO);
       tmp.setDate(tmp.getDate() + 1);
       endISO = tmp.toISOString();
@@ -450,6 +453,7 @@ export default function InlineQuickTimeEntry({
     selectedDate,
     initialStartTime,
     initialEndTime,
+    blankInitialEndTime,
     shouldInitializeFromProps,
     setFormDataWithSync,
     hhmmToISO,

--- a/web/src/components/InlineQuickTimeEntry.tsx
+++ b/web/src/components/InlineQuickTimeEntry.tsx
@@ -354,6 +354,7 @@ export default function InlineQuickTimeEntry({
   // removed duplicate state declarations for areas
 
   // Refs for keyboard navigation
+  const formRef = useRef<HTMLFormElement | null>(null);
   const titleRef = useRef<HTMLInputElement>(null);
   const areaRef = useRef<HTMLInputElement>(null);
 
@@ -834,7 +835,7 @@ export default function InlineQuickTimeEntry({
         </div>
       </div>
 
-      <form onSubmit={handleSubmit} className="space-y-4">
+      <form ref={formRef} onSubmit={handleSubmit} className="space-y-4">
         {/* Quick input row */}
         <div className="flex flex-col lg:flex-row items-start lg:items-center gap-3">
           {/* Start Time */}
@@ -974,7 +975,7 @@ export default function InlineQuickTimeEntry({
           <FormActions
             loading={loading}
             onCancel={sessionAwareCancel}
-            onSubmit={() => document.querySelector("form")?.requestSubmit()}
+            onSubmit={() => formRef.current?.requestSubmit()}
             disabled={
               !formData.title.trim() ||
               formData.area_id === "" ||

--- a/web/src/components/PersonTimelineModal.tsx
+++ b/web/src/components/PersonTimelineModal.tsx
@@ -6,12 +6,21 @@ import LoadingSpinner from "./LoadingSpinner";
 import EmptyState from "./EmptyState";
 import ActionButton from "./ActionButton";
 import { Icon } from "./icons";
-import { formatDateTime } from "@/utils/datetime";
+import {
+  formatDate,
+  formatDateTime,
+  formatDurationFromTimes,
+  formatTime,
+  resolvePreferredTimezone,
+} from "@/utils/datetime";
 import type { PersonSummary } from "@/services/api";
 import type {
   PersonActivityItem,
   PersonActivityType,
 } from "@/services/api/persons";
+import { useAreas } from "@/hooks/queries/useAreas";
+import { usePreferenceWithBootstrap } from "@/hooks/queries/usePreferenceWithBootstrap";
+import AreaBadge from "./AreaBadge";
 
 interface PersonTimelineModalProps {
   person: PersonSummary | null;
@@ -52,35 +61,41 @@ const PersonTimelineModal: React.FC<PersonTimelineModalProps> = ({
 }) => {
   const { t } = useTranslation();
   const parentRef = useRef<HTMLDivElement>(null);
+  const timezonePreference = usePreferenceWithBootstrap<string>({
+    key: "system.timezone",
+    defaultValue: resolvePreferredTimezone(),
+    module: "system",
+    validator: (value) => typeof value === "string" && value.length > 0,
+  });
+  const activeTimezone = resolvePreferredTimezone(timezonePreference.value);
+  const { areaMap } = useAreas();
 
-  // 虚拟化配置 - 使用动态高度测量
+  // Virtualize the timeline with dynamic row-height measurement.
   const virtualizer = useVirtualizer({
     count: activities.length,
     getScrollElement: () => parentRef.current,
     estimateSize: (index: number) => {
-      // 根据内容类型估算高度
+      // Estimate height from content shape.
       const activity = activities[index];
       if (!activity) return 60;
 
-      // 基础高度：时间 + 模块 + 标题 + padding
-      let baseHeight = 100; // 增加基础高度以适应新的间距
+      // Base height: time, module, title, and padding.
+      let baseHeight = 100;
 
-      // 如果有描述，增加描述高度（按行数估算）
+      // Add room for descriptions by estimating wrapped line count.
       if (activity.description) {
         const descriptionLength = activity.description.length;
-        // 更精确的行数估算，考虑中文字符和容器宽度
-        const containerWidth = 1000; // 估算容器宽度
-        const charWidth = 14; // 估算字符宽度（稍微增加）
+        const containerWidth = 1000;
+        const charWidth = 14;
         const charsPerLine = Math.floor(containerWidth / charWidth);
         const estimatedLines = Math.ceil(descriptionLength / charsPerLine);
-        baseHeight += estimatedLines * 22 + 20; // 每行22px + 间距20px
+        baseHeight += estimatedLines * 22 + 20;
       }
 
-      return Math.max(baseHeight, 100); // 最小高度100px
+      return Math.max(baseHeight, 100);
     },
-    overscan: 5, // 预渲染额外项目
+    overscan: 5,
     measureElement: (element: Element | null) => {
-      // 使用实际测量的高度
       return element?.getBoundingClientRect().height ?? 60;
     },
   });
@@ -196,9 +211,40 @@ const PersonTimelineModal: React.FC<PersonTimelineModalProps> = ({
     );
   };
 
+  const renderTimelogDetails = (activity: PersonActivityItem) => {
+    const startTime = activity.start_time ?? activity.date;
+    const endTime = activity.end_time ?? null;
+    const timeRange = `${formatTime(startTime, activeTimezone)}${
+      endTime ? `-${formatTime(endTime, activeTimezone)}` : ""
+    }`;
+    const duration = formatDurationFromTimes(startTime, endTime);
+    const areaName =
+      (activity.area_id ? areaMap.get(activity.area_id)?.name : null) ??
+      t("taskTimelogs.unknownArea");
+    return (
+      <div className="grid grid-cols-[minmax(100px,0.8fr)_minmax(70px,0.6fr)_minmax(120px,0.8fr)_minmax(180px,2fr)] gap-3 text-sm leading-relaxed">
+        <div className="text-base-content/80">{timeRange}</div>
+        <div className="text-base-content/80">{duration}</div>
+        <div className="min-w-0">
+          <AreaBadge
+            areaId={activity.area_id ?? undefined}
+            areaMap={areaMap}
+            name={areaName}
+            showLabel
+            size="sm"
+            labelClassName="text-sm"
+            ariaLabel={areaName}
+          />
+        </div>
+        <div className="min-w-0 truncate text-base-content/90" title={activity.title}>
+          {activity.title}
+        </div>
+      </div>
+    );
+  };
+
   if (!isOpen || !person) return null;
 
-  // 构建标题内容
   const titleContent = (
     <>
       {t("persons.timeline.title", {
@@ -263,6 +309,7 @@ const PersonTimelineModal: React.FC<PersonTimelineModalProps> = ({
                       const activity = activities[virtualItem.index];
                       if (!activity) return null;
                       const typeMeta = getActivityTypeMeta(activity.type);
+                      const isTimelog = activity.type === "timelog";
                       return (
                         <div
                           key={`${activity.type}-${activity.id}`}
@@ -281,7 +328,12 @@ const PersonTimelineModal: React.FC<PersonTimelineModalProps> = ({
                           <div className="flex items-start space-x-4">
                             {/* Time */}
                             <div className="flex-shrink-0 text-sm font-mono min-w-[110px] text-base-content/80">
-                              {formatDateTime(activity.date)}
+                              {isTimelog
+                                ? formatDate(
+                                    activity.start_time ?? activity.date,
+                                    activeTimezone,
+                                  )
+                                : formatDateTime(activity.date, activeTimezone)}
                             </div>
 
                             {/* Module */}
@@ -297,7 +349,7 @@ const PersonTimelineModal: React.FC<PersonTimelineModalProps> = ({
                                 />
                                 {typeMeta.label}
                               </span>
-                              {activity.status && (
+                              {activity.status && !isTimelog && (
                                 <span
                                   className={`inline-flex items-center px-2 py-1 text-sm rounded ${getStatusColor(activity.status)}`}
                                 >
@@ -308,14 +360,18 @@ const PersonTimelineModal: React.FC<PersonTimelineModalProps> = ({
 
                             {/* Title */}
                             <div className="flex-1 min-w-0">
-                              <h4 className="text-base font-medium break-words leading-relaxed">
-                                {activity.title}
-                              </h4>
+                              {isTimelog ? (
+                                renderTimelogDetails(activity)
+                              ) : (
+                                <h4 className="text-base font-medium break-words leading-relaxed">
+                                  {activity.title}
+                                </h4>
+                              )}
                             </div>
                           </div>
 
                           {/* Description line (if exists) - aligned to record start */}
-                          {activity.description && (
+                          {activity.description && !isTimelog && (
                             <div className="flex mt-2">
                               <div className="flex-shrink-0 min-w-[110px]"></div>
                               <div className="flex-shrink-0 min-w-[140px]"></div>

--- a/web/src/components/PersonTimelineModal.tsx
+++ b/web/src/components/PersonTimelineModal.tsx
@@ -295,7 +295,10 @@ const PersonTimelineModal: React.FC<PersonTimelineModalProps> = ({
           </div>
           {activities.length > 0 ? (
             <>
-              <div ref={parentRef} className="h-[48rem] overflow-auto">
+              <div
+                ref={parentRef}
+                className="min-h-[18rem] max-h-[calc(100dvh-12rem)] overflow-auto md:max-h-[42rem]"
+              >
                 <div
                   style={{
                     height: `${virtualizer.getTotalSize()}px`,
@@ -310,6 +313,13 @@ const PersonTimelineModal: React.FC<PersonTimelineModalProps> = ({
                       if (!activity) return null;
                       const typeMeta = getActivityTypeMeta(activity.type);
                       const isTimelog = activity.type === "timelog";
+                      const shouldRenderDescription =
+                        Boolean(activity.description) &&
+                        !isTimelog &&
+                        !(
+                          activity.type === "note" &&
+                          activity.description?.trim() === activity.title.trim()
+                        );
                       return (
                         <div
                           key={`${activity.type}-${activity.id}`}
@@ -371,7 +381,7 @@ const PersonTimelineModal: React.FC<PersonTimelineModalProps> = ({
                           </div>
 
                           {/* Description line (if exists) - aligned to record start */}
-                          {activity.description && !isTimelog && (
+                          {shouldRenderDescription && (
                             <div className="flex mt-2">
                               <div className="flex-shrink-0 min-w-[110px]"></div>
                               <div className="flex-shrink-0 min-w-[140px]"></div>

--- a/web/src/components/TaskManagementWrapper.tsx
+++ b/web/src/components/TaskManagementWrapper.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import TaskEditModal from "./TaskEditModal";
 import TaskTimelogsModal from "./TaskTimelogsModal";
+import TaskTimelogQuickAddModal from "./TaskTimelogQuickAddModal";
 import TaskNotesModal from "./TaskNotesModal";
 import CreateNoteModal from "./CreateNoteModal";
 import ConfirmDialog from "./ConfirmDialog";
@@ -172,6 +173,15 @@ const TaskManagementWrapper: React.FC<TaskManagementWrapperProps> = ({
           lockTaskSelection={createNoteDefaults?.lockTaskSelection ?? false}
           lockPersonSelection={createNoteDefaults?.lockPersonSelection ?? false}
           onNoteCreated={taskManagement.actions.handleNoteCreated}
+        />
+      )}
+
+      {taskManagement.isCreateTimelogModalOpen && (
+        <TaskTimelogQuickAddModal
+          isOpen={taskManagement.isCreateTimelogModalOpen}
+          onClose={taskManagement.actions.closeCreateTimelogModal}
+          task={taskManagement.creatingTimelogForTask}
+          onTimelogCreated={taskManagement.actions.handleTimelogCreated}
         />
       )}
     </>

--- a/web/src/components/TaskTimelogQuickAddModal.tsx
+++ b/web/src/components/TaskTimelogQuickAddModal.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
+import ModalBase from "@/layouts/ModalBase";
+import InlineQuickTimeEntry from "./InlineQuickTimeEntry";
+import type {
+  TaskWithSubtasks,
+  TimelogWithEnergyResponse,
+} from "@/services/api";
+import { tasksApi } from "@/services/api/tasks";
+import { tasksKeys } from "@/services/api/queryKeys";
+import { usePreferenceWithBootstrap } from "@/hooks/queries/usePreferenceWithBootstrap";
+import { formatTime, resolvePreferredTimezone } from "@/utils/datetime";
+import { createModalSessionId } from "@/utils/session";
+
+interface TaskTimelogQuickAddModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  task: TaskWithSubtasks | null;
+  onTimelogCreated: (result: TimelogWithEnergyResponse) => void;
+}
+
+export default function TaskTimelogQuickAddModal({
+  isOpen,
+  onClose,
+  task,
+  onTimelogCreated,
+}: TaskTimelogQuickAddModalProps) {
+  const { t } = useTranslation();
+  const timezonePreference = usePreferenceWithBootstrap<string>({
+    key: "system.timezone",
+    defaultValue: resolvePreferredTimezone(),
+    module: "system",
+    validator: (value) => typeof value === "string" && value.length > 0,
+  });
+  const activeTimezone = resolvePreferredTimezone(timezonePreference.value);
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setLocalError(null);
+    }
+  }, [isOpen]);
+
+  const latestTimelogQuery = useQuery({
+    queryKey: task?.id
+      ? [...tasksKeys.timelogs(task.id), "latest"]
+      : [...tasksKeys.all, "timelogs", "latest", "idle"],
+    queryFn: async () => {
+      if (!task?.id) return null;
+      const response = await tasksApi.getTimelogs(task.id, 1, 1);
+      return response.items[0] ?? null;
+    },
+    enabled: isOpen && Boolean(task?.id),
+    staleTime: 30 * 1000,
+  });
+
+  const sessionId = useMemo(() => createModalSessionId(), []);
+
+  const latestEndTime = latestTimelogQuery.data?.end_time ?? null;
+  const selectedDate = useMemo(
+    () => (latestEndTime ? new Date(latestEndTime) : new Date()),
+    [latestEndTime],
+  );
+  const defaultTime = latestEndTime
+    ? formatTime(latestEndTime, activeTimezone)
+    : "";
+
+  if (!task) {
+    return null;
+  }
+
+  return (
+    <ModalBase
+      isOpen={isOpen}
+      onClose={onClose}
+      header={t("timeLog.modal.addTimeLog")}
+      size="2xl"
+      loading={latestTimelogQuery.isLoading}
+      error={latestTimelogQuery.error?.message ?? localError ?? undefined}
+      onErrorDismiss={() => {
+        if (latestTimelogQuery.error) {
+          void latestTimelogQuery.refetch();
+          return;
+        }
+        setLocalError(null);
+      }}
+      showLoadingSpinner
+      loadingSpinnerSize="md"
+      showCloseButton
+      errorDisplayMode="inline"
+    >
+      {!latestTimelogQuery.isLoading && !latestTimelogQuery.error && (
+        <InlineQuickTimeEntry
+          selectedDate={selectedDate}
+          startTime={defaultTime}
+          endTime={defaultTime}
+          preselectedTaskId={task.id}
+          allowedTaskIds={[task.id]}
+          preloadedTasks={[task]}
+          idPrefix={`task-${task.id}-timelog`}
+          sessionId={sessionId}
+          timezone={activeTimezone}
+          onEntryCreated={(result) => {
+            setLocalError(null);
+            onTimelogCreated(result);
+          }}
+          onError={setLocalError}
+          onCancel={() => onClose()}
+        />
+      )}
+    </ModalBase>
+  );
+}

--- a/web/src/components/TaskTimelogQuickAddModal.tsx
+++ b/web/src/components/TaskTimelogQuickAddModal.tsx
@@ -94,7 +94,8 @@ export default function TaskTimelogQuickAddModal({
         <InlineQuickTimeEntry
           selectedDate={selectedDate}
           startTime={defaultTime}
-          endTime={defaultTime}
+          endTime=""
+          blankInitialEndTime
           preselectedTaskId={task.id}
           allowedTaskIds={[task.id]}
           preloadedTasks={[task]}

--- a/web/src/components/TaskTimelogsModal.tsx
+++ b/web/src/components/TaskTimelogsModal.tsx
@@ -32,7 +32,7 @@ const TaskTimelogsModal: React.FC<TaskTimelogsModalProps> = ({
 }) => {
   const { t } = useTranslation();
   const [page, setPage] = useState(1);
-  const pageSize = 50;
+  const pageSize = 15;
   const timezonePreference = usePreferenceWithBootstrap<string>({
     key: "system.timezone",
     defaultValue: resolvePreferredTimezone(),
@@ -123,190 +123,198 @@ const TaskTimelogsModal: React.FC<TaskTimelogsModalProps> = ({
       loadingSpinnerSize="md"
       showCloseButton={true}
       errorDisplayMode="inline"
+      bodyOverflow="hidden"
     >
-      {!isLoading && !error && (
-        <div className="px-2 pt-4 pb-2 flex items-center justify-between">
-          <div className="text-base">
-            {task && (
-              <span>
-                {t("taskTimelogs.taskLabel")} {task.content}
-              </span>
-            )}
-          </div>
-          <div className="flex items-center gap-3">
-            <div className="text-sm text-base-content/40">
-              {t("taskTimelogs.totalTime")} {calculateTotalTime()}
+      <div className="flex max-h-[calc(100dvh-8rem)] min-h-0 flex-col overflow-hidden md:max-h-[42rem]">
+        {!isLoading && !error && (
+          <div className="flex flex-shrink-0 flex-wrap items-center justify-between gap-2 px-2 pt-4 pb-2">
+            <div className="min-w-0 text-base">
+              {task && (
+                <span className="line-clamp-2">
+                  {t("taskTimelogs.taskLabel")} {task.content}
+                </span>
+              )}
             </div>
-            <div className="text-sm text-base-content/40">
-              {t("taskTimelogs.recordsCount", {
-                count: totalRecords,
-              })}
-            </div>
-          </div>
-        </div>
-      )}
-
-      <ListContainer
-        title={t("taskTimelogs.title")}
-        hideHeader
-        size="lg"
-        borderVariant="subtle"
-        columns={[
-          {
-            key: "date",
-            label: t("taskTimelogs.columns.date"),
-            width: "0.5fr",
-            align: "left",
-          },
-          {
-            key: "timeRange",
-            label: t("taskTimelogs.columns.timeRange"),
-            width: "0.7fr",
-            align: "left",
-          },
-          {
-            key: "duration",
-            label: t("taskTimelogs.columns.duration"),
-            width: "0.5fr",
-            align: "left",
-          },
-          {
-            key: "area",
-            label: t("taskTimelogs.columns.area"),
-            width: "0.5fr",
-            align: "left",
-          },
-          {
-            key: "description",
-            label: t("taskTimelogs.columns.description"),
-            width: "2.5fr",
-            align: "left",
-          },
-        ]}
-        emptyState={
-          !isLoading && !error && timelogs.length === 0 ? (
-            <div className="flex items-center justify-center py-16">
-              <div className="text-center max-w-md">
-                <Icon
-                  name="timer"
-                  size={48}
-                  className="mb-6 opacity-60 text-info"
-                  aria-hidden
-                />
-                <h3 className="text-lg font-semibold text-base-content mb-3">
-                  {t("taskTimelogs.emptyState.title")}
-                </h3>
-                <p className="text-base-content/80 mb-4 leading-relaxed">
-                  {t("taskTimelogs.emptyState.description")}
-                </p>
+            <div className="flex flex-shrink-0 items-center gap-3">
+              <div className="text-sm text-base-content/40">
+                {t("taskTimelogs.totalTime")} {calculateTotalTime()}
+              </div>
+              <div className="text-sm text-base-content/40">
+                {t("taskTimelogs.recordsCount", {
+                  count: totalRecords,
+                })}
               </div>
             </div>
-          ) : null
-        }
-      >
-        {!isLoading && !error && timelogs.length > 0 && (
-          <div className="px-2 py-3 overflow-x-auto">
-            <div
-              className="min-w-[760px] grid gap-4"
-              style={{
-                gridTemplateColumns: [
-                  "0.5fr",
-                  "0.7fr",
-                  "0.5fr",
-                  "0.5fr",
-                  "2.5fr",
-                ].join(" "),
-              }}
-            >
-              {timelogs.map((event) => {
-                const trimmedTitle = event.title.trim();
-                const description =
-                  trimmedTitle.length > 0
-                    ? trimmedTitle
-                    : t("taskTimelogs.untitled");
-                const areaName =
-                  event.area_summary?.name ??
-                  (event.area_id ? areaMap.get(event.area_id)?.name : null) ??
-                  t("taskTimelogs.unknownArea");
-                const areaColor =
-                  event.area_summary?.color ??
-                  (event.area_id ? areaMap.get(event.area_id)?.color : null) ??
-                  undefined;
-
-                return (
-                  <React.Fragment key={event.id}>
-                    <div className="text-base-content/80 flex items-center">
-                      {formatDate(event.start_time, activeTimezone)}
-                    </div>
-                    <div className="text-base-content/90 flex items-center">
-                      <TimeRangeText
-                        start={event.start_time}
-                        end={event.end_time || null}
-                        timezone={activeTimezone}
-                      />
-                    </div>
-                    <div className="text-left text-base-content/90 flex items-center gap-2">
-                      {calculateDuration(event)}
-                    </div>
-                    <div className="flex items-center">
-                      <AreaBadge
-                        areaId={event.area_id ?? undefined}
-                        areaMap={areaMap}
-                        name={areaName}
-                        color={areaColor}
-                        showLabel
-                        labelClassName="text-base"
-                        ariaLabel={areaName}
-                      />
-                    </div>
-                    <div
-                      className="text-base-content/90 flex items-center truncate"
-                      title={description}
-                    >
-                      {description}
-                    </div>
-                  </React.Fragment>
-                );
-              })}
-            </div>
-            {safeTotalPages > 1 && (
-              <div className="flex items-center justify-between pt-4">
-                <ActionButton
-                  label={t("taskTimelogs.previousPage")}
-                  size="sm"
-                  variant="outline"
-                  color="neutral"
-                  disabled={!canGoPrev}
-                  onClick={() => setPage((current) => Math.max(1, current - 1))}
-                />
-                <div className="flex items-center gap-3 text-sm text-base-content/70">
-                  <span>
-                    {t("taskTimelogs.pageIndicator", {
-                      page,
-                      total: safeTotalPages,
-                    })}
-                  </span>
-                  {isFetching && (
-                    <span className="text-xs text-base-content/60">
-                      {t("common.loading")}
-                    </span>
-                  )}
-                </div>
-                <ActionButton
-                  label={t("taskTimelogs.nextPage")}
-                  size="sm"
-                  variant="outline"
-                  color="neutral"
-                  disabled={!canGoNext}
-                  onClick={() =>
-                    setPage((current) => Math.min(safeTotalPages, current + 1))
-                  }
-                />
-              </div>
-            )}
           </div>
         )}
-      </ListContainer>
+
+        <ListContainer
+          title={t("taskTimelogs.title")}
+          hideHeader
+          size="lg"
+          borderVariant="subtle"
+          className="min-h-0 flex flex-1 flex-col overflow-hidden"
+          columns={[
+            {
+              key: "date",
+              label: t("taskTimelogs.columns.date"),
+              width: "0.5fr",
+              align: "left",
+            },
+            {
+              key: "timeRange",
+              label: t("taskTimelogs.columns.timeRange"),
+              width: "0.7fr",
+              align: "left",
+            },
+            {
+              key: "duration",
+              label: t("taskTimelogs.columns.duration"),
+              width: "0.5fr",
+              align: "left",
+            },
+            {
+              key: "area",
+              label: t("taskTimelogs.columns.area"),
+              width: "0.5fr",
+              align: "left",
+            },
+            {
+              key: "description",
+              label: t("taskTimelogs.columns.description"),
+              width: "2.5fr",
+              align: "left",
+            },
+          ]}
+          emptyState={
+            !isLoading && !error && timelogs.length === 0 ? (
+              <div className="flex items-center justify-center py-16">
+                <div className="text-center max-w-md">
+                  <Icon
+                    name="timer"
+                    size={48}
+                    className="mb-6 opacity-60 text-info"
+                    aria-hidden
+                  />
+                  <h3 className="text-lg font-semibold text-base-content mb-3">
+                    {t("taskTimelogs.emptyState.title")}
+                  </h3>
+                  <p className="text-base-content/80 mb-4 leading-relaxed">
+                    {t("taskTimelogs.emptyState.description")}
+                  </p>
+                </div>
+              </div>
+            ) : null
+          }
+        >
+          {!isLoading && !error && timelogs.length > 0 && (
+            <div className="overflow-x-auto px-2 py-3">
+              <div
+                className="min-w-[760px] grid gap-4"
+                style={{
+                  gridTemplateColumns: [
+                    "0.5fr",
+                    "0.7fr",
+                    "0.5fr",
+                    "0.5fr",
+                    "2.5fr",
+                  ].join(" "),
+                }}
+              >
+                {timelogs.map((event) => {
+                  const trimmedTitle = event.title.trim();
+                  const description =
+                    trimmedTitle.length > 0
+                      ? trimmedTitle
+                      : t("taskTimelogs.untitled");
+                  const areaName =
+                    event.area_summary?.name ??
+                    (event.area_id ? areaMap.get(event.area_id)?.name : null) ??
+                    t("taskTimelogs.unknownArea");
+                  const areaColor =
+                    event.area_summary?.color ??
+                    (event.area_id ? areaMap.get(event.area_id)?.color : null) ??
+                    undefined;
+
+                  return (
+                    <React.Fragment key={event.id}>
+                      <div className="text-base-content/80 flex items-center">
+                        {formatDate(event.start_time, activeTimezone)}
+                      </div>
+                      <div className="text-base-content/90 flex items-center">
+                        <TimeRangeText
+                          start={event.start_time}
+                          end={event.end_time || null}
+                          timezone={activeTimezone}
+                        />
+                      </div>
+                      <div className="text-left text-base-content/90 flex items-center gap-2">
+                        {calculateDuration(event)}
+                      </div>
+                      <div className="flex items-center">
+                        <AreaBadge
+                          areaId={event.area_id ?? undefined}
+                          areaMap={areaMap}
+                          name={areaName}
+                          color={areaColor}
+                          showLabel
+                          labelClassName="text-base"
+                          ariaLabel={areaName}
+                        />
+                      </div>
+                      <div
+                        className="text-base-content/90 flex items-center truncate"
+                        title={description}
+                      >
+                        {description}
+                      </div>
+                    </React.Fragment>
+                  );
+                })}
+              </div>
+              {safeTotalPages > 1 && (
+                <div className="flex items-center justify-between pt-4">
+                  <ActionButton
+                    label={t("taskTimelogs.previousPage")}
+                    size="sm"
+                    variant="outline"
+                    color="neutral"
+                    disabled={!canGoPrev}
+                    onClick={() =>
+                      setPage((current) => Math.max(1, current - 1))
+                    }
+                  />
+                  <div className="flex items-center gap-3 text-sm text-base-content/70">
+                    <span>
+                      {t("taskTimelogs.pageIndicator", {
+                        page,
+                        total: safeTotalPages,
+                      })}
+                    </span>
+                    {isFetching && (
+                      <span className="text-xs text-base-content/60">
+                        {t("common.loading")}
+                      </span>
+                    )}
+                  </div>
+                  <ActionButton
+                    label={t("taskTimelogs.nextPage")}
+                    size="sm"
+                    variant="outline"
+                    color="neutral"
+                    disabled={!canGoNext}
+                    onClick={() =>
+                      setPage((current) =>
+                        Math.min(safeTotalPages, current + 1),
+                      )
+                    }
+                  />
+                </div>
+              )}
+            </div>
+          )}
+        </ListContainer>
+      </div>
     </ModalBase>
   );
 };

--- a/web/src/components/TaskTimelogsModal.tsx
+++ b/web/src/components/TaskTimelogsModal.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { Timelog, TaskWithSubtasks } from "@/services/api";
 import type { UUID } from "@/types/primitive";
@@ -10,6 +10,8 @@ import ListContainer from "@/layouts/ListContainer";
 import AreaBadge from "./AreaBadge";
 import { Icon } from "./icons";
 import { usePreferenceWithBootstrap } from "@/hooks/queries/usePreferenceWithBootstrap";
+import { useAreas } from "@/hooks/queries/useAreas";
+import ActionButton from "./ActionButton";
 
 interface TaskTimelogsModalProps {
   isOpen: boolean;
@@ -29,6 +31,8 @@ const TaskTimelogsModal: React.FC<TaskTimelogsModalProps> = ({
   task,
 }) => {
   const { t } = useTranslation();
+  const [page, setPage] = useState(1);
+  const pageSize = 50;
   const timezonePreference = usePreferenceWithBootstrap<string>({
     key: "system.timezone",
     defaultValue: resolvePreferredTimezone(),
@@ -36,20 +40,39 @@ const TaskTimelogsModal: React.FC<TaskTimelogsModalProps> = ({
     validator: (value) => typeof value === "string" && value.length > 0,
   });
   const activeTimezone = resolvePreferredTimezone(timezonePreference.value);
+  const { areaMap } = useAreas();
 
-  // 使用 TanStack Query 替代手动状态管理
+  useEffect(() => {
+    if (isOpen) {
+      setPage(1);
+    }
+  }, [isOpen, task?.id]);
+
   const {
     data: timelogsData,
     isLoading,
+    isFetching,
     error,
     refetch,
   } = useTaskTimelogs(task?.id || ("" as UUID), {
     enabled: !!task?.id && isOpen,
+    page,
+    size: pageSize,
   });
   const timelogs = useMemo(
-    () => timelogsData ?? [],
+    () => timelogsData?.items ?? [],
     [timelogsData],
   );
+  const totalRecords = timelogsData?.pagination.total ?? 0;
+  const safeTotalPages = Math.max(1, timelogsData?.pagination.pages ?? 0);
+  const canGoPrev = page > 1;
+  const canGoNext = page < safeTotalPages;
+
+  useEffect(() => {
+    if (page > safeTotalPages) {
+      setPage(safeTotalPages);
+    }
+  }, [page, safeTotalPages]);
 
   // Calculate duration for an event
   const calculateDuration = (event: Timelog): string => {
@@ -73,30 +96,19 @@ const TaskTimelogsModal: React.FC<TaskTimelogsModalProps> = ({
     }
   };
 
-  // Replaced by TimeRangeText
-
-  // Calculate total time spent on this task
-  const calculateTotalTime = (): string => {
-    let totalMinutes = 0;
-    timelogs.forEach((event) => {
-      if (event.start_time && event.end_time) {
-        const startTime = new Date(event.start_time);
-        const endTime = new Date(event.end_time);
-        const durationMs = endTime.getTime() - startTime.getTime();
-        totalMinutes += Math.round(durationMs / (1000 * 60));
-      }
-    });
-
+  const formatMinutes = (totalMinutes: number): string => {
     if (totalMinutes < 60) {
       return `${totalMinutes}${t("taskTimelogs.minutes")}`;
-    } else {
-      const hours = Math.floor(totalMinutes / 60);
-      const minutes = totalMinutes % 60;
-      return minutes > 0
-        ? `${hours}${t("taskTimelogs.hours")}${minutes}${t("taskTimelogs.minutes")}`
-        : `${hours}${t("taskTimelogs.hours")}`;
     }
+    const hours = Math.floor(totalMinutes / 60);
+    const minutes = totalMinutes % 60;
+    return minutes > 0
+      ? `${hours}${t("taskTimelogs.hours")}${minutes}${t("taskTimelogs.minutes")}`
+      : `${hours}${t("taskTimelogs.hours")}`;
   };
+
+  const calculateTotalTime = (): string =>
+    formatMinutes(Math.max(0, task?.actual_effort_self ?? 0));
 
   return (
     <ModalBase
@@ -127,7 +139,7 @@ const TaskTimelogsModal: React.FC<TaskTimelogsModalProps> = ({
             </div>
             <div className="text-sm text-base-content/40">
               {t("taskTimelogs.recordsCount", {
-                count: timelogs.length,
+                count: totalRecords,
               })}
             </div>
           </div>
@@ -213,21 +225,20 @@ const TaskTimelogsModal: React.FC<TaskTimelogsModalProps> = ({
                     ? trimmedTitle
                     : t("taskTimelogs.untitled");
                 const areaName =
-                  event.area_summary?.name ||
+                  event.area_summary?.name ??
+                  (event.area_id ? areaMap.get(event.area_id)?.name : null) ??
                   t("taskTimelogs.unknownArea");
+                const areaColor =
+                  event.area_summary?.color ??
+                  (event.area_id ? areaMap.get(event.area_id)?.color : null) ??
+                  undefined;
 
                 return (
                   <React.Fragment key={event.id}>
                     <div className="text-base-content/80 flex items-center">
                       {formatDate(event.start_time, activeTimezone)}
                     </div>
-                    <div className="text-base-content/90 flex items-center gap-2">
-                      <Icon
-                        name="timer"
-                        size={16}
-                        className="text-primary/70"
-                        aria-hidden
-                      />
+                    <div className="text-base-content/90 flex items-center">
                       <TimeRangeText
                         start={event.start_time}
                         end={event.end_time || null}
@@ -239,10 +250,12 @@ const TaskTimelogsModal: React.FC<TaskTimelogsModalProps> = ({
                     </div>
                     <div className="flex items-center">
                       <AreaBadge
+                        areaId={event.area_id ?? undefined}
+                        areaMap={areaMap}
                         name={areaName}
-                        color={event.area_summary?.color || undefined}
+                        color={areaColor}
                         showLabel
-                        className="text-sm"
+                        labelClassName="text-base"
                         ariaLabel={areaName}
                       />
                     </div>
@@ -256,6 +269,41 @@ const TaskTimelogsModal: React.FC<TaskTimelogsModalProps> = ({
                 );
               })}
             </div>
+            {safeTotalPages > 1 && (
+              <div className="flex items-center justify-between pt-4">
+                <ActionButton
+                  label={t("taskTimelogs.previousPage")}
+                  size="sm"
+                  variant="outline"
+                  color="neutral"
+                  disabled={!canGoPrev}
+                  onClick={() => setPage((current) => Math.max(1, current - 1))}
+                />
+                <div className="flex items-center gap-3 text-sm text-base-content/70">
+                  <span>
+                    {t("taskTimelogs.pageIndicator", {
+                      page,
+                      total: safeTotalPages,
+                    })}
+                  </span>
+                  {isFetching && (
+                    <span className="text-xs text-base-content/60">
+                      {t("common.loading")}
+                    </span>
+                  )}
+                </div>
+                <ActionButton
+                  label={t("taskTimelogs.nextPage")}
+                  size="sm"
+                  variant="outline"
+                  color="neutral"
+                  disabled={!canGoNext}
+                  onClick={() =>
+                    setPage((current) => Math.min(safeTotalPages, current + 1))
+                  }
+                />
+              </div>
+            )}
           </div>
         )}
       </ListContainer>

--- a/web/src/components/VisionManager.tsx
+++ b/web/src/components/VisionManager.tsx
@@ -655,6 +655,10 @@ const VisionManager = forwardRef<VisionManagerHandle, VisionManagerProps>(
                               onViewNotes={
                                 taskManagement.actions.handleViewNotes
                               }
+                              onCreateTimeRecord={
+                                taskManagement.actions
+                                  .handleOpenCreateTimelogModal
+                              }
                               expandedTasks={
                                 expandedTasksInVision[vision.id] || new Set()
                               }

--- a/web/src/components/__tests__/PersonTimelineModal.test.tsx
+++ b/web/src/components/__tests__/PersonTimelineModal.test.tsx
@@ -121,4 +121,34 @@ describe("PersonTimelineModal", () => {
     expect(screen.getByText("Deep work")).toBeInTheDocument();
     expect(screen.queryByText("manual")).not.toBeInTheDocument();
   });
+
+  it("does not render duplicate note content when title and description match", () => {
+    renderWithProviders(
+      <PersonTimelineModal
+        person={person}
+        isOpen
+        onClose={vi.fn()}
+        activities={[
+          {
+            id: "note-1",
+            type: "note",
+            title: "Remember the meeting notes",
+            description: "Remember the meeting notes",
+            date: "2026-07-02T09:00:00.000Z",
+            status: null,
+          },
+        ]}
+        total={1}
+        totalPages={1}
+        isLoadingActivities={false}
+        isFetchingActivities={false}
+        page={1}
+        onPageChange={vi.fn()}
+        activityType="note"
+        onActivityTypeChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getAllByText("Remember the meeting notes")).toHaveLength(1);
+  });
 });

--- a/web/src/components/__tests__/PersonTimelineModal.test.tsx
+++ b/web/src/components/__tests__/PersonTimelineModal.test.tsx
@@ -1,0 +1,124 @@
+import type React from "react";
+import { screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import PersonTimelineModal from "@/components/PersonTimelineModal";
+import type { PersonSummary } from "@/services/api";
+import type { PersonActivityItem } from "@/services/api/persons";
+import { renderWithProviders, setupTranslationMock } from "@test/utils";
+
+vi.mock("@tanstack/react-virtual", () => ({
+  useVirtualizer: ({ count }: { count: number }) => ({
+    getTotalSize: () => count * 120,
+    getVirtualItems: () =>
+      Array.from({ length: count }, (_, index) => ({
+        index,
+        key: index,
+        start: index * 120,
+        size: 120,
+      })),
+    measureElement: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/queries/useAreas", () => ({
+  useAreas: () => ({
+    areaMap: new Map([["area-1", { name: "Work", color: "#3B82F6" }]]),
+  }),
+}));
+
+vi.mock("@/hooks/queries/usePreferenceWithBootstrap", () => ({
+  usePreferenceWithBootstrap: vi.fn((opts: { defaultValue: unknown }) => ({
+    value:
+      typeof opts.defaultValue === "string" ? "Asia/Shanghai" : opts.defaultValue,
+    loading: false,
+    error: null,
+  })),
+}));
+
+vi.mock("@/layouts/ModalBase", () => ({
+  __esModule: true,
+  default: ({
+    isOpen,
+    title,
+    children,
+  }: {
+    isOpen: boolean;
+    title?: React.ReactNode;
+    children?: React.ReactNode;
+  }) =>
+    isOpen ? (
+      <div>
+        <h2>{title}</h2>
+        {children}
+      </div>
+    ) : null,
+}));
+
+setupTranslationMock({
+  translator: (key, options) => {
+    const translations: Record<string, string> = {
+      "persons.timeline.title": `${(options as { name?: string })?.name} 的活动时间线`,
+      "persons.timeline.activityCount": `（${(options as { count?: number })?.count} 项活动）`,
+      "persons.activityTypes.timelog": "时间日志",
+      "taskTimelogs.unknownArea": "未分配领域",
+      "common.all": "全部",
+      "persons.activityTypes.note": "快速笔记",
+      "persons.activityTypes.task": "任务",
+      "persons.activityTypes.planned_event": "日程安排",
+      "persons.activityTypes.vision": "愿景管理",
+    };
+    return translations[key] ?? key;
+  },
+});
+
+const person = {
+  id: "person-1",
+  name: "Ada",
+  display_name: "Ada",
+} as unknown as PersonSummary;
+
+const activity: PersonActivityItem = {
+  id: "timelog-1",
+  type: "timelog",
+  title: "Deep work",
+  description: null,
+  date: "2026-07-02T09:00:00.000Z",
+  status: "manual",
+  start_time: "2026-07-02T09:00:00.000Z",
+  end_time: "2026-07-02T09:30:00.000Z",
+  area_id: "area-1",
+};
+
+describe("PersonTimelineModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders timelog activity details without the manual tracking method", () => {
+    renderWithProviders(
+      <PersonTimelineModal
+        person={person}
+        isOpen
+        onClose={vi.fn()}
+        activities={[activity]}
+        total={1}
+        totalPages={1}
+        isLoadingActivities={false}
+        isFetchingActivities={false}
+        page={1}
+        onPageChange={vi.fn()}
+        activityType="timelog"
+        onActivityTypeChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getAllByText("时间日志").length).toBeGreaterThan(0);
+    expect(screen.getByText("2026-07-02")).toBeInTheDocument();
+    expect(screen.getByText("17:00-17:30")).toBeInTheDocument();
+    expect(screen.getByText("30m")).toBeInTheDocument();
+    expect(screen.getByText("Work")).toBeInTheDocument();
+    expect(screen.getByText("Deep work")).toBeInTheDocument();
+    expect(screen.queryByText("manual")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/__tests__/TaskTimelogQuickAddModal.test.tsx
+++ b/web/src/components/__tests__/TaskTimelogQuickAddModal.test.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+import { waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type InlineQuickTimeEntryComponent from "@/components/InlineQuickTimeEntry";
+import type { TaskWithSubtasks } from "@/services/api";
+import { tasksApi } from "@/services/api/tasks";
+import { renderWithProviders, setupTranslationMock } from "@test/utils";
+
+type InlineQuickProps = React.ComponentProps<
+  typeof InlineQuickTimeEntryComponent
+>;
+
+const inlinePropsRef: { current: InlineQuickProps | null } = { current: null };
+
+setupTranslationMock();
+
+vi.mock("@/hooks/queries/usePreferenceWithBootstrap", () => ({
+  usePreferenceWithBootstrap: vi.fn((opts: { defaultValue: unknown }) => ({
+    value:
+      typeof opts.defaultValue === "string" ? "Asia/Shanghai" : opts.defaultValue,
+    loading: false,
+    error: null,
+  })),
+}));
+
+vi.mock("@/layouts/ModalBase", () => ({
+  __esModule: true,
+  default: ({
+    isOpen,
+    children,
+  }: {
+    isOpen: boolean;
+    children?: React.ReactNode;
+  }) => (isOpen ? <div data-testid="modal">{children}</div> : null),
+}));
+
+vi.mock("@/components/InlineQuickTimeEntry", () => {
+  const MockInlineQuick: React.FC<InlineQuickProps> = (props) => {
+    inlinePropsRef.current = props;
+    return <div data-testid="inline-entry" />;
+  };
+  return { __esModule: true, default: MockInlineQuick };
+});
+
+import TaskTimelogQuickAddModal from "@/components/TaskTimelogQuickAddModal";
+
+const buildTask = (): TaskWithSubtasks =>
+  ({
+    id: "task-1",
+    content: "Review timezone handling",
+    subtasks: [],
+  }) as unknown as TaskWithSubtasks;
+
+describe("TaskTimelogQuickAddModal", () => {
+  beforeEach(() => {
+    inlinePropsRef.current = null;
+    vi.restoreAllMocks();
+  });
+
+  it("prefills the start time from the latest task timelog and leaves the end time blank", async () => {
+    vi.spyOn(tasksApi, "getTimelogs").mockResolvedValue({
+      items: [
+        {
+          id: "timelog-1",
+          title: "Previous task work",
+          start_time: "2026-07-02T08:30:00.000Z",
+          end_time: "2026-07-02T09:00:00.000Z",
+          area_id: null,
+          tracking_method: "manual",
+          created_at: "2026-07-02T09:00:00.000Z",
+          updated_at: "2026-07-02T09:00:00.000Z",
+        },
+      ],
+      pagination: { page: 1, size: 1, total: 1, pages: 1 },
+      meta: {},
+    } as Awaited<ReturnType<typeof tasksApi.getTimelogs>>);
+
+    renderWithProviders(
+      <TaskTimelogQuickAddModal
+        isOpen
+        task={buildTask()}
+        onClose={vi.fn()}
+        onTimelogCreated={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(inlinePropsRef.current).not.toBeNull();
+    });
+
+    expect(inlinePropsRef.current?.startTime).toBe("17:00");
+    expect(inlinePropsRef.current?.endTime).toBe("");
+    expect(inlinePropsRef.current?.blankInitialEndTime).toBe(true);
+  });
+});

--- a/web/src/components/__tests__/TaskTimelogsModal.test.tsx
+++ b/web/src/components/__tests__/TaskTimelogsModal.test.tsx
@@ -1,0 +1,145 @@
+import type React from "react";
+import { fireEvent, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import TaskTimelogsModal from "@/components/TaskTimelogsModal";
+import type { TaskWithSubtasks } from "@/services/api";
+import { renderWithProviders, setupTranslationMock } from "@test/utils";
+
+const { useTaskTimelogsMock } = vi.hoisted(() => ({
+  useTaskTimelogsMock: vi.fn(),
+}));
+
+vi.mock("@/hooks/queries/useTaskTimelogs", () => ({
+  useTaskTimelogs: useTaskTimelogsMock,
+}));
+
+vi.mock("@/hooks/queries/useAreas", () => ({
+  useAreas: () => ({
+    areaMap: new Map([["area-1", { name: "Work", color: "#3B82F6" }]]),
+  }),
+}));
+
+vi.mock("@/hooks/queries/usePreferenceWithBootstrap", () => ({
+  usePreferenceWithBootstrap: vi.fn((opts: { defaultValue: unknown }) => ({
+    value:
+      typeof opts.defaultValue === "string" ? "Asia/Shanghai" : opts.defaultValue,
+    loading: false,
+    error: null,
+  })),
+}));
+
+vi.mock("@/layouts/ModalBase", () => ({
+  __esModule: true,
+  default: ({
+    isOpen,
+    header,
+    children,
+  }: {
+    isOpen: boolean;
+    header?: React.ReactNode;
+    children?: React.ReactNode;
+  }) =>
+    isOpen ? (
+      <div>
+        <h2>{header}</h2>
+        {children}
+      </div>
+    ) : null,
+}));
+
+vi.mock("@/components/TimeRangeText", () => ({
+  __esModule: true,
+  default: () => <span data-testid="time-range">17:00-17:30</span>,
+}));
+
+vi.mock("@/components/icons", () => ({
+  Icon: ({ name }: { name: string }) => <span data-testid={`icon-${name}`} />,
+}));
+
+setupTranslationMock({
+  translator: (key, options) => {
+    const translations: Record<string, string> = {
+      "taskTimelogs.title": "时间日志",
+      "taskTimelogs.taskLabel": "任务：",
+      "taskTimelogs.totalTime": "总计",
+      "taskTimelogs.minutes": "分钟",
+      "taskTimelogs.hours": "小时",
+      "taskTimelogs.recordsCount": `${(options as { count?: number })?.count} 条记录`,
+      "taskTimelogs.previousPage": "上一页",
+      "taskTimelogs.nextPage": "下一页",
+      "taskTimelogs.pageIndicator": `第 ${(options as { page?: number })?.page} / ${(options as { total?: number })?.total} 页`,
+      "taskTimelogs.unknownArea": "未分配领域",
+      "taskTimelogs.columns.date": "日期",
+      "taskTimelogs.columns.timeRange": "时间段",
+      "taskTimelogs.columns.duration": "时长",
+      "taskTimelogs.columns.area": "领域",
+      "taskTimelogs.columns.description": "行为描述",
+    };
+    return translations[key] ?? key;
+  },
+});
+
+const buildTask = (): TaskWithSubtasks =>
+  ({
+    id: "task-1",
+    content: "Review task logs",
+    actual_effort_self: 30,
+    subtasks: [],
+  }) as unknown as TaskWithSubtasks;
+
+describe("TaskTimelogsModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useTaskTimelogsMock.mockReturnValue({
+      data: {
+        items: [
+          {
+            id: "timelog-1",
+            title: "Deep work",
+            start_time: "2026-07-02T09:00:00.000Z",
+            end_time: "2026-07-02T09:30:00.000Z",
+            area_id: "area-1",
+            area_summary: { id: "area-1", name: null, color: null },
+            tracking_method: "manual",
+            created_at: "2026-07-02T09:30:00.000Z",
+            updated_at: "2026-07-02T09:30:00.000Z",
+          },
+        ],
+        pagination: { page: 1, size: 50, total: 101, pages: 3 },
+        meta: {},
+      },
+      isLoading: false,
+      isFetching: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+  });
+
+  it("renders paginated task time logs with resolved area names and no time icon", () => {
+    renderWithProviders(
+      <TaskTimelogsModal
+        isOpen
+        onClose={vi.fn()}
+        task={buildTask()}
+      />,
+    );
+
+    expect(useTaskTimelogsMock).toHaveBeenCalledWith(
+      "task-1",
+      expect.objectContaining({ page: 1, size: 50 }),
+    );
+    expect(screen.getAllByText("时间日志").length).toBeGreaterThan(0);
+    expect(screen.getByText("101 条记录")).toBeInTheDocument();
+    expect(screen.getByText("Work")).toBeInTheDocument();
+    expect(screen.getByText("Deep work")).toBeInTheDocument();
+    expect(screen.queryByTestId("icon-timer")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "下一页" }));
+
+    expect(useTaskTimelogsMock).toHaveBeenLastCalledWith(
+      "task-1",
+      expect.objectContaining({ page: 2, size: 50 }),
+    );
+  });
+});

--- a/web/src/components/__tests__/TaskTimelogsModal.test.tsx
+++ b/web/src/components/__tests__/TaskTimelogsModal.test.tsx
@@ -127,7 +127,7 @@ describe("TaskTimelogsModal", () => {
 
     expect(useTaskTimelogsMock).toHaveBeenCalledWith(
       "task-1",
-      expect.objectContaining({ page: 1, size: 50 }),
+      expect.objectContaining({ page: 1, size: 15 }),
     );
     expect(screen.getAllByText("时间日志").length).toBeGreaterThan(0);
     expect(screen.getByText("101 条记录")).toBeInTheDocument();
@@ -139,7 +139,7 @@ describe("TaskTimelogsModal", () => {
 
     expect(useTaskTimelogsMock).toHaveBeenLastCalledWith(
       "task-1",
-      expect.objectContaining({ page: 2, size: 50 }),
+      expect.objectContaining({ page: 2, size: 15 }),
     );
   });
 });

--- a/web/src/components/planning/TaskListSection.tsx
+++ b/web/src/components/planning/TaskListSection.tsx
@@ -110,6 +110,9 @@ export const TaskListSection: React.FC<TaskListSectionProps> = ({
               onViewTimeRecords={taskManagement.actions.handleViewTimeRecords}
               onCreateNote={taskManagement.actions.handleOpenCreateNoteModal}
               onViewNotes={taskManagement.actions.handleViewNotes}
+              onCreateTimeRecord={
+                taskManagement.actions.handleOpenCreateTimelogModal
+              }
               expandedTasks={getExpandedTasksForDraggable(groupId)}
               onToggleExpansion={(taskId) =>
                 toggleTaskExpansion(groupId, taskId)

--- a/web/src/features/notes/controller/useCreateNoteModalController.ts
+++ b/web/src/features/notes/controller/useCreateNoteModalController.ts
@@ -23,7 +23,11 @@ import {
   isTimelogsAdvancedSearchQuery,
   type QueryLike,
 } from "@/services/api/queryPredicates";
-import { invalidateTasksByIds, updateTaskCaches } from "@/utils/query";
+import {
+  invalidateTasksByIds,
+  updateTaskCaches,
+  updateTaskRelationshipCounts,
+} from "@/utils/query";
 import { logger } from "@/utils/core";
 import type { UUID } from "@/types/primitive";
 
@@ -184,6 +188,10 @@ export function useCreateNoteModalController({
               typeof noteTask.notes_count === "number"
                 ? noteTask.notes_count
                 : baseTask.notes_count,
+            timelogs_count:
+              typeof noteTask.timelogs_count === "number"
+                ? noteTask.timelogs_count
+                : baseTask.timelogs_count,
             actual_effort_total:
               typeof noteTask.actual_effort_total === "number"
                 ? noteTask.actual_effort_total
@@ -247,6 +255,11 @@ export function useCreateNoteModalController({
       }
 
       const refreshCaches = async () => {
+        Array.from(taskIds).forEach((taskId) => {
+          updateTaskRelationshipCounts(queryClient, taskId, {
+            notes_count: (current) => Math.max(1, current + 1),
+          });
+        });
         await syncTaskFromNoteSummary(createdNote?.task);
         await invalidateRelatedQueries({
           timelogIds: Array.from(timelogIds),

--- a/web/src/features/notes/controller/useCreateNoteModalController.ts
+++ b/web/src/features/notes/controller/useCreateNoteModalController.ts
@@ -255,12 +255,12 @@ export function useCreateNoteModalController({
       }
 
       const refreshCaches = async () => {
+        await syncTaskFromNoteSummary(createdNote?.task);
         Array.from(taskIds).forEach((taskId) => {
           updateTaskRelationshipCounts(queryClient, taskId, {
             notes_count: (current) => Math.max(1, current + 1),
           });
         });
-        await syncTaskFromNoteSummary(createdNote?.task);
         await invalidateRelatedQueries({
           timelogIds: Array.from(timelogIds),
           taskIds: Array.from(taskIds),

--- a/web/src/hooks/queries/useTaskTimelogs.ts
+++ b/web/src/hooks/queries/useTaskTimelogs.ts
@@ -2,6 +2,7 @@ import { useQuery, useQueries } from "@tanstack/react-query";
 import { tasksApi } from "@/services/api/tasks";
 import { tasksKeys } from "@/services/api/queryKeys";
 import type { Timelog } from "@/services/api";
+import type { TimelogListResponse } from "@/services/api/timelogs";
 import type { UUID } from "@/types/primitive";
 
 /**
@@ -9,18 +10,26 @@ import type { UUID } from "@/types/primitive";
  */
 export function useTaskTimelogs(
   taskId: UUID,
-  options?: { enabled?: boolean },
+  options?: { enabled?: boolean; page?: number; size?: number },
 ) {
-  const page = 1;
-  const size = 100;
+  const page = Math.max(1, options?.page ?? 1);
+  const size = Math.max(1, options?.size ?? 50);
   return useQuery({
-    queryKey: tasksKeys.timelogs(taskId),
+    queryKey: [...tasksKeys.timelogs(taskId), { page, size }],
     queryFn: async () => {
+      if (!taskId) {
+        return {
+          items: [],
+          pagination: { page, size, total: 0, pages: 0 },
+          meta: {},
+        } satisfies TimelogListResponse;
+      }
       const response = await tasksApi.getTimelogs(taskId, page, size);
-      return response.items ?? [];
+      return response;
     },
     enabled: options?.enabled ?? !!taskId,
-    staleTime: 5 * 60 * 1000, // 5分钟缓存
+    staleTime: 5 * 60 * 1000,
+    placeholderData: (previousData) => previousData,
   });
 }
 
@@ -34,7 +43,6 @@ export function useMultipleTaskTimelogs(
 ) {
   const page = 1;
   const size = 100;
-  // 使用 useQueries 来并行获取多个任务的实际事件
   const queries = useQueries({
     queries: taskIds.map((taskId) => ({
       queryKey: tasksKeys.timelogs(taskId),
@@ -43,7 +51,7 @@ export function useMultipleTaskTimelogs(
         return response.items ?? [];
       },
       enabled: (options?.enabled ?? true) && !!taskId,
-      staleTime: 5 * 60 * 1000, // 5分钟缓存
+      staleTime: 5 * 60 * 1000,
     })),
   });
 

--- a/web/src/hooks/useTaskManagement.ts
+++ b/web/src/hooks/useTaskManagement.ts
@@ -1,10 +1,15 @@
 import { useState, useCallback } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { Task, TaskWithSubtasks, Vision } from "@/services/api";
+import type { TimelogWithEnergyResponse } from "@/services/api/timelogs";
 import { tasksApi } from "@/services/api";
 import { useToast } from "@/contexts/ToastContext";
 import type { UUID } from "@/types/primitive";
-import { invalidateTasksByIds, updateTaskCaches } from "@/utils/query";
+import {
+  invalidateTasksByIds,
+  updateTaskCaches,
+  updateTaskRelationshipCounts,
+} from "@/utils/query";
 import { tasksKeys } from "@/services/api/queryKeys";
 import { createModalSessionId } from "@/utils/session";
 
@@ -78,6 +83,10 @@ interface TaskManagementState {
   creatingNoteForTask: TaskWithSubtasks | null;
   isCreateNoteModalOpen: boolean;
 
+  // Timelog creation state
+  creatingTimelogForTask: TaskWithSubtasks | null;
+  isCreateTimelogModalOpen: boolean;
+
   // 创建子任务相关状态
   creatingSubtask: boolean;
   parentTaskId: UUID | null;
@@ -115,6 +124,11 @@ interface TaskManagementActions {
   handleOpenCreateNoteModal: (task: TaskWithSubtasks) => void;
   closeCreateNoteModal: () => void;
   handleNoteCreated: () => void;
+
+  // Timelog creation
+  handleOpenCreateTimelogModal: (task: TaskWithSubtasks) => void;
+  closeCreateTimelogModal: () => void;
+  handleTimelogCreated: (result: TimelogWithEnergyResponse) => void;
 
   // 任务重排序
   handleTasksReorder: (reorderedTasks: TaskWithSubtasks[]) => Promise<void>;
@@ -257,6 +271,8 @@ export const useTaskManagement = (config: TaskManagementConfig = {}) => {
     isNotesModalOpen: false,
     creatingNoteForTask: null,
     isCreateNoteModalOpen: false,
+    creatingTimelogForTask: null,
+    isCreateTimelogModalOpen: false,
     creatingSubtask: false,
     parentTaskId: null,
   });
@@ -539,6 +555,53 @@ export const useTaskManagement = (config: TaskManagementConfig = {}) => {
     }
   }, [onNoteCreated]);
 
+  const handleOpenCreateTimelogModal = useCallback((task: TaskWithSubtasks) => {
+    setState((prev) => ({
+      ...prev,
+      creatingTimelogForTask: task,
+      isCreateTimelogModalOpen: true,
+    }));
+  }, []);
+
+  const closeCreateTimelogModal = useCallback(() => {
+    setState((prev) => ({
+      ...prev,
+      isCreateTimelogModalOpen: false,
+      creatingTimelogForTask: null,
+    }));
+  }, []);
+
+  const handleTimelogCreated = useCallback(
+    (result: TimelogWithEnergyResponse) => {
+      const taskId =
+        result.task?.id ??
+        result.task_id ??
+        state.creatingTimelogForTask?.id ??
+        null;
+
+      setState((prev) => ({
+        ...prev,
+        isCreateTimelogModalOpen: false,
+        creatingTimelogForTask: null,
+      }));
+
+      if (!taskId) {
+        onTaskUpdate?.();
+        return;
+      }
+
+      updateTaskRelationshipCounts(queryClient, taskId, {
+        timelogs_count: (current) => Math.max(1, current + 1),
+      });
+
+      void invalidateTasksByIds(queryClient, [taskId]).catch((error) => {
+        console.warn("Failed to refresh task after creating timelog:", error);
+      });
+      onTaskUpdate?.();
+    },
+    [onTaskUpdate, queryClient, state.creatingTimelogForTask?.id],
+  );
+
   // 任务重排序处理
   const handleTasksReorder = useCallback(
     async (reorderedTasks: TaskWithSubtasks[]) => {
@@ -580,6 +643,9 @@ export const useTaskManagement = (config: TaskManagementConfig = {}) => {
     handleOpenCreateNoteModal,
     closeCreateNoteModal,
     handleNoteCreated,
+    handleOpenCreateTimelogModal,
+    closeCreateTimelogModal,
+    handleTimelogCreated,
     handleTasksReorder,
   };
 
@@ -598,6 +664,8 @@ export const useTaskManagement = (config: TaskManagementConfig = {}) => {
     isNotesModalOpen: state.isNotesModalOpen,
     creatingNoteForTask: state.creatingNoteForTask,
     isCreateNoteModalOpen: state.isCreateNoteModalOpen,
+    creatingTimelogForTask: state.creatingTimelogForTask,
+    isCreateTimelogModalOpen: state.isCreateTimelogModalOpen,
     creatingSubtask: state.creatingSubtask,
     parentTaskId: state.parentTaskId,
   };

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -1396,7 +1396,7 @@
     },
     "activityTypes": {
       "vision": "Vision Management",
-      "timelog": "Timelog",
+      "timelog": "Time Logs",
       "note": "Notes",
       "task": "Tasks",
       "planned_event": "Calendar"
@@ -1811,17 +1811,20 @@
     }
   },
   "taskTimelogs": {
-    "title": "Logs",
+    "title": "Time Logs",
     "taskLabel": "Task:",
     "totalTime": "Total",
     "recordsCount": "{{count}} records",
+    "previousPage": "Previous Page",
+    "nextPage": "Next Page",
+    "pageIndicator": "Page {{page}} / {{total}}",
     "duration": "In progress",
     "minutes": "minutes",
     "hours": "hours",
-    "untitled": "Untitled event",
+    "untitled": "Untitled time log",
     "unknownArea": "Unassigned area",
     "emptyState": {
-      "title": "No Logs",
+      "title": "No Time Logs",
       "description": "Link timelog entries to this task to review them here."
     },
     "columns": {

--- a/web/src/locales/zh/common.json
+++ b/web/src/locales/zh/common.json
@@ -1396,7 +1396,7 @@
     },
     "activityTypes": {
       "vision": "愿景管理",
-      "timelog": "时间跟踪",
+      "timelog": "时间日志",
       "note": "快速笔记",
       "task": "任务",
       "planned_event": "日程安排"
@@ -1811,17 +1811,20 @@
     }
   },
   "taskTimelogs": {
-    "title": "日志",
+    "title": "时间日志",
     "taskLabel": "任务：",
     "totalTime": "总计",
     "recordsCount": "{{count}} 条记录",
+    "previousPage": "上一页",
+    "nextPage": "下一页",
+    "pageIndicator": "第 {{page}} / {{total}} 页",
     "duration": "进行中",
     "minutes": "分钟",
     "hours": "小时",
-    "untitled": "未命名事件",
+    "untitled": "未命名时间日志",
     "unknownArea": "未分配领域",
     "emptyState": {
-      "title": "暂无日志",
+      "title": "暂无时间日志",
       "description": "在时间日志页面记录时间时关联此任务即可显示"
     },
     "columns": {

--- a/web/src/services/api/__tests__/client.test.ts
+++ b/web/src/services/api/__tests__/client.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ApiError, http } from "@/services/api/client";
+import { subscribeApiError } from "@/services/api/errorBus";
 
 const localUrl = (path: string) => new URL(path, "http://localhost").toString();
 
@@ -68,5 +69,17 @@ describe("local web http client", () => {
     );
 
     await expect(http.get("/api/v1/missing")).rejects.toBeInstanceOf(ApiError);
+  });
+
+  it("does not emit global errors for aborted requests", async () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeApiError(listener);
+    const abortError = new Error("signal is aborted without reason");
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(abortError);
+
+    await expect(http.get("/api/v1/test")).rejects.toBe(abortError);
+
+    expect(listener).not.toHaveBeenCalled();
+    unsubscribe();
   });
 });

--- a/web/src/services/api/__tests__/tasks.test.ts
+++ b/web/src/services/api/__tests__/tasks.test.ts
@@ -34,3 +34,35 @@ describe("tasksApi.updateStatus", () => {
     expect(init.body).toBe(JSON.stringify({ status: "done" }));
   });
 });
+
+describe("tasksApi.getTimelogs", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("queries timelogs through the task_id filter", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          items: [{ id: "timelog-1", title: "Focus" }],
+          pagination: { page: 2, size: 10, total: 1, pages: 1 },
+          meta: { task_id: "task-1" },
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    const response = await tasksApi.getTimelogs("task-1", 2, 10);
+
+    expect(response.items).toHaveLength(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(
+      localUrl(`${ENDPOINTS.TIMELOGS.BASE}?task_id=task-1&page=2&size=10`),
+    );
+    expect(init.method).toBe("GET");
+  });
+});

--- a/web/src/services/api/client.ts
+++ b/web/src/services/api/client.ts
@@ -64,6 +64,23 @@ async function request<T>(
     signal?: AbortSignal;
   },
 ): Promise<T> {
+  const isAbortError = (error: unknown): boolean => {
+    if (
+      typeof DOMException !== "undefined" &&
+      error instanceof DOMException &&
+      error.name === "AbortError"
+    ) {
+      return true;
+    }
+    if (error instanceof Error) {
+      return (
+        error.name === "AbortError" ||
+        error.message.toLowerCase().includes("aborted")
+      );
+    }
+    return false;
+  };
+
   try {
     const response = await fetch(buildUrl(path, options?.query), {
       method,
@@ -85,6 +102,9 @@ async function request<T>(
     }
     return (await response.json()) as T;
   } catch (error) {
+    if (isAbortError(error)) {
+      throw error;
+    }
     if (error instanceof ApiError) {
       emitApiError({ title: error.title, message: error.message });
     } else {

--- a/web/src/services/api/notes.ts
+++ b/web/src/services/api/notes.ts
@@ -40,6 +40,7 @@ export interface TaskSummary {
   priority?: number | null;
   estimated_effort?: number | null;
   notes_count?: number;
+  timelogs_count?: number;
   actual_effort_total?: number | null;
   actual_effort_self?: number | null;
   planning_cycle_type?: string | null;

--- a/web/src/services/api/persons.ts
+++ b/web/src/services/api/persons.ts
@@ -75,6 +75,9 @@ export interface PersonActivityItem {
   description?: string | null;
   date: string;
   status?: string | null;
+  start_time?: string | null;
+  end_time?: string | null;
+  area_id?: UUID | null;
 }
 
 export type PersonActivityType = PersonActivityItem["type"];

--- a/web/src/services/api/tasks.ts
+++ b/web/src/services/api/tasks.ts
@@ -24,6 +24,7 @@ export interface Task {
   actual_effort_self: number;
   actual_effort_total: number;
   notes_count: number;
+  timelogs_count?: number;
   created_at: string;
   updated_at: string;
   deleted_at?: string | null;
@@ -333,10 +334,10 @@ export const tasksApi = {
     page: number = 1,
     size: number = 100,
   ): Promise<TimelogListResponse> {
-    return Promise.resolve({
-      items: [],
-      pagination: { page, size, total: 0, pages: 0 },
-      meta: { task_id: id },
+    return http.get<TimelogListResponse>(ENDPOINTS.TIMELOGS.BASE, {
+      task_id: id,
+      page,
+      size,
     });
   },
 };

--- a/web/src/utils/datetime/__tests__/datetime.test.ts
+++ b/web/src/utils/datetime/__tests__/datetime.test.ts
@@ -44,6 +44,17 @@ describe("datetime helpers", () => {
     expect(isoString).toBe("2024-05-15T06:45:00.000Z");
   });
 
+  it("keeps UTC+8 task quick-entry times on the selected local day", () => {
+    const baseDate = new Date("2026-07-02T09:00:00.000Z");
+
+    expect(hhmmOnDateToISO(baseDate, "17:00", "Asia/Shanghai")).toBe(
+      "2026-07-02T09:00:00.000Z",
+    );
+    expect(hhmmOnDateToISO(baseDate, "17:10", "Asia/Shanghai")).toBe(
+      "2026-07-02T09:10:00.000Z",
+    );
+  });
+
   it("formats datetime strings with explicit timezone", () => {
     const value = "2024-01-01T00:00:00.000Z";
     expect(formatDateTime(value, "Asia/Shanghai")).toBe("2024-01-01 08:00");

--- a/web/src/utils/query/__tests__/queryHelpers.test.ts
+++ b/web/src/utils/query/__tests__/queryHelpers.test.ts
@@ -7,6 +7,7 @@ import { normalizeTaskSelectorSourceFilters } from "@/services/api/taskFilters";
 import {
   removeTaskFromSelectorSourceCache,
   updateTaskCaches,
+  updateTaskRelationshipCounts,
 } from "@/utils/query";
 
 const createTask = (overrides?: Partial<Task>): Task => ({
@@ -112,5 +113,28 @@ describe("queryHelpers selector source cache syncing", () => {
     expect(hierarchyData?.root_tasks[0].subtasks?.[0].content).toBe(
       "Updated Child",
     );
+  });
+
+  it("normalizes task relationship count aliases when patching cache data", () => {
+    const taskId = "task-note-alias" as UUID;
+    const queryKey = ["task-alias-cache"];
+    const taskWithAlias = {
+      ...createTask({ id: taskId, notes_count: 0 }),
+      note_count: 2,
+    } as Task & { note_count: number };
+
+    queryClient.setQueryData(queryKey, { root_tasks: [taskWithAlias] });
+
+    updateTaskRelationshipCounts(queryClient, taskId, {
+      notes_count: (current) => current + 1,
+    });
+
+    const data = queryClient.getQueryData<{
+      root_tasks: Array<Task & { note_count?: number }>;
+    }>(queryKey);
+    const updatedTask = data?.root_tasks[0];
+
+    expect(updatedTask?.notes_count).toBe(3);
+    expect(updatedTask?.note_count).toBe(3);
   });
 });

--- a/web/src/utils/query/queryHelpers.ts
+++ b/web/src/utils/query/queryHelpers.ts
@@ -112,6 +112,123 @@ const upsertTaskInUnknownData = (data: unknown, task: Task): unknown => {
   return changed ? result : data;
 };
 
+type TaskRelationshipCountPatch = {
+  notes_count?: number | ((current: number) => number);
+  timelogs_count?: number | ((current: number) => number);
+};
+
+const resolveCountPatch = (
+  current: number | undefined,
+  patch: number | ((current: number) => number) | undefined,
+): number | undefined => {
+  if (patch === undefined) return current;
+  const currentValue = current ?? 0;
+  if (typeof patch === "function") {
+    return patch(currentValue);
+  }
+  return patch;
+};
+
+const patchTaskRelationshipCountsInValue = (
+  value: unknown,
+  taskId: UUID,
+  patch: TaskRelationshipCountPatch,
+): { result: unknown; changed: boolean } => {
+  if (value === null || value === undefined) {
+    return { result: value, changed: false };
+  }
+
+  if (Array.isArray(value)) {
+    let nextArray: unknown[] | null = null;
+    for (let i = 0; i < value.length; i += 1) {
+      const item = value[i];
+      const { result, changed } = patchTaskRelationshipCountsInValue(
+        item,
+        taskId,
+        patch,
+      );
+      if (changed && !nextArray) {
+        nextArray = value.slice(0, i);
+      }
+      if (nextArray) {
+        nextArray.push(result);
+      }
+    }
+    if (nextArray) {
+      return { result: nextArray, changed: true };
+    }
+    return { result: value, changed: false };
+  }
+
+  if (isTaskLike(value)) {
+    const originalTask = value as Task;
+    let nextTask: Task = originalTask;
+    let changed = false;
+
+    if (originalTask.id === taskId) {
+      const nextNotesCount = resolveCountPatch(
+        originalTask.notes_count,
+        patch.notes_count,
+      );
+      const nextTimelogsCount = resolveCountPatch(
+        originalTask.timelogs_count,
+        patch.timelogs_count,
+      );
+      nextTask = {
+        ...originalTask,
+        ...(nextNotesCount !== undefined ? { notes_count: nextNotesCount } : {}),
+        ...(nextTimelogsCount !== undefined
+          ? { timelogs_count: nextTimelogsCount }
+          : {}),
+      };
+      changed =
+        nextNotesCount !== originalTask.notes_count ||
+        nextTimelogsCount !== originalTask.timelogs_count;
+    }
+
+    let working: Record<string, unknown> | Task = nextTask;
+    Object.entries(nextTask).forEach(([key, child]) => {
+      const { result, changed: childChanged } =
+        patchTaskRelationshipCountsInValue(child, taskId, patch);
+      if (childChanged) {
+        if (working === nextTask) {
+          working = { ...nextTask };
+        }
+        (working as Record<string, unknown>)[key] = result;
+        changed = true;
+      }
+    });
+
+    if (changed) {
+      return { result: working as Task, changed: true };
+    }
+    return { result: value, changed: false };
+  }
+
+  if (isPlainObject(value)) {
+    let nextObject: Record<string, unknown> | null = null;
+    for (const [key, child] of Object.entries(value)) {
+      const { result, changed } = patchTaskRelationshipCountsInValue(
+        child,
+        taskId,
+        patch,
+      );
+      if (changed) {
+        if (!nextObject) {
+          nextObject = { ...(value as Record<string, unknown>) };
+        }
+        nextObject[key] = result;
+      }
+    }
+    if (nextObject) {
+      return { result: nextObject, changed: true };
+    }
+    return { result: value, changed: false };
+  }
+
+  return { result: value, changed: false };
+};
+
 const dataContainsTask = (value: unknown, taskId: UUID): boolean => {
   if (value === null || value === undefined) return false;
 
@@ -314,6 +431,31 @@ export const updateTaskCaches = (
   });
 
   syncSelectorSourceQueries(queryClient, task);
+};
+
+export const updateTaskRelationshipCounts = (
+  queryClient: QueryClient,
+  taskId: UUID,
+  patch: TaskRelationshipCountPatch,
+): void => {
+  if (!taskId) return;
+
+  const queries = queryClient.getQueryCache().findAll({
+    predicate: (query) => queryContainsTask(query as QueryLike, taskId),
+  }) as QueryLike[];
+
+  queries.forEach((query) => {
+    const currentData = query.state.data;
+    const { result, changed } = patchTaskRelationshipCountsInValue(
+      currentData,
+      taskId,
+      patch,
+    );
+    if (changed) {
+      const queryKey = query.queryKey as readonly unknown[];
+      queryClient.setQueryData(queryKey, result);
+    }
+  });
 };
 
 export const removeTaskFromSelectorSourceCache = (

--- a/web/src/utils/query/queryHelpers.ts
+++ b/web/src/utils/query/queryHelpers.ts
@@ -117,6 +117,26 @@ type TaskRelationshipCountPatch = {
   timelogs_count?: number | ((current: number) => number);
 };
 
+const readNumericCount = (
+  source: Record<string, unknown>,
+  keys: string[],
+): number | undefined => {
+  let count: number | undefined;
+  for (const key of keys) {
+    const value = source[key];
+    if (typeof value === "number" && Number.isFinite(value)) {
+      count = Math.max(count ?? 0, value);
+    }
+    if (typeof value === "string" && value.trim() !== "") {
+      const parsed = Number(value);
+      if (Number.isFinite(parsed)) {
+        count = Math.max(count ?? 0, parsed);
+      }
+    }
+  }
+  return count;
+};
+
 const resolveCountPatch = (
   current: number | undefined,
   patch: number | ((current: number) => number) | undefined,
@@ -166,24 +186,48 @@ const patchTaskRelationshipCountsInValue = (
     let changed = false;
 
     if (originalTask.id === taskId) {
+      const originalRecord = originalTask as unknown as Record<string, unknown>;
+      const originalNotesCount = readNumericCount(originalRecord, [
+        "notes_count",
+        "note_count",
+        "linked_notes_count",
+      ]);
+      const originalTimelogsCount = readNumericCount(originalRecord, [
+        "timelogs_count",
+        "timelog_count",
+      ]);
       const nextNotesCount = resolveCountPatch(
-        originalTask.notes_count,
+        originalNotesCount,
         patch.notes_count,
       );
       const nextTimelogsCount = resolveCountPatch(
-        originalTask.timelogs_count,
+        originalTimelogsCount,
         patch.timelogs_count,
       );
       nextTask = {
         ...originalTask,
         ...(nextNotesCount !== undefined ? { notes_count: nextNotesCount } : {}),
+        ...(nextNotesCount !== undefined && "note_count" in originalRecord
+          ? { note_count: nextNotesCount }
+          : {}),
+        ...(nextNotesCount !== undefined &&
+        "linked_notes_count" in originalRecord
+          ? { linked_notes_count: nextNotesCount }
+          : {}),
         ...(nextTimelogsCount !== undefined
           ? { timelogs_count: nextTimelogsCount }
           : {}),
+        ...(nextTimelogsCount !== undefined && "timelog_count" in originalRecord
+          ? { timelog_count: nextTimelogsCount }
+          : {}),
       };
       changed =
-        nextNotesCount !== originalTask.notes_count ||
-        nextTimelogsCount !== originalTask.timelogs_count;
+        nextNotesCount !== originalNotesCount ||
+        nextTimelogsCount !== originalTimelogsCount ||
+        (nextNotesCount !== undefined &&
+          originalTask.notes_count !== nextNotesCount) ||
+        (nextTimelogsCount !== undefined &&
+          originalTask.timelogs_count !== nextTimelogsCount);
     }
 
     let working: Record<string, unknown> | Task = nextTask;


### PR DESCRIPTION
## 变更概览

- 修复任务条相关 timelog 按钮点击后无法加载关联日志的问题：前端 `tasksApi.getTimelogs` 改为通过现有 timelog 列表接口按 `task_id` 查询。
- 为任务列表/层级 payload 增加轻量派生计数 `notes_count` 与 `timelogs_count`，任务条按钮只依赖计数点亮，不预先消费完整关联数据。
- 修复任务条相关 note 按钮未点亮的问题：后端任务关系计数改为按 note-task `relates_to` 关联计数；前端读取任务关系计数时兼容 `notes_count`、`note_count`、`linked_notes_count` 等摘要别名，缓存补丁也同步这些别名。
- 修复 `notes/?task_id=...` 查询中的 SQLAlchemy 笛卡尔积 warning，补齐 association 与目标表的 join 条件。
- 新建 note / timelog 后即时更新任务缓存计数，让任务条按钮能立即恢复点亮，再通过查询失效校准真实数据；新建 note 的 task summary 同步顺序调整为先合并摘要、再增加 note 计数，避免旧摘要覆盖点亮状态。
- 任务条操作按钮不再使用“更多操作”收起菜单，全部按钮直接展示，避免菜单 tips 被任务条裁切或只多一个按钮却被收起。
- 新增任务条 timelog 快捷添加按钮，位置在相关 note 按钮右侧、查看 timelog 按钮左侧；弹窗复用 timelog 页快速添加容器，并自动锁定当前任务。
- 快捷添加 timelog 时只把最新关联 timelog 的结束时间作为默认开始时间，结束时间保持空白，由用户填写。
- 优化任务相关时间日志模态框：标题改为“时间日志 / Time Logs”，列表按页请求并显示翻页控件，领域通过 `area_id` 兜底映射，领域字号与其它列一致，时间段前不再显示 timer 图标。
- 任务相关时间日志模态框改为自适应最大高度并默认每页 15 条，列表内部滚动，避免数据多时遮挡导航栏或小屏下方区域。
- 优化 people 活动时间线中的 timelog 展示：类型文案改为“时间日志 / Time Logs”，不再显示 `manual` tracking method；timelog 详情显示日期、开始-结束时间、时长、领域与行为描述。
- 修复 people 活动时间线中 note 内容重复渲染：后端 note activity 不再把同一内容同时放入 title 和 description；前端也会跳过 title/description 完全相同的 note 描述行，并且 person-note 查询按 `is_about` 去重。
- people 活动时间线滚动区从固定 `48rem` 改为视口自适应最大高度，数据少时不再强行占满高度。
- API client 对主动取消的请求不再触发全局错误提示，避免编辑/切换相关笔记时出现 `signal is aborted without reason`。
- 清理本分支引入的冗余状态更新与中文注释；全仓 dead-code 扫描无高确信可删项。

## 根因

- `tasksApi.getTimelogs()` 原先返回空占位数据，未请求后端，因此相关 timelog 弹窗始终显示为空。
- 后端任务树 payload 中 `notes_count` 曾写死为 `0`；随后任务关系计数又误用了 note-timelog 的 `captured_from`，但 note 关联 task 的真实 link type 是 `relates_to`，导致已有关联笔记的任务条仍无法点亮。
- `notes/?task_id=...` 的 exists 子查询检查目标 task 是否存在，但缺少 `Association.target_id == Task.id` 条件，因此会产生 SQLAlchemy cartesian product warning。
- 任务条 note 按钮只读取 `notes_count`，但部分缓存/摘要路径可能携带其它 note 计数字段或旧摘要；新建 note 后的 task summary 同步也可能覆盖刚写入的轻量计数。
- React Query 在筛选切换、弹窗关闭或编辑后刷新时会取消旧请求；这些 AbortError 被 API client 当作普通错误广播，导致界面出现无业务意义的 abort 提示。
- 任务条快捷 timelog 弹窗曾把最新结束时间同时传给开始/结束输入；底层快速添加组件在空结束时间路径上会把空字符串合成为当天 `00:00`，容易造成不符合用户预期的结束时间与时区表现。
- 任务时间日志列表固定只取前 100 条，且只依赖 `area_summary.name`；当前 timelog API 返回的 `area_summary` 可能只有 id，因此领域会落到“未分配领域”。
- 任务时间日志模态框此前一次渲染 50 条，内容高度会撑满弹窗；people 活动时间线使用固定 `48rem`，两者在小屏或数据多时都缺少足够上下留白。
- people 活动时间线把 timelog 的 `tracking_method` 复用到通用 `status` 字段，导致界面显示 `manual`，且缺少 timelog 专属时间段/时长/领域字段。
- people note activity 曾把 note content 同时作为 title 和 description 返回，前端又按标题行和描述行渲染，因此同一条笔记显示两次；person-note 查询也未限定 `is_about` link type，存在重复候选风险。

## Issue 关系

- 无关联 issue；本次按协作要求未新建 issue。

## 验证

- `npm run build`
- `npm run lint`
- `npm test -- --run src/services/api/__tests__/tasks.test.ts`
- `npm test -- --run src/services/api/__tests__/client.test.ts src/utils/query/__tests__/queryHelpers.test.ts`
- `npm test -- --run src/components/__tests__/TaskTimelogQuickAddModal.test.tsx src/utils/datetime/__tests__/datetime.test.ts`
- `npm test -- --run src/components/__tests__/TaskTimelogsModal.test.tsx src/components/__tests__/PersonTimelineModal.test.tsx`
- `npm test -- --run src/components/__tests__/TaskTimelogsModal.test.tsx src/components/__tests__/PersonTimelineModal.test.tsx src/components/__tests__/TaskTimelogQuickAddModal.test.tsx src/utils/datetime/__tests__/datetime.test.ts`
- `.venv/bin/python -m pytest tests/test_note_services.py tests/test_web_cli.py -q`
- `.venv/bin/python -m pytest tests/test_web_cli.py -q`
- `bash ./scripts/dead_code_check.sh`
- `bash ./scripts/doctor.sh`

说明：`doctor.sh` 完整通过；PostgreSQL CLI integration 因未设置 `LIFEOS_TEST_DATABASE_URL` 按脚本设计跳过。
