### PR TITLE
feat: Support flexible habit recurrence

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,21 +133,21 @@
         "filename": "src/lifeos_cli/locales/en/cli_messages.json",
         "hashed_secret": "49db5cedcbe4d24c102d1c9212c0aeed9d71b528",
         "is_verified": false,
-        "line_number": 875
+        "line_number": 878
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lifeos_cli/locales/en/cli_messages.json",
         "hashed_secret": "d7c832c06c94ed9bfadd601d7a1ca12551261433",
         "is_verified": false,
-        "line_number": 883
+        "line_number": 886
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lifeos_cli/locales/en/cli_messages.json",
         "hashed_secret": "cd6ace16b1f2ff3150b89368ac9df7c86b78ea50",
         "is_verified": false,
-        "line_number": 884
+        "line_number": 887
       }
     ],
     "src/lifeos_cli/locales/zh_Hans/cli_messages.json": [
@@ -156,7 +156,7 @@
         "filename": "src/lifeos_cli/locales/zh_Hans/cli_messages.json",
         "hashed_secret": "5a59e0d7fb6e3aa28246673b01fd19d3e3f3f009",
         "is_verified": false,
-        "line_number": 875
+        "line_number": 878
       }
     ],
     "web/src/features/auth/__tests__/ChangePasswordCard.test.tsx": [
@@ -233,5 +233,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-01T11:08:14Z"
+  "generated_at": "2026-07-03T07:02:41Z"
 }

--- a/src/lifeos_cli/alembic/versions/20260703_0900_add_habit_monthday_cadence.py
+++ b/src/lifeos_cli/alembic/versions/20260703_0900_add_habit_monthday_cadence.py
@@ -1,0 +1,30 @@
+"""Add monthday cadence selectors to habits."""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260703_0900"
+down_revision = "20260629_1000"
+branch_labels = None
+depends_on = None
+
+
+def _schema_name() -> str | None:
+    context = op.get_context()
+    return context.version_table_schema
+
+
+def upgrade() -> None:
+    schema_name = _schema_name()
+
+    with op.batch_alter_table("habits", schema=schema_name) as batch_op:
+        batch_op.add_column(sa.Column("cadence_monthdays", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    schema_name = _schema_name()
+
+    with op.batch_alter_table("habits", schema=schema_name) as batch_op:
+        batch_op.drop_column("cadence_monthdays")

--- a/src/lifeos_cli/alembic/versions/20260704_1100_add_habit_status_changed_date.py
+++ b/src/lifeos_cli/alembic/versions/20260704_1100_add_habit_status_changed_date.py
@@ -1,0 +1,49 @@
+"""Add habit status change date."""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260704_1100"
+down_revision = "20260703_0900"
+branch_labels = None
+depends_on = None
+
+
+def _schema_name() -> str | None:
+    context = op.get_context()
+    return context.version_table_schema
+
+
+def upgrade() -> None:
+    schema_name = _schema_name()
+
+    with op.batch_alter_table("habits", schema=schema_name) as batch_op:
+        batch_op.add_column(sa.Column("status_changed_date", sa.Date(), nullable=True))
+
+    habits_table = sa.table(
+        "habits",
+        sa.column("status", sa.String()),
+        sa.column("start_date", sa.Date()),
+        sa.column("updated_at", sa.DateTime(timezone=True)),
+        sa.column("status_changed_date", sa.Date()),
+        schema=schema_name,
+    )
+    op.execute(
+        habits_table.update()
+        .where(habits_table.c.status == "active")
+        .values(status_changed_date=habits_table.c.start_date)
+    )
+    op.execute(
+        habits_table.update()
+        .where(habits_table.c.status != "active")
+        .values(status_changed_date=sa.func.date(habits_table.c.updated_at))
+    )
+
+
+def downgrade() -> None:
+    schema_name = _schema_name()
+
+    with op.batch_alter_table("habits", schema=schema_name) as batch_op:
+        batch_op.drop_column("status_changed_date")

--- a/src/lifeos_cli/cli_support/resources/habit/handlers.py
+++ b/src/lifeos_cli/cli_support/resources/habit/handlers.py
@@ -60,11 +60,22 @@ def _format_cadence_weekdays(habit: Habit) -> str:
     return ",".join(str(weekday) for weekday in weekdays)
 
 
+def _format_cadence_monthdays(habit: Habit) -> str:
+    monthdays = getattr(habit, "cadence_monthdays", None)
+    if not monthdays:
+        return "-"
+    return ",".join(str(monthday) for monthday in monthdays)
+
+
 def _format_habit_cadence(habit: Habit) -> str:
     cadence_frequency = getattr(habit, "cadence_frequency", "daily")
     target_per_cycle = getattr(habit, "target_per_cycle", 1)
     cadence_weekdays = _format_cadence_weekdays(habit)
-    return f"{cadence_frequency}:{target_per_cycle}:{cadence_weekdays}"
+    cadence_monthdays = _format_cadence_monthdays(habit)
+    cadence = f"{cadence_frequency}:{target_per_cycle}:{cadence_weekdays}"
+    if cadence_monthdays == "-":
+        return cadence
+    return f"{cadence}:monthdays={cadence_monthdays}"
 
 
 def _format_habit_summary(habit: Habit) -> str:
@@ -97,6 +108,7 @@ def _format_habit_detail(habit: Habit, stats: dict[str, object]) -> str:
             f"duration_days: {habit.duration_days}",
             f"cadence_frequency: {getattr(habit, 'cadence_frequency', 'daily')}",
             f"cadence_weekdays: {_format_cadence_weekdays(habit)}",
+            f"cadence_monthdays: {_format_cadence_monthdays(habit)}",
             f"target_per_cycle: {getattr(habit, 'target_per_cycle', 1)}",
             f"task_id: {habit.task_id or '-'}",
             f"progress_percentage: {stats['progress_percentage']:.1f}",
@@ -131,11 +143,16 @@ def _extract_habit_overview(overview: dict[str, object]) -> tuple[Habit, dict[st
 def _format_habit_stats(stats: dict[str, object]) -> str:
     cadence_weekdays = cast(tuple[str, ...] | None, stats["cadence_weekdays"])
     cadence_weekdays_text = "-" if not cadence_weekdays else ",".join(cadence_weekdays)
+    cadence_monthdays = cast(tuple[int, ...] | None, stats["cadence_monthdays"])
+    cadence_monthdays_text = (
+        "-" if not cadence_monthdays else ",".join(str(day) for day in cadence_monthdays)
+    )
     return "\n".join(
         (
             f"habit_id: {stats['habit_id']}",
             f"cadence_frequency: {stats['cadence_frequency']}",
             f"cadence_weekdays: {cadence_weekdays_text}",
+            f"cadence_monthdays: {cadence_monthdays_text}",
             f"target_per_cycle: {stats['target_per_cycle']}",
             f"total_actions: {stats['total_actions']}",
             f"completed_actions: {stats['completed_actions']}",
@@ -166,6 +183,7 @@ async def handle_habit_add_async(args: argparse.Namespace) -> int:
                 duration_days=args.duration_days,
                 cadence_frequency=args.cadence_frequency,
                 cadence_weekdays=_resolve_weekday_selection(args),
+                cadence_monthdays=args.monthdays,
                 target_per_cycle=args.target_per_cycle,
                 task_id=args.task_id,
             )
@@ -272,6 +290,11 @@ async def handle_habit_update_async(args: argparse.Namespace) -> int:
             "--weekdays / --weekends-only",
             "--clear-weekdays",
         ),
+        (
+            args.clear_monthdays and args.monthdays is not None,
+            "--monthdays",
+            "--clear-monthdays",
+        ),
     )
     conflict_error = cli_handler_utils.validate_mutually_exclusive_pairs(conflicts)
     if conflict_error is not None:
@@ -289,6 +312,8 @@ async def handle_habit_update_async(args: argparse.Namespace) -> int:
                 cadence_frequency=args.cadence_frequency,
                 cadence_weekdays=_resolve_weekday_selection(args),
                 clear_weekdays=args.clear_weekdays,
+                cadence_monthdays=args.monthdays,
+                clear_monthdays=args.clear_monthdays,
                 target_per_cycle=args.target_per_cycle,
                 status=args.status,
                 task_id=args.task_id,

--- a/src/lifeos_cli/cli_support/resources/habit/parser_actions.py
+++ b/src/lifeos_cli/cli_support/resources/habit/parser_actions.py
@@ -46,6 +46,21 @@ def _parse_habit_weekdays(value: str) -> list[str]:
     return weekdays
 
 
+def _parse_habit_monthdays(value: str) -> list[int]:
+    """Parse one CLI monthday list into integer day numbers."""
+    parts = [part for part in _WEEKDAY_SPLIT_PATTERN.split(value.strip()) if part]
+    if not parts:
+        raise argparse.ArgumentTypeError("Expected at least one month day, for example `1,15,28`.")
+    monthdays: list[int] = []
+    for part in parts:
+        try:
+            monthday = int(part)
+        except ValueError as exc:
+            raise argparse.ArgumentTypeError("Month days must be integers.") from exc
+        monthdays.append(monthday)
+    return monthdays
+
+
 def build_habit_add_parser(
     habit_subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
 ) -> None:
@@ -65,6 +80,8 @@ def build_habit_add_parser(
                 'lifeos habit add "Gym" --start-date 2026-04-09 --duration-days 100 '
                 "--cadence-frequency weekly --weekdays monday,wednesday,friday "
                 "--target-per-week 3",
+                'lifeos habit add "Monthly cleanup" --start-date 2026-04-09 --duration-days 365 '
+                "--cadence-frequency monthly --monthdays 1,15 --target-per-cycle 2",
                 'lifeos habit add "Read annual plan" --start-date 2026-01-01 --duration-days 365 '
                 "--cadence-frequency yearly --target-per-cycle 6",
             ),
@@ -116,6 +133,11 @@ def build_habit_add_parser(
         "--weekends-only",
         action="store_true",
         help=_("resources.habit.parser_actions.shortcut_for_weekdays_saturday_sunday"),
+    )
+    add_parser.add_argument(
+        "--monthdays",
+        type=_parse_habit_monthdays,
+        help=_("resources.habit.parser_actions.allowed_monthdays_for_example_1_15_28"),
     )
     add_parser.add_argument(
         "--target-per-cycle",
@@ -249,8 +271,9 @@ def build_habit_update_parser(
                 "lifeos habit update 11111111-1111-1111-1111-111111111111 "
                 "--cadence-frequency weekly --weekends-only --target-per-week 1",
                 "lifeos habit update 11111111-1111-1111-1111-111111111111 "
-                "--cadence-frequency monthly --target-per-cycle 2",
+                "--cadence-frequency monthly --monthdays 1,15 --target-per-cycle 2",
                 "lifeos habit update 11111111-1111-1111-1111-111111111111 --clear-weekdays",
+                "lifeos habit update 11111111-1111-1111-1111-111111111111 --clear-monthdays",
                 "lifeos habit update 11111111-1111-1111-1111-111111111111 --clear-task",
             ),
             notes=(
@@ -310,6 +333,16 @@ def build_habit_update_parser(
         "--clear-weekdays",
         action="store_true",
         help=_("resources.habit.parser_actions.remove_weekday_restrictions_from_habit_cadence"),
+    )
+    update_parser.add_argument(
+        "--monthdays",
+        type=_parse_habit_monthdays,
+        help=_("resources.habit.parser_actions.updated_allowed_monthdays_for_example_1_15_28"),
+    )
+    update_parser.add_argument(
+        "--clear-monthdays",
+        action="store_true",
+        help=_("resources.habit.parser_actions.remove_monthday_restrictions_from_habit_cadence"),
     )
     update_parser.add_argument(
         "--target-per-cycle",

--- a/src/lifeos_cli/db/models/habit.py
+++ b/src/lifeos_cli/db/models/habit.py
@@ -29,6 +29,7 @@ class Habit(UUIDPrimaryKeyMixin, TimestampedMixin, SoftDeleteMixin, Base):
     duration_days: Mapped[int] = mapped_column(Integer, nullable=False)
     cadence_frequency: Mapped[str] = mapped_column(String(16), nullable=False, default="daily")
     cadence_weekdays: Mapped[list[str] | None] = mapped_column(JSON, nullable=True)
+    cadence_monthdays: Mapped[list[int] | None] = mapped_column(JSON, nullable=True)
     target_per_cycle: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
     status: Mapped[str] = mapped_column(String(20), nullable=False, default="active")
     task_id: Mapped[UUID | None] = mapped_column(

--- a/src/lifeos_cli/db/models/habit.py
+++ b/src/lifeos_cli/db/models/habit.py
@@ -32,6 +32,7 @@ class Habit(UUIDPrimaryKeyMixin, TimestampedMixin, SoftDeleteMixin, Base):
     cadence_monthdays: Mapped[list[int] | None] = mapped_column(JSON, nullable=True)
     target_per_cycle: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
     status: Mapped[str] = mapped_column(String(20), nullable=False, default="active")
+    status_changed_date: Mapped[date | None] = mapped_column(Date, nullable=True)
     task_id: Mapped[UUID | None] = mapped_column(
         Uuid,
         ForeignKey("tasks.id", ondelete="SET NULL"),

--- a/src/lifeos_cli/db/services/data_ops.py
+++ b/src/lifeos_cli/db/services/data_ops.py
@@ -867,8 +867,11 @@ def _batch_update_habit_kwargs(payload: dict[str, Any]) -> dict[str, Any]:
         "title",
         "start_date",
         "duration_days",
+        "end_date",
+        "repeat_count",
         "cadence_frequency",
         "cadence_weekdays",
+        "cadence_monthdays",
         "target_per_cycle",
         "status",
     ):
@@ -878,6 +881,8 @@ def _batch_update_habit_kwargs(payload: dict[str, Any]) -> dict[str, Any]:
     kwargs.update(_null_means_clear(payload, field="task_id", clear_flag="clear_task"))
     if "cadence_weekdays" in payload and payload["cadence_weekdays"] is None:
         kwargs["clear_weekdays"] = True
+    if "cadence_monthdays" in payload and payload["cadence_monthdays"] is None:
+        kwargs["clear_monthdays"] = True
     return kwargs
 
 

--- a/src/lifeos_cli/db/services/habit_mutations.py
+++ b/src/lifeos_cli/db/services/habit_mutations.py
@@ -29,6 +29,7 @@ from lifeos_cli.db.services.habit_support import (
     calculate_habit_duration_for_repeat_count,
     ensure_active_capacity,
     ensure_task_exists,
+    get_habit_occurrence_end_date,
     habit_occurs_on_date,
     refresh_habit_expiration,
     validate_habit_action_status,
@@ -95,6 +96,7 @@ async def create_habit(
         ),
         target_per_cycle=normalized_target_per_cycle,
         status="active",
+        status_changed_date=start_date,
         task_id=task_id,
     )
     session.add(habit)
@@ -213,6 +215,8 @@ async def update_habit(
         normalized_status = validate_habit_status(status)
         if normalized_status == "active" and habit.status != "active":
             await ensure_active_capacity(session, exclude_habit_id=habit.id)
+        if normalized_status != habit.status:
+            habit.status_changed_date = get_operational_date()
         habit.status = normalized_status
 
     if schedule_changed:
@@ -294,6 +298,17 @@ async def update_habit_action_by_date(
     habit = await get_habit(session, habit_id=habit_id)
     if habit is None:
         raise HabitNotFoundError(f"Habit {habit_id} was not found")
+    if not habit_occurs_on_date(
+        start_date=habit.start_date,
+        end_date=get_habit_occurrence_end_date(habit),
+        cadence_frequency=habit.cadence_frequency,
+        cadence_weekdays=habit.cadence_weekdays,
+        cadence_monthdays=habit.cadence_monthdays,
+        target_date=action_date,
+    ):
+        raise HabitActionNotFoundError(
+            f"Habit action for habit {habit.id} on {action_date} was not found"
+        )
     action = (
         await session.execute(
             select(HabitAction).where(
@@ -324,7 +339,7 @@ async def _soft_delete_unscheduled_habit_actions(session: AsyncSession, habit: H
     for action in existing_actions:
         if not habit_occurs_on_date(
             start_date=habit.start_date,
-            end_date=habit.end_date,
+            end_date=get_habit_occurrence_end_date(habit),
             cadence_frequency=habit.cadence_frequency,
             cadence_weekdays=habit.cadence_weekdays,
             cadence_monthdays=habit.cadence_monthdays,

--- a/src/lifeos_cli/db/services/habit_mutations.py
+++ b/src/lifeos_cli/db/services/habit_mutations.py
@@ -24,7 +24,9 @@ from lifeos_cli.db.services.habit_support import (
     HABIT_EDITABLE_DAYS,
     HabitActionNotFoundError,
     HabitNotFoundError,
+    HabitValidationError,
     InvalidHabitOperationError,
+    calculate_habit_duration_for_repeat_count,
     ensure_active_capacity,
     ensure_task_exists,
     habit_occurs_on_date,
@@ -32,6 +34,7 @@ from lifeos_cli.db.services.habit_support import (
     validate_habit_action_status,
     validate_habit_cadence,
     validate_habit_duration,
+    validate_habit_end_date,
     validate_habit_schedule_window,
     validate_habit_start_date,
     validate_habit_status,
@@ -44,24 +47,37 @@ async def create_habit(
     title: str,
     description: str | None = None,
     start_date: date,
-    duration_days: int,
+    duration_days: int | None = None,
+    end_date: date | None = None,
+    repeat_count: int | None = None,
     cadence_frequency: str | None = None,
     cadence_weekdays: Sequence[str] | None = None,
+    cadence_monthdays: Sequence[object] | None = None,
     target_per_cycle: int | None = None,
     task_id: UUID | None = None,
 ) -> Habit:
     """Create a new habit without pre-generating dated action rows."""
     normalized_title = title.strip()
     validate_habit_start_date(start_date)
-    validate_habit_duration(duration_days)
     (
         normalized_cadence_frequency,
         normalized_cadence_weekdays,
+        normalized_cadence_monthdays,
         normalized_target_per_cycle,
     ) = validate_habit_cadence(
         cadence_frequency=cadence_frequency,
         cadence_weekdays=cadence_weekdays,
+        cadence_monthdays=cadence_monthdays,
         target_per_cycle=target_per_cycle,
+    )
+    normalized_duration_days = _resolve_habit_duration_days(
+        start_date=start_date,
+        duration_days=duration_days,
+        end_date=end_date,
+        repeat_count=repeat_count,
+        cadence_frequency=normalized_cadence_frequency,
+        cadence_weekdays=normalized_cadence_weekdays,
+        cadence_monthdays=normalized_cadence_monthdays,
     )
     await ensure_active_capacity(session)
     await ensure_task_exists(session, task_id)
@@ -69,10 +85,13 @@ async def create_habit(
         title=normalized_title,
         description=description,
         start_date=start_date,
-        duration_days=duration_days,
+        duration_days=normalized_duration_days,
         cadence_frequency=normalized_cadence_frequency,
         cadence_weekdays=(
             None if normalized_cadence_weekdays is None else list(normalized_cadence_weekdays)
+        ),
+        cadence_monthdays=(
+            None if normalized_cadence_monthdays is None else list(normalized_cadence_monthdays)
         ),
         target_per_cycle=normalized_target_per_cycle,
         status="active",
@@ -85,6 +104,7 @@ async def create_habit(
         end_date=habit.end_date,
         cadence_frequency=habit.cadence_frequency,
         cadence_weekdays=habit.cadence_weekdays,
+        cadence_monthdays=habit.cadence_monthdays,
     )
     await refresh_habit_expiration(session, habit_id=habit.id)
     await session.refresh(habit)
@@ -100,9 +120,13 @@ async def update_habit(
     clear_description: bool = False,
     start_date: date | None = None,
     duration_days: int | None = None,
+    end_date: date | None = None,
+    repeat_count: int | None = None,
     cadence_frequency: str | None = None,
     cadence_weekdays: Sequence[str] | None = None,
     clear_weekdays: bool = False,
+    cadence_monthdays: Sequence[object] | None = None,
+    clear_monthdays: bool = False,
     target_per_cycle: int | None = None,
     status: str | None = None,
     task_id: UUID | None = None,
@@ -125,35 +149,60 @@ async def update_habit(
         validate_habit_start_date(start_date)
         habit.start_date = start_date
         schedule_changed = True
-    if duration_days is not None:
-        habit.duration_days = validate_habit_duration(duration_days)
-        schedule_changed = True
     if clear_weekdays:
         next_cadence_weekdays: Sequence[str] | None = None
     elif cadence_weekdays is not None:
         next_cadence_weekdays = cadence_weekdays
     else:
         next_cadence_weekdays = getattr(habit, "cadence_weekdays", None)
+    if clear_monthdays:
+        next_cadence_monthdays: Sequence[object] | None = None
+    elif cadence_monthdays is not None:
+        next_cadence_monthdays = cadence_monthdays
+    else:
+        next_cadence_monthdays = getattr(habit, "cadence_monthdays", None)
     if (
         cadence_frequency is not None
         or cadence_weekdays is not None
         or clear_weekdays
+        or cadence_monthdays is not None
+        or clear_monthdays
         or target_per_cycle is not None
     ):
         (
             normalized_cadence_frequency,
             normalized_cadence_weekdays,
+            normalized_cadence_monthdays,
             normalized_target_per_cycle,
         ) = validate_habit_cadence(
             cadence_frequency=cadence_frequency or getattr(habit, "cadence_frequency", None),
             cadence_weekdays=next_cadence_weekdays,
-            target_per_cycle=target_per_cycle or getattr(habit, "target_per_cycle", None),
+            cadence_monthdays=next_cadence_monthdays,
+            target_per_cycle=(
+                target_per_cycle
+                if target_per_cycle is not None
+                else getattr(habit, "target_per_cycle", None)
+            ),
         )
         habit.cadence_frequency = normalized_cadence_frequency
         habit.cadence_weekdays = (
             None if normalized_cadence_weekdays is None else list(normalized_cadence_weekdays)
         )
+        habit.cadence_monthdays = (
+            None if normalized_cadence_monthdays is None else list(normalized_cadence_monthdays)
+        )
         habit.target_per_cycle = normalized_target_per_cycle
+        schedule_changed = True
+    if duration_days is not None or end_date is not None or repeat_count is not None:
+        habit.duration_days = _resolve_habit_duration_days(
+            start_date=habit.start_date,
+            duration_days=duration_days,
+            end_date=end_date,
+            repeat_count=repeat_count,
+            cadence_frequency=habit.cadence_frequency,
+            cadence_weekdays=habit.cadence_weekdays,
+            cadence_monthdays=habit.cadence_monthdays,
+        )
         schedule_changed = True
     if clear_task:
         habit.task_id = None
@@ -172,6 +221,7 @@ async def update_habit(
             end_date=habit.end_date,
             cadence_frequency=habit.cadence_frequency,
             cadence_weekdays=habit.cadence_weekdays,
+            cadence_monthdays=habit.cadence_monthdays,
         )
         await _soft_delete_unscheduled_habit_actions(session, habit)
 
@@ -275,7 +325,9 @@ async def _soft_delete_unscheduled_habit_actions(session: AsyncSession, habit: H
         if not habit_occurs_on_date(
             start_date=habit.start_date,
             end_date=habit.end_date,
+            cadence_frequency=habit.cadence_frequency,
             cadence_weekdays=habit.cadence_weekdays,
+            cadence_monthdays=habit.cadence_monthdays,
             target_date=action.action_date,
         ):
             action.deleted_at = utc_now()
@@ -288,3 +340,36 @@ async def _load_active_actions(session: AsyncSession, habit: Habit) -> list[Habi
         HabitAction.deleted_at.is_(None),
     )
     return list((await session.execute(stmt)).scalars())
+
+
+def _resolve_habit_duration_days(
+    *,
+    start_date: date,
+    duration_days: int | None,
+    end_date: date | None,
+    repeat_count: int | None,
+    cadence_frequency: str,
+    cadence_weekdays: Sequence[str] | None,
+    cadence_monthdays: Sequence[object] | None,
+) -> int:
+    provided_modes = [
+        duration_days is not None,
+        end_date is not None,
+        repeat_count is not None,
+    ]
+    if sum(provided_modes) != 1:
+        raise HabitValidationError(
+            "Provide exactly one of duration_days, end_date, or repeat_count."
+        )
+    if duration_days is not None:
+        return validate_habit_duration(duration_days)
+    if end_date is not None:
+        return validate_habit_end_date(start_date=start_date, end_date=end_date)
+    assert repeat_count is not None
+    return calculate_habit_duration_for_repeat_count(
+        start_date=start_date,
+        repeat_count=repeat_count,
+        cadence_frequency=cadence_frequency,
+        cadence_weekdays=cadence_weekdays,
+        cadence_monthdays=cadence_monthdays,
+    )

--- a/src/lifeos_cli/db/services/habit_queries.py
+++ b/src/lifeos_cli/db/services/habit_queries.py
@@ -109,7 +109,9 @@ async def _materialize_habit_action_for_date(
     if not habit_occurs_on_date(
         start_date=habit.start_date,
         end_date=habit.end_date,
-        cadence_weekdays=habit.cadence_weekdays,
+        cadence_frequency=getattr(habit, "cadence_frequency", "daily"),
+        cadence_weekdays=getattr(habit, "cadence_weekdays", None),
+        cadence_monthdays=getattr(habit, "cadence_monthdays", None),
         target_date=action_date,
     ):
         raise HabitActionNotFoundError(
@@ -144,7 +146,9 @@ def _iter_habit_window_dates(
         if habit_occurs_on_date(
             start_date=habit.start_date,
             end_date=habit.end_date,
-            cadence_weekdays=habit.cadence_weekdays,
+            cadence_frequency=getattr(habit, "cadence_frequency", "daily"),
+            cadence_weekdays=getattr(habit, "cadence_weekdays", None),
+            cadence_monthdays=getattr(habit, "cadence_monthdays", None),
             target_date=current_date,
         )
     ]
@@ -301,7 +305,9 @@ async def _build_habit_action_views(
                 if habit_occurs_on_date(
                     start_date=habit.start_date,
                     end_date=habit.end_date,
-                    cadence_weekdays=habit.cadence_weekdays,
+                    cadence_frequency=getattr(habit, "cadence_frequency", "daily"),
+                    cadence_weekdays=getattr(habit, "cadence_weekdays", None),
+                    cadence_monthdays=getattr(habit, "cadence_monthdays", None),
                     target_date=target_date,
                 )
             ]

--- a/src/lifeos_cli/db/services/habit_queries.py
+++ b/src/lifeos_cli/db/services/habit_queries.py
@@ -185,6 +185,7 @@ async def _load_candidate_habits(
     *,
     habit_id: UUID | None,
     action_window: tuple[date, date] | None,
+    habit_status: str | None = None,
     target_dates: tuple[date, ...] = (),
 ) -> list[Habit]:
     if habit_id is not None:
@@ -195,6 +196,8 @@ async def _load_candidate_habits(
 
     stmt = select(Habit).options(_active_habit_task_loader())
     stmt = stmt.where(Habit.deleted_at.is_(None))
+    if habit_status is not None:
+        stmt = stmt.where(Habit.status == validate_habit_status(habit_status))
     if target_dates:
         habit_end_expr = _habit_end_expr()
         stmt = stmt.where(
@@ -263,12 +266,14 @@ async def _build_habit_action_views(
     habit_id: UUID | None,
     status: str | None,
     action_window: tuple[date, date] | None,
+    habit_status: str | None = None,
     target_dates: tuple[date, ...] = (),
 ) -> list[HabitActionView]:
     normalized_target_dates = tuple(deduplicate_preserving_order(target_dates))
     habits = await _load_candidate_habits(
         session,
         habit_id=habit_id,
+        habit_status=habit_status,
         action_window=action_window,
         target_dates=normalized_target_dates,
     )
@@ -410,6 +415,7 @@ async def get_habit_stats(session: AsyncSession, *, habit_id: UUID) -> dict[str,
     actions = await _build_habit_action_views(
         session,
         habit_id=habit.id,
+        habit_status=None,
         status=None,
         action_window=None,
     )
@@ -428,6 +434,7 @@ async def get_habit_overview(
     actions = await _build_habit_action_views(
         session,
         habit_id=habit.id,
+        habit_status=None,
         status=None,
         action_window=None,
     )
@@ -462,6 +469,7 @@ async def list_habit_overviews(
         actions = await _build_habit_action_views(
             session,
             habit_id=habit.id,
+            habit_status=None,
             status=None,
             action_window=None,
         )
@@ -501,6 +509,7 @@ async def list_habit_actions(
     session: AsyncSession,
     *,
     habit_id: UUID | None = None,
+    habit_status: str | None = None,
     status: str | None = None,
     date_values: tuple[date, ...] = (),
     start_date: date | None = None,
@@ -509,6 +518,8 @@ async def list_habit_actions(
     offset: int = 0,
 ) -> list[HabitActionView]:
     """List habit-action occurrence views with optional filters."""
+    if habit_status is not None and validate_habit_status(habit_status) == "active":
+        await refresh_habit_expiration(session)
     target_dates = tuple(deduplicate_preserving_order(date_values))
     action_window = (
         None if target_dates else _normalize_action_window(start_date=start_date, end_date=end_date)
@@ -516,6 +527,7 @@ async def list_habit_actions(
     views = await _build_habit_action_views(
         session,
         habit_id=habit_id,
+        habit_status=habit_status,
         status=status,
         action_window=action_window,
         target_dates=target_dates,
@@ -573,6 +585,7 @@ async def list_habit_actions_in_range(
     views = await _build_habit_action_views(
         session,
         habit_id=None,
+        habit_status=None,
         status=None,
         action_window=(start_date, end_date),
     )
@@ -583,12 +596,15 @@ async def count_habit_actions(
     session: AsyncSession,
     *,
     habit_id: UUID | None = None,
+    habit_status: str | None = None,
     status: str | None = None,
     date_values: tuple[date, ...] = (),
     start_date: date | None = None,
     end_date: date | None = None,
 ) -> int:
     """Count habit-action occurrence views with the same filters used by list_habit_actions."""
+    if habit_status is not None and validate_habit_status(habit_status) == "active":
+        await refresh_habit_expiration(session)
     target_dates = tuple(deduplicate_preserving_order(date_values))
     action_window = (
         None if target_dates else _normalize_action_window(start_date=start_date, end_date=end_date)
@@ -596,6 +612,7 @@ async def count_habit_actions(
     views = await _build_habit_action_views(
         session,
         habit_id=habit_id,
+        habit_status=habit_status,
         status=status,
         action_window=action_window,
         target_dates=target_dates,

--- a/src/lifeos_cli/db/services/habit_queries.py
+++ b/src/lifeos_cli/db/services/habit_queries.py
@@ -21,6 +21,7 @@ from lifeos_cli.db.services.habit_support import (
     HabitNotFoundError,
     HabitValidationError,
     build_habit_stats_payload,
+    get_habit_occurrence_end_date,
     habit_occurs_on_date,
     refresh_habit_expiration,
     validate_habit_action_status,
@@ -108,7 +109,7 @@ async def _materialize_habit_action_for_date(
     """Create one materialized dated action for a scheduled occurrence."""
     if not habit_occurs_on_date(
         start_date=habit.start_date,
-        end_date=habit.end_date,
+        end_date=get_habit_occurrence_end_date(habit),
         cadence_frequency=getattr(habit, "cadence_frequency", "daily"),
         cadence_weekdays=getattr(habit, "cadence_weekdays", None),
         cadence_monthdays=getattr(habit, "cadence_monthdays", None),
@@ -134,7 +135,7 @@ def _iter_habit_window_dates(
     end_date: date,
 ) -> list[date]:
     effective_start = max(start_date, habit.start_date)
-    effective_end = min(end_date, habit.end_date)
+    effective_end = min(end_date, get_habit_occurrence_end_date(habit))
     if effective_end < effective_start:
         return []
     return [
@@ -145,7 +146,7 @@ def _iter_habit_window_dates(
         )
         if habit_occurs_on_date(
             start_date=habit.start_date,
-            end_date=habit.end_date,
+            end_date=get_habit_occurrence_end_date(habit),
             cadence_frequency=getattr(habit, "cadence_frequency", "daily"),
             cadence_weekdays=getattr(habit, "cadence_weekdays", None),
             cadence_monthdays=getattr(habit, "cadence_monthdays", None),
@@ -185,7 +186,6 @@ async def _load_candidate_habits(
     *,
     habit_id: UUID | None,
     action_window: tuple[date, date] | None,
-    habit_status: str | None = None,
     target_dates: tuple[date, ...] = (),
 ) -> list[Habit]:
     if habit_id is not None:
@@ -196,8 +196,6 @@ async def _load_candidate_habits(
 
     stmt = select(Habit).options(_active_habit_task_loader())
     stmt = stmt.where(Habit.deleted_at.is_(None))
-    if habit_status is not None:
-        stmt = stmt.where(Habit.status == validate_habit_status(habit_status))
     if target_dates:
         habit_end_expr = _habit_end_expr()
         stmt = stmt.where(
@@ -266,14 +264,12 @@ async def _build_habit_action_views(
     habit_id: UUID | None,
     status: str | None,
     action_window: tuple[date, date] | None,
-    habit_status: str | None = None,
     target_dates: tuple[date, ...] = (),
 ) -> list[HabitActionView]:
     normalized_target_dates = tuple(deduplicate_preserving_order(target_dates))
     habits = await _load_candidate_habits(
         session,
         habit_id=habit_id,
-        habit_status=habit_status,
         action_window=action_window,
         target_dates=normalized_target_dates,
     )
@@ -309,7 +305,7 @@ async def _build_habit_action_views(
                 for target_date in normalized_target_dates
                 if habit_occurs_on_date(
                     start_date=habit.start_date,
-                    end_date=habit.end_date,
+                    end_date=get_habit_occurrence_end_date(habit),
                     cadence_frequency=getattr(habit, "cadence_frequency", "daily"),
                     cadence_weekdays=getattr(habit, "cadence_weekdays", None),
                     cadence_monthdays=getattr(habit, "cadence_monthdays", None),
@@ -415,7 +411,6 @@ async def get_habit_stats(session: AsyncSession, *, habit_id: UUID) -> dict[str,
     actions = await _build_habit_action_views(
         session,
         habit_id=habit.id,
-        habit_status=None,
         status=None,
         action_window=None,
     )
@@ -434,7 +429,6 @@ async def get_habit_overview(
     actions = await _build_habit_action_views(
         session,
         habit_id=habit.id,
-        habit_status=None,
         status=None,
         action_window=None,
     )
@@ -469,7 +463,6 @@ async def list_habit_overviews(
         actions = await _build_habit_action_views(
             session,
             habit_id=habit.id,
-            habit_status=None,
             status=None,
             action_window=None,
         )
@@ -509,7 +502,6 @@ async def list_habit_actions(
     session: AsyncSession,
     *,
     habit_id: UUID | None = None,
-    habit_status: str | None = None,
     status: str | None = None,
     date_values: tuple[date, ...] = (),
     start_date: date | None = None,
@@ -518,8 +510,7 @@ async def list_habit_actions(
     offset: int = 0,
 ) -> list[HabitActionView]:
     """List habit-action occurrence views with optional filters."""
-    if habit_status is not None and validate_habit_status(habit_status) == "active":
-        await refresh_habit_expiration(session)
+    await refresh_habit_expiration(session)
     target_dates = tuple(deduplicate_preserving_order(date_values))
     action_window = (
         None if target_dates else _normalize_action_window(start_date=start_date, end_date=end_date)
@@ -527,7 +518,6 @@ async def list_habit_actions(
     views = await _build_habit_action_views(
         session,
         habit_id=habit_id,
-        habit_status=habit_status,
         status=status,
         action_window=action_window,
         target_dates=target_dates,
@@ -585,7 +575,6 @@ async def list_habit_actions_in_range(
     views = await _build_habit_action_views(
         session,
         habit_id=None,
-        habit_status=None,
         status=None,
         action_window=(start_date, end_date),
     )
@@ -596,15 +585,13 @@ async def count_habit_actions(
     session: AsyncSession,
     *,
     habit_id: UUID | None = None,
-    habit_status: str | None = None,
     status: str | None = None,
     date_values: tuple[date, ...] = (),
     start_date: date | None = None,
     end_date: date | None = None,
 ) -> int:
     """Count habit-action occurrence views with the same filters used by list_habit_actions."""
-    if habit_status is not None and validate_habit_status(habit_status) == "active":
-        await refresh_habit_expiration(session)
+    await refresh_habit_expiration(session)
     target_dates = tuple(deduplicate_preserving_order(date_values))
     action_window = (
         None if target_dates else _normalize_action_window(start_date=start_date, end_date=end_date)
@@ -612,7 +599,6 @@ async def count_habit_actions(
     views = await _build_habit_action_views(
         session,
         habit_id=habit_id,
-        habit_status=habit_status,
         status=status,
         action_window=action_window,
         target_dates=target_dates,

--- a/src/lifeos_cli/db/services/habit_support.py
+++ b/src/lifeos_cli/db/services/habit_support.py
@@ -12,6 +12,7 @@ from zoneinfo import ZoneInfo
 from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from lifeos_cli.application.calendar_adapter import CalendarGranularity, get_calendar_period_range
 from lifeos_cli.application.time_preferences import (
     get_operational_date,
     get_week_bounds,
@@ -24,7 +25,7 @@ from lifeos_cli.db.services.recurrence_core import (
     SeriesDefinition,
     build_series_definition,
     get_cycle_date_bounds,
-    get_occurrence_starts_in_range,
+    normalize_month_days,
     normalize_recurrence_frequency,
     normalize_weekday_names,
 )
@@ -34,6 +35,11 @@ if TYPE_CHECKING:
     from lifeos_cli.db.models.habit import Habit
 
 VALID_HABIT_STATUSES = {"active", "completed", "paused", "expired"}
+CADENCE_TO_CALENDAR_GRANULARITY: dict[str, CalendarGranularity] = {
+    "weekly": "week",
+    "monthly": "month",
+    "yearly": "year",
+}
 HABIT_ACTION_STATUS_CONFIG = {
     "pending": {
         "display_name": "Pending",
@@ -61,7 +67,7 @@ HABIT_ACTION_STATUS_CONFIG = {
     },
 }
 VALID_HABIT_ACTION_STATUSES = set(HABIT_ACTION_STATUS_CONFIG)
-HABIT_DURATION_OPTIONS = {7, 14, 21, 100, 365, 1000}
+MAX_HABIT_DURATION_DAYS = 10000
 WEEKEND_HABIT_WEEKDAYS = ("saturday", "sunday")
 HABIT_EDITABLE_DAYS = 10000
 MAX_ACTIVE_HABITS = 99
@@ -142,13 +148,32 @@ def validate_habit_action_status(status: str) -> str:
 
 
 def validate_habit_duration(duration_days: int) -> int:
-    """Validate habit duration options."""
-    if duration_days not in HABIT_DURATION_OPTIONS:
-        allowed = ", ".join(str(value) for value in sorted(HABIT_DURATION_OPTIONS))
+    """Validate habit duration length."""
+    if duration_days <= 0:
+        raise HabitValidationError("duration_days must be greater than zero")
+    if duration_days > MAX_HABIT_DURATION_DAYS:
         raise HabitValidationError(
-            f"Invalid duration_days {duration_days!r}. Expected one of: {allowed}"
+            f"duration_days must be no greater than {MAX_HABIT_DURATION_DAYS}"
         )
     return duration_days
+
+
+def validate_habit_repeat_count(repeat_count: int) -> int:
+    """Validate a requested number of scheduled habit occurrences."""
+    if repeat_count <= 0:
+        raise HabitValidationError("repeat_count must be greater than zero")
+    if repeat_count > MAX_HABIT_DURATION_DAYS:
+        raise HabitValidationError(
+            f"repeat_count must be no greater than {MAX_HABIT_DURATION_DAYS}"
+        )
+    return repeat_count
+
+
+def validate_habit_end_date(*, start_date: date, end_date: date) -> int:
+    """Return duration days for an inclusive habit end date."""
+    if end_date < start_date:
+        raise HabitValidationError("end_date must be on or after start_date")
+    return validate_habit_duration((end_date - start_date).days + 1)
 
 
 def validate_habit_start_date(start_date: date) -> date:
@@ -168,12 +193,24 @@ def normalize_habit_weekdays(weekdays: Sequence[str] | None) -> tuple[str, ...] 
         raise HabitValidationError(str(exc)) from exc
 
 
+def normalize_habit_monthdays(monthdays: Sequence[object] | None) -> tuple[int, ...] | None:
+    """Normalize optional calendar month day selections."""
+    try:
+        normalized = normalize_month_days(monthdays)
+    except RecurrenceValidationError as exc:
+        raise HabitValidationError(str(exc)) from exc
+    if normalized is not None and any(day < 1 for day in normalized):
+        raise HabitValidationError("cadence_monthdays values must be between 1 and 31.")
+    return normalized
+
+
 def validate_habit_cadence(
     *,
     cadence_frequency: str | None,
     cadence_weekdays: Sequence[str] | None,
+    cadence_monthdays: Sequence[object] | None = None,
     target_per_cycle: int | None,
-) -> tuple[str, tuple[str, ...] | None, int]:
+) -> tuple[str, tuple[str, ...] | None, tuple[int, ...] | None, int]:
     """Validate cadence fields and normalize defaults."""
     try:
         normalized_frequency = (
@@ -184,6 +221,7 @@ def validate_habit_cadence(
     except RecurrenceValidationError as exc:
         raise HabitValidationError(str(exc)) from exc
     normalized_weekdays = normalize_habit_weekdays(cadence_weekdays)
+    normalized_monthdays = normalize_habit_monthdays(cadence_monthdays)
     normalized_target = 1 if target_per_cycle is None else target_per_cycle
     if normalized_target <= 0:
         raise HabitValidationError("target_per_cycle must be greater than zero")
@@ -201,12 +239,25 @@ def validate_habit_cadence(
                 f"target_per_cycle {normalized_target!r} exceeds the cadence "
                 f"capacity {max_cycle_capacity}."
             )
+    if normalized_frequency == "monthly" and normalized_monthdays is not None:
+        max_cycle_capacity = len(normalized_monthdays)
+        if normalized_target > max_cycle_capacity:
+            raise HabitValidationError(
+                f"target_per_cycle {normalized_target!r} exceeds the cadence "
+                f"capacity {max_cycle_capacity}."
+            )
     if normalized_frequency == "daily" and normalized_weekdays is not None:
         raise HabitValidationError(
             "Daily cadence does not accept weekday restrictions. "
             "Use weekly or longer cycles instead."
         )
-    return normalized_frequency, normalized_weekdays, normalized_target
+    if normalized_frequency == "daily" and normalized_monthdays is not None:
+        raise HabitValidationError(
+            "Daily cadence does not accept monthday restrictions. Use monthly cadence instead."
+        )
+    if normalized_frequency != "monthly" and normalized_monthdays is not None:
+        raise HabitValidationError("Monthday restrictions require monthly cadence.")
+    return normalized_frequency, normalized_weekdays, normalized_monthdays, normalized_target
 
 
 def _habit_anchor_datetime(reference_date: date) -> datetime:
@@ -249,12 +300,21 @@ def get_habit_cycle_bounds(
 ) -> tuple[date, date]:
     """Return cadence cycle bounds for one scheduled action date."""
     try:
-        return get_cycle_date_bounds(
-            reference_date=action_date,
-            cycle_frequency=cadence_frequency,
-            week_starts_on=get_preferences_settings().week_starts_on,
+        if cadence_frequency == "daily":
+            return get_cycle_date_bounds(
+                reference_date=action_date,
+                cycle_frequency=cadence_frequency,
+                week_starts_on=get_preferences_settings().week_starts_on,
+            )
+        preferences = get_preferences_settings()
+        granularity = CADENCE_TO_CALENDAR_GRANULARITY[cadence_frequency]
+        return get_calendar_period_range(
+            granularity,
+            action_date,
+            calendar_system=preferences.calendar_system,
+            first_day_of_week=preferences.calendar_first_day_of_week,
         )
-    except RecurrenceValidationError as exc:
+    except (KeyError, RecurrenceValidationError, ValueError) as exc:
         raise HabitValidationError(str(exc)) from exc
 
 
@@ -264,47 +324,102 @@ def iter_habit_scheduled_dates(
     end_date: date,
     cadence_frequency: str,
     cadence_weekdays: Sequence[str] | None,
+    cadence_monthdays: Sequence[object] | None = None,
 ) -> list[date]:
     """Return scheduled habit-action dates for the requested window."""
-    normalized_frequency, normalized_weekdays, normalized_target = validate_habit_cadence(
+    normalized_frequency, normalized_weekdays, normalized_monthdays, _ = validate_habit_cadence(
         cadence_frequency=cadence_frequency,
         cadence_weekdays=cadence_weekdays,
+        cadence_monthdays=cadence_monthdays,
         target_per_cycle=1,
     )
-    series = _build_habit_series_definition(
-        start_date=start_date,
-        cadence_frequency=normalized_frequency,
-        cadence_weekdays=normalized_weekdays,
-        target_per_cycle=normalized_target,
-    )
-    window_start = _habit_anchor_datetime(start_date)
-    window_end = _habit_anchor_datetime(end_date + timedelta(days=1)) - timedelta(microseconds=1)
-    preferred_timezone = ZoneInfo(get_preferences_settings().timezone)
     return [
-        occurrence_start.astimezone(preferred_timezone).date()
-        for occurrence_start in get_occurrence_starts_in_range(
-            series,
-            window_start=window_start,
-            window_end=window_end,
+        current_date
+        for current_date in (
+            start_date + timedelta(days=offset)
+            for offset in range((end_date - start_date).days + 1)
+        )
+        if habit_occurs_on_date(
+            start_date=start_date,
+            end_date=end_date,
+            cadence_frequency=normalized_frequency,
+            cadence_weekdays=normalized_weekdays,
+            cadence_monthdays=normalized_monthdays,
+            target_date=current_date,
         )
     ]
+
+
+def calculate_habit_duration_for_repeat_count(
+    *,
+    start_date: date,
+    repeat_count: int,
+    cadence_frequency: str,
+    cadence_weekdays: Sequence[str] | None,
+    cadence_monthdays: Sequence[object] | None = None,
+) -> int:
+    """Return duration days needed to include a requested occurrence count."""
+    normalized_repeat_count = validate_habit_repeat_count(repeat_count)
+    scheduled_dates: list[date] = []
+    cursor = start_date
+    latest_allowed_date = start_date + timedelta(days=MAX_HABIT_DURATION_DAYS - 1)
+    while cursor <= latest_allowed_date and len(scheduled_dates) < normalized_repeat_count:
+        if habit_occurs_on_date(
+            start_date=start_date,
+            end_date=latest_allowed_date,
+            cadence_frequency=cadence_frequency,
+            cadence_weekdays=cadence_weekdays,
+            cadence_monthdays=cadence_monthdays,
+            target_date=cursor,
+        ):
+            scheduled_dates.append(cursor)
+        cursor += timedelta(days=1)
+    if len(scheduled_dates) < normalized_repeat_count:
+        raise HabitValidationError(
+            "repeat_count does not fit within the maximum habit duration window"
+        )
+    return validate_habit_duration((scheduled_dates[-1] - start_date).days + 1)
+
+
+def _calendar_monthday(target_date: date) -> int:
+    preferences = get_preferences_settings()
+    month_start, _ = get_calendar_period_range(
+        "month",
+        target_date,
+        calendar_system=preferences.calendar_system,
+        first_day_of_week=preferences.calendar_first_day_of_week,
+    )
+    return (target_date - month_start).days + 1
 
 
 def habit_occurs_on_date(
     *,
     start_date: date,
     end_date: date,
+    cadence_frequency: str = "daily",
     cadence_weekdays: Sequence[str] | None,
+    cadence_monthdays: Sequence[object] | None = None,
     target_date: date,
 ) -> bool:
     """Return whether one habit schedules an occurrence on the requested date."""
     if target_date < start_date or target_date > end_date:
         return False
-    normalized_weekdays = normalize_habit_weekdays(cadence_weekdays)
+    normalized_frequency, normalized_weekdays, normalized_monthdays, _ = validate_habit_cadence(
+        cadence_frequency=cadence_frequency,
+        cadence_weekdays=cadence_weekdays,
+        cadence_monthdays=cadence_monthdays,
+        target_per_cycle=1,
+    )
     if normalized_weekdays is None:
-        return True
-    weekday_name = VALID_WEEKDAY_NAMES[target_date.weekday()]
-    return weekday_name in normalized_weekdays
+        weekday_matches = True
+    else:
+        weekday_name = VALID_WEEKDAY_NAMES[target_date.weekday()]
+        weekday_matches = weekday_name in normalized_weekdays
+    if not weekday_matches:
+        return False
+    if normalized_frequency == "monthly" and normalized_monthdays is not None:
+        return _calendar_monthday(target_date) in normalized_monthdays
+    return True
 
 
 def validate_habit_schedule_window(
@@ -313,6 +428,7 @@ def validate_habit_schedule_window(
     end_date: date,
     cadence_frequency: str,
     cadence_weekdays: Sequence[str] | None,
+    cadence_monthdays: Sequence[object] | None = None,
 ) -> None:
     """Ensure one habit definition produces at least one scheduled date."""
     desired_dates = iter_habit_scheduled_dates(
@@ -320,6 +436,7 @@ def validate_habit_schedule_window(
         end_date=end_date,
         cadence_frequency=cadence_frequency,
         cadence_weekdays=cadence_weekdays,
+        cadence_monthdays=cadence_monthdays,
     )
     if desired_dates:
         return
@@ -333,9 +450,10 @@ def build_habit_cycle_summaries(
     actions: Sequence[HabitActionLike],
 ) -> list[HabitCycleSummary]:
     """Build cadence-cycle summaries for one habit."""
-    cadence_frequency, cadence_weekdays, target_per_cycle = validate_habit_cadence(
+    cadence_frequency, cadence_weekdays, _, target_per_cycle = validate_habit_cadence(
         cadence_frequency=getattr(habit, "cadence_frequency", None),
         cadence_weekdays=getattr(habit, "cadence_weekdays", None),
+        cadence_monthdays=getattr(habit, "cadence_monthdays", None),
         target_per_cycle=getattr(habit, "target_per_cycle", None),
     )
     series = _build_habit_series_definition(
@@ -495,10 +613,13 @@ def build_habit_stats_payload(
 ) -> dict[str, object]:
     """Build stats shared by overview, show, and stats commands."""
     current_week_start, current_week_end = get_week_bounds(get_operational_date())
-    cadence_frequency, cadence_weekdays, target_per_cycle = validate_habit_cadence(
-        cadence_frequency=getattr(habit, "cadence_frequency", None),
-        cadence_weekdays=getattr(habit, "cadence_weekdays", None),
-        target_per_cycle=getattr(habit, "target_per_cycle", None),
+    cadence_frequency, cadence_weekdays, cadence_monthdays, target_per_cycle = (
+        validate_habit_cadence(
+            cadence_frequency=getattr(habit, "cadence_frequency", None),
+            cadence_weekdays=getattr(habit, "cadence_weekdays", None),
+            cadence_monthdays=getattr(habit, "cadence_monthdays", None),
+            target_per_cycle=getattr(habit, "target_per_cycle", None),
+        )
     )
     series = _build_habit_series_definition(
         start_date=habit.start_date,
@@ -531,6 +652,7 @@ def build_habit_stats_payload(
         "habit_id": habit.id,
         "cadence_frequency": cadence_frequency,
         "cadence_weekdays": cadence_weekdays,
+        "cadence_monthdays": cadence_monthdays,
         "target_per_cycle": target_per_cycle,
         "total_actions": total_actions,
         "completed_actions": completed_actions,

--- a/src/lifeos_cli/db/services/habit_support.py
+++ b/src/lifeos_cli/db/services/habit_support.py
@@ -422,6 +422,18 @@ def habit_occurs_on_date(
     return True
 
 
+def get_habit_occurrence_end_date(habit: object) -> date:
+    """Return the final date where a habit should produce action occurrences."""
+    end_date = getattr(habit, "end_date", None)
+    if not isinstance(end_date, date):
+        raise HabitValidationError("Habit occurrence end date is unavailable")
+    status = getattr(habit, "status", "active")
+    status_changed_date = getattr(habit, "status_changed_date", None)
+    if status != "active" and isinstance(status_changed_date, date):
+        return min(end_date, status_changed_date - timedelta(days=1))
+    return end_date
+
+
 def validate_habit_schedule_window(
     *,
     start_date: date,
@@ -601,7 +613,15 @@ async def refresh_habit_expiration(
     ]
     if habit_id is not None:
         filters.append(Habit.id == habit_id)
-    stmt = update(Habit).where(*filters).values(status="expired", updated_at=utc_now())
+    stmt = (
+        update(Habit)
+        .where(*filters)
+        .values(
+            status="expired",
+            status_changed_date=local_today,
+            updated_at=utc_now(),
+        )
+    )
     result = await session.execute(stmt)
     rowcount = getattr(result, "rowcount", 0)
     return int(0 if rowcount is None else rowcount)

--- a/src/lifeos_cli/locales/en/cli_messages.json
+++ b/src/lifeos_cli/locales/en/cli_messages.json
@@ -294,6 +294,7 @@
         "use_list_as_primary_query_entrypoint_for_habits": "Use `list` as the primary query entrypoint for habits."
       },
       "parser_actions": {
+        "allowed_monthdays_for_example_1_15_28": "Allowed calendar month days, for example 1,15,28",
         "allowed_weekdays_for_example_monday_wednesday_friday": "Allowed weekdays, for example monday,wednesday,friday",
         "cadence_and_timing_changes_reconcile_materialized_habit_action_records_without_regenerating_full": "Cadence and timing changes reconcile materialized habit-action records without regenerating full histories.",
         "cadence_target_count_for_one_cycle_daily_habits_must_keep_1": "Cadence target count for one cycle. Daily habits must keep 1.",
@@ -320,6 +321,7 @@
         "optional_habit_description": "Optional habit description",
         "reactivating_habit_still_respects_active_habit_limit": "Reactivating a habit still respects the active habit limit.",
         "remove_linked_task_reference": "Remove the linked task reference",
+        "remove_monthday_restrictions_from_habit_cadence": "Remove monthday restrictions from the habit cadence",
         "remove_weekday_restrictions_from_habit_cadence": "Remove weekday restrictions from the habit cadence",
         "restrict_results_to_habits_whose_duration_still_covers_today": "Restrict results to habits whose duration still covers today",
         "run_bulk_habit_operations": "Run bulk habit operations",
@@ -333,6 +335,7 @@
         "update_habit": "Update a habit",
         "update_mutable_habit_fields": "Update mutable habit fields.",
         "updated_allowed_weekdays_for_example_monday_wednesday_friday": "Updated allowed weekdays, for example monday,wednesday,friday",
+        "updated_allowed_monthdays_for_example_1_15_28": "Updated allowed calendar month days, for example 1,15,28",
         "updated_cadence_frequency_daily_weekly_monthly_or_yearly": "Updated cadence frequency: daily, weekly, monthly, or yearly",
         "updated_cadence_target_count_for_one_cycle": "Updated cadence target count for one cycle",
         "updated_duration_in_days": "Updated duration in days",

--- a/src/lifeos_cli/locales/zh_Hans/cli_messages.json
+++ b/src/lifeos_cli/locales/zh_Hans/cli_messages.json
@@ -294,6 +294,7 @@
         "use_list_as_primary_query_entrypoint_for_habits": "将 `list` 作为 `habit` 的主要查询入口。"
       },
       "parser_actions": {
+        "allowed_monthdays_for_example_1_15_28": "允许的历法月内日期，例如 1,15,28",
         "allowed_weekdays_for_example_monday_wednesday_friday": "允许的星期几，例如 monday,wednesday,friday",
         "cadence_and_timing_changes_reconcile_materialized_habit_action_records_without_regenerating_full": "cadence 与时间参数变化会对齐已物化的 `habit-action` 记录，而不会重新生成完整历史。",
         "cadence_target_count_for_one_cycle_daily_habits_must_keep_1": "单个周期的 cadence 目标次数。daily `habit` 必须保持为 1。",
@@ -320,6 +321,7 @@
         "optional_habit_description": "可选的 `habit` 描述",
         "reactivating_habit_still_respects_active_habit_limit": "重新激活 `habit` 仍然遵循主动 `habit` 限制。",
         "remove_linked_task_reference": "删除链接的 `task` 参考",
+        "remove_monthday_restrictions_from_habit_cadence": "移除该 `habit` cadence 的 monthday 限制",
         "remove_weekday_restrictions_from_habit_cadence": "移除该 `habit` cadence 的 weekday 限制",
         "restrict_results_to_habits_whose_duration_still_covers_today": "将结果限制为持续时间仍然覆盖今天的 `habit`",
         "run_bulk_habit_operations": "执行批量 `habit` 操作",
@@ -333,6 +335,7 @@
         "update_habit": "更新 `habit`",
         "update_mutable_habit_fields": "更新可变的 `habit` 字段。",
         "updated_allowed_weekdays_for_example_monday_wednesday_friday": "更新后的允许星期几，例如 monday,wednesday,friday",
+        "updated_allowed_monthdays_for_example_1_15_28": "更新后的允许历法月内日期，例如 1,15,28",
         "updated_cadence_frequency_daily_weekly_monthly_or_yearly": "更新后的 cadence 频率：daily、weekly、monthly 或 yearly",
         "updated_cadence_target_count_for_one_cycle": "更新后的单个周期 cadence 目标次数",
         "updated_duration_in_days": "更新持续时间（以天为单位）",

--- a/src/lifeos_web/routers/habits.py
+++ b/src/lifeos_web/routers/habits.py
@@ -31,6 +31,7 @@ def _habit_model_payload(habit: Habit) -> dict[str, object]:
         "duration_days": habit.duration_days,
         "cadence_frequency": habit.cadence_frequency,
         "cadence_weekdays": habit.cadence_weekdays,
+        "cadence_monthdays": getattr(habit, "cadence_monthdays", None),
         "target_per_cycle": habit.target_per_cycle,
         "status": habit.status,
         "task_id": str(habit.task_id) if habit.task_id else None,
@@ -178,8 +179,11 @@ async def create_habit(
             description=payload.description,
             start_date=payload.start_date,
             duration_days=payload.duration_days,
+            end_date=payload.end_date,
+            repeat_count=payload.repeat_count,
             cadence_frequency=payload.cadence_frequency,
             cadence_weekdays=payload.cadence_weekdays,
+            cadence_monthdays=payload.cadence_monthdays,
             target_per_cycle=payload.target_per_cycle,
             task_id=payload.task_id,
         )
@@ -198,6 +202,7 @@ async def update_habit(
     fields = payload.model_fields_set
     clear_description = "description" in fields and payload.description is None
     clear_weekdays = "cadence_weekdays" in fields and payload.cadence_weekdays is None
+    clear_monthdays = "cadence_monthdays" in fields and payload.cadence_monthdays is None
     clear_task = "task_id" in fields and payload.task_id is None
     try:
         habit = await habit_services.update_habit(
@@ -208,9 +213,13 @@ async def update_habit(
             clear_description=clear_description,
             start_date=payload.start_date,
             duration_days=payload.duration_days,
+            end_date=payload.end_date,
+            repeat_count=payload.repeat_count,
             cadence_frequency=payload.cadence_frequency,
             cadence_weekdays=payload.cadence_weekdays,
             clear_weekdays=clear_weekdays,
+            cadence_monthdays=payload.cadence_monthdays,
+            clear_monthdays=clear_monthdays,
             target_per_cycle=payload.target_per_cycle,
             status=payload.status,
             task_id=payload.task_id,

--- a/src/lifeos_web/routers/habits.py
+++ b/src/lifeos_web/routers/habits.py
@@ -252,6 +252,7 @@ async def list_actions_by_date(
     """List materialized habit actions for one local date."""
     actions = await habit_action_services.list_habit_actions(
         session,
+        habit_status="active",
         date_values=(action_date,),
         limit=500,
     )

--- a/src/lifeos_web/routers/habits.py
+++ b/src/lifeos_web/routers/habits.py
@@ -252,7 +252,6 @@ async def list_actions_by_date(
     """List materialized habit actions for one local date."""
     actions = await habit_action_services.list_habit_actions(
         session,
-        habit_status="active",
         date_values=(action_date,),
         limit=500,
     )

--- a/src/lifeos_web/routers/timelogs.py
+++ b/src/lifeos_web/routers/timelogs.py
@@ -47,6 +47,15 @@ def _timelog_payload(timelog: object) -> dict[str, object]:
     return payload
 
 
+@router.get("/latest-end-time")
+async def get_latest_timelog_end_time(session: SessionDep) -> dict[str, str | None]:
+    """Return the latest active timelog end time for cursor inheritance."""
+    latest_end_time = await timelog_services.get_latest_timelog_end_time(session)
+    return {
+        "end_time": latest_end_time.isoformat() if latest_end_time else None,
+    }
+
+
 @router.get("/", response_model=ListResponse)
 async def list_timelogs(
     session: SessionDep,

--- a/src/lifeos_web/schemas.py
+++ b/src/lifeos_web/schemas.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from datetime import date, datetime
-from typing import Any
+from typing import Annotated, Any
 from uuid import UUID
 
 from pydantic import BaseModel, Field
+
+PositiveIntField = Annotated[int, Field(ge=1)]
 
 
 class Pagination(BaseModel):
@@ -161,9 +163,12 @@ class HabitCreate(BaseModel):
     title: str
     description: str | None = None
     start_date: date
-    duration_days: int = Field(..., ge=1)
+    duration_days: PositiveIntField | None = None
+    end_date: date | None = None
+    repeat_count: PositiveIntField | None = None
     cadence_frequency: str | None = None
     cadence_weekdays: list[str] | None = None
+    cadence_monthdays: list[int] | None = None
     target_per_cycle: int | None = None
     task_id: UUID | None = None
 
@@ -174,9 +179,12 @@ class HabitUpdate(BaseModel):
     title: str | None = None
     description: str | None = None
     start_date: date | None = None
-    duration_days: int | None = Field(None, ge=1)
+    duration_days: PositiveIntField | None = None
+    end_date: date | None = None
+    repeat_count: PositiveIntField | None = None
     cadence_frequency: str | None = None
     cadence_weekdays: list[str] | None = None
+    cadence_monthdays: list[int] | None = None
     target_per_cycle: int | None = None
     status: str | None = None
     task_id: UUID | None = None

--- a/tests/test_cli_domains_workflows.py
+++ b/tests/test_cli_domains_workflows.py
@@ -881,6 +881,7 @@ def test_main_habit_add_creates_habit(
         assert kwargs["duration_days"] == 21
         assert kwargs["cadence_frequency"] == "daily"
         assert kwargs["cadence_weekdays"] is None
+        assert kwargs["cadence_monthdays"] is None
         assert kwargs["target_per_cycle"] is None
         return make_record(id=UUID("77777777-7777-7777-7777-777777777777"))
 
@@ -911,6 +912,7 @@ def test_main_habit_add_passes_weekly_cadence_fields(
     async def fake_create_habit(_session: object, **kwargs: object) -> object:
         assert kwargs["cadence_frequency"] == "weekly"
         assert kwargs["cadence_weekdays"] == ["saturday", "sunday"]
+        assert kwargs["cadence_monthdays"] is None
         assert kwargs["target_per_cycle"] == 1
         return make_record(id=UUID("78787878-7878-7878-7878-787878787878"))
 
@@ -946,6 +948,7 @@ def test_main_habit_add_passes_monthly_cadence_fields(
     async def fake_create_habit(_session: object, **kwargs: object) -> object:
         assert kwargs["cadence_frequency"] == "monthly"
         assert kwargs["cadence_weekdays"] is None
+        assert kwargs["cadence_monthdays"] == [1, 15]
         assert kwargs["target_per_cycle"] == 2
         return make_record(id=UUID("79797979-7979-7979-7979-797979797979"))
 
@@ -963,6 +966,8 @@ def test_main_habit_add_passes_monthly_cadence_fields(
             "365",
             "--cadence-frequency",
             "monthly",
+            "--monthdays",
+            "1,15",
             "--target-per-cycle",
             "2",
         ]

--- a/tests/test_cli_parser_core.py
+++ b/tests/test_cli_parser_core.py
@@ -1042,6 +1042,8 @@ def test_cli_parser_supports_habit_add_monthly_cadence_command() -> None:
             "365",
             "--cadence-frequency",
             "monthly",
+            "--monthdays",
+            "1,15",
             "--target-per-cycle",
             "2",
         ]
@@ -1050,6 +1052,7 @@ def test_cli_parser_supports_habit_add_monthly_cadence_command() -> None:
     assert args.resource == "habit"
     assert args.habit_command == "add"
     assert args.cadence_frequency == "monthly"
+    assert args.monthdays == [1, 15]
     assert args.target_per_cycle == 2
 
 
@@ -1095,6 +1098,23 @@ def test_cli_parser_supports_habit_update_clear_weekdays_command() -> None:
     assert args.habit_command == "update"
     assert str(args.habit_id) == "11111111-1111-1111-1111-111111111111"
     assert args.clear_weekdays is True
+
+
+def test_cli_parser_supports_habit_update_clear_monthdays_command() -> None:
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "habit",
+            "update",
+            "11111111-1111-1111-1111-111111111111",
+            "--clear-monthdays",
+        ]
+    )
+
+    assert args.resource == "habit"
+    assert args.habit_command == "update"
+    assert str(args.habit_id) == "11111111-1111-1111-1111-111111111111"
+    assert args.clear_monthdays is True
 
 
 def test_cli_parser_supports_habit_action_list_by_date_command() -> None:

--- a/tests/test_domain_services_tasks_and_habits.py
+++ b/tests/test_domain_services_tasks_and_habits.py
@@ -1422,6 +1422,7 @@ def test_build_habit_action_views_uses_discrete_target_dates_without_gap_expansi
 
     async def fake_load_candidate_habits(*args: object, **kwargs: object) -> list[object]:
         assert kwargs["action_window"] is None
+        assert kwargs["habit_status"] is None
         assert kwargs["target_dates"] == selected_dates
         return [habit]
 
@@ -1449,6 +1450,37 @@ def test_build_habit_action_views_uses_discrete_target_dates_without_gap_expansi
     )
 
     assert [view.action_date for view in views] == [date(2026, 4, 1), date(2026, 4, 30)]
+
+
+def test_load_candidate_habits_can_filter_active_status_for_target_dates() -> None:
+    statements: list[object] = []
+
+    class Result:
+        def scalars(self) -> list[object]:
+            return []
+
+    session = SimpleNamespace()
+
+    async def fake_execute(statement: object) -> Result:
+        statements.append(statement)
+        return Result()
+
+    session.execute = fake_execute
+
+    habits_result = asyncio.run(
+        habit_queries._load_candidate_habits(
+            cast(Any, session),
+            habit_id=None,
+            habit_status="active",
+            action_window=None,
+            target_dates=(date(2026, 4, 9),),
+        )
+    )
+
+    assert habits_result == []
+    assert statements
+    compiled = str(statements[-1])
+    assert "habits.status =" in compiled
 
 
 def test_list_and_count_habit_actions_pass_discrete_dates_to_builder(
@@ -1501,7 +1533,9 @@ def test_list_and_count_habit_actions_pass_discrete_dates_to_builder(
 
     assert [view.action_date for view in views] == [date(2026, 4, 3), date(2026, 4, 1)]
     assert count == 2
+    assert captured_calls[0]["habit_status"] is None
     assert captured_calls[0]["target_dates"] == (date(2026, 4, 3), date(2026, 4, 1))
     assert captured_calls[0]["action_window"] is None
+    assert captured_calls[1]["habit_status"] is None
     assert captured_calls[1]["target_dates"] == (date(2026, 4, 3), date(2026, 4, 1))
     assert captured_calls[1]["action_window"] is None

--- a/tests/test_domain_services_tasks_and_habits.py
+++ b/tests/test_domain_services_tasks_and_habits.py
@@ -1066,6 +1066,47 @@ def test_update_habit_can_clear_task_without_committing(monkeypatch: pytest.Monk
     session.commit.assert_not_called()
 
 
+def test_update_habit_records_status_changed_date(monkeypatch: pytest.MonkeyPatch) -> None:
+    habit = SimpleNamespace(
+        id=UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        title="Daily Exercise",
+        description="Move every day",
+        start_date=date(2026, 4, 9),
+        duration_days=90,
+        cadence_frequency="daily",
+        cadence_weekdays=None,
+        cadence_monthdays=None,
+        target_per_cycle=1,
+        status="active",
+        status_changed_date=date(2026, 4, 9),
+        task_id=None,
+    )
+    session = SimpleNamespace(flush=AsyncMock(), refresh=AsyncMock())
+
+    async def fake_get_habit(_: object, *, habit_id: UUID) -> object:
+        assert habit_id == UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+        return habit
+
+    async def fake_refresh_habit_expiration(_: object, *, habit_id: UUID | None = None) -> int:
+        assert habit_id == UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+        return 0
+
+    monkeypatch.setattr(habit_mutations, "get_habit", fake_get_habit)
+    monkeypatch.setattr(habit_mutations, "refresh_habit_expiration", fake_refresh_habit_expiration)
+    monkeypatch.setattr(habit_mutations, "get_operational_date", lambda: date(2026, 7, 1))
+
+    updated_habit = asyncio.run(
+        habits.update_habit(
+            cast(Any, session),
+            habit_id=UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+            status="paused",
+        )
+    )
+
+    assert updated_habit.status == "paused"
+    assert updated_habit.status_changed_date == date(2026, 7, 1)
+
+
 def test_update_habit_rejects_zero_target_per_cycle(monkeypatch: pytest.MonkeyPatch) -> None:
     habit = SimpleNamespace(
         id=UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
@@ -1265,7 +1306,16 @@ def test_update_habit_action_by_date_uses_existing_update_rules(
             return action
 
     async def fake_get_habit(_: object, *, habit_id: UUID) -> object:
-        return SimpleNamespace(id=habit_id)
+        return SimpleNamespace(
+            id=habit_id,
+            start_date=date(2026, 4, 1),
+            end_date=date(2026, 4, 30),
+            cadence_frequency="daily",
+            cadence_weekdays=None,
+            cadence_monthdays=None,
+            status="active",
+            status_changed_date=date(2026, 4, 1),
+        )
 
     async def fake_execute(statement: object) -> Result:
         return Result()
@@ -1318,7 +1368,11 @@ def test_update_habit_action_by_date_materializes_missing_occurrence(
             id=habit_id,
             start_date=date(2026, 4, 1),
             end_date=date(2026, 4, 30),
+            cadence_frequency="daily",
             cadence_weekdays=None,
+            cadence_monthdays=None,
+            status="active",
+            status_changed_date=date(2026, 4, 1),
         )
 
     async def fake_execute(statement: object) -> Result:
@@ -1422,7 +1476,6 @@ def test_build_habit_action_views_uses_discrete_target_dates_without_gap_expansi
 
     async def fake_load_candidate_habits(*args: object, **kwargs: object) -> list[object]:
         assert kwargs["action_window"] is None
-        assert kwargs["habit_status"] is None
         assert kwargs["target_dates"] == selected_dates
         return [habit]
 
@@ -1452,35 +1505,48 @@ def test_build_habit_action_views_uses_discrete_target_dates_without_gap_expansi
     assert [view.action_date for view in views] == [date(2026, 4, 1), date(2026, 4, 30)]
 
 
-def test_load_candidate_habits_can_filter_active_status_for_target_dates() -> None:
-    statements: list[object] = []
+def test_build_habit_action_views_stops_after_status_change_date(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    habit_id = UUID("77777777-7777-7777-7777-777777777777")
+    selected_dates = (date(2026, 6, 30), date(2026, 7, 1))
+    habit = SimpleNamespace(
+        id=habit_id,
+        title="Daily Exercise",
+        start_date=date(2026, 6, 1),
+        end_date=date(2026, 7, 31),
+        cadence_frequency="daily",
+        cadence_weekdays=None,
+        cadence_monthdays=None,
+        status="paused",
+        status_changed_date=date(2026, 7, 1),
+    )
 
-    class Result:
-        def scalars(self) -> list[object]:
-            return []
+    async def fake_load_candidate_habits(*args: object, **kwargs: object) -> list[object]:
+        assert kwargs["target_dates"] == selected_dates
+        return [habit]
 
-    session = SimpleNamespace()
+    async def fake_load_materialized_actions(*args: object, **kwargs: object) -> list[object]:
+        return []
 
-    async def fake_execute(statement: object) -> Result:
-        statements.append(statement)
-        return Result()
+    monkeypatch.setattr(habit_queries, "_load_candidate_habits", fake_load_candidate_habits)
+    monkeypatch.setattr(
+        habit_queries,
+        "_load_materialized_actions_for_habits",
+        fake_load_materialized_actions,
+    )
 
-    session.execute = fake_execute
-
-    habits_result = asyncio.run(
-        habit_queries._load_candidate_habits(
-            cast(Any, session),
+    views = asyncio.run(
+        habit_queries._build_habit_action_views(
+            cast(Any, object()),
             habit_id=None,
-            habit_status="active",
+            status=None,
             action_window=None,
-            target_dates=(date(2026, 4, 9),),
+            target_dates=selected_dates,
         )
     )
 
-    assert habits_result == []
-    assert statements
-    compiled = str(statements[-1])
-    assert "habits.status =" in compiled
+    assert [view.action_date for view in views] == [date(2026, 6, 30)]
 
 
 def test_list_and_count_habit_actions_pass_discrete_dates_to_builder(
@@ -1517,6 +1583,7 @@ def test_list_and_count_habit_actions_pass_discrete_dates_to_builder(
         ]
 
     monkeypatch.setattr(habit_queries, "_build_habit_action_views", fake_build_views)
+    monkeypatch.setattr(habit_queries, "refresh_habit_expiration", AsyncMock(return_value=0))
 
     views = asyncio.run(
         habits.list_habit_actions(
@@ -1533,9 +1600,7 @@ def test_list_and_count_habit_actions_pass_discrete_dates_to_builder(
 
     assert [view.action_date for view in views] == [date(2026, 4, 3), date(2026, 4, 1)]
     assert count == 2
-    assert captured_calls[0]["habit_status"] is None
     assert captured_calls[0]["target_dates"] == (date(2026, 4, 3), date(2026, 4, 1))
     assert captured_calls[0]["action_window"] is None
-    assert captured_calls[1]["habit_status"] is None
     assert captured_calls[1]["target_dates"] == (date(2026, 4, 3), date(2026, 4, 1))
     assert captured_calls[1]["action_window"] is None

--- a/tests/test_domain_services_tasks_and_habits.py
+++ b/tests/test_domain_services_tasks_and_habits.py
@@ -819,6 +819,163 @@ def test_create_habit_keeps_monthly_cadence_without_pre_generation(
     session.commit.assert_not_called()
 
 
+def test_create_habit_keeps_monthly_monthday_cadence_without_pre_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Result:
+        def scalars(self) -> list[object]:
+            return []
+
+    session = SimpleNamespace(
+        add=None,
+        execute=AsyncMock(return_value=Result()),
+        flush=AsyncMock(),
+        refresh=AsyncMock(),
+        commit=AsyncMock(),
+    )
+    added_records: list[object] = []
+
+    def fake_add(record: object) -> None:
+        if getattr(record, "id", None) is None:
+            cast(Any, record).id = UUID("99999999-9999-9999-9999-999999999999")
+        added_records.append(record)
+
+    async def fake_ensure_active_capacity(_: object, **__: object) -> None:
+        return None
+
+    async def fake_ensure_task_exists(_: object, __: UUID | None) -> None:
+        return None
+
+    async def fake_refresh_habit_expiration(_: object, *, habit_id: UUID | None = None) -> int:
+        assert habit_id == UUID("99999999-9999-9999-9999-999999999999")
+        return 0
+
+    session.add = fake_add
+    monkeypatch.setattr(habit_mutations, "ensure_active_capacity", fake_ensure_active_capacity)
+    monkeypatch.setattr(habit_mutations, "ensure_task_exists", fake_ensure_task_exists)
+    monkeypatch.setattr(habit_mutations, "refresh_habit_expiration", fake_refresh_habit_expiration)
+
+    habit = asyncio.run(
+        habits.create_habit(
+            cast(Any, session),
+            title="Monthly cleanup",
+            start_date=date(2026, 4, 1),
+            duration_days=100,
+            cadence_frequency="monthly",
+            cadence_monthdays=[1, 15],
+            target_per_cycle=2,
+        )
+    )
+
+    assert habit.cadence_frequency == "monthly"
+    assert habit.cadence_monthdays == [1, 15]
+    assert habit.target_per_cycle == 2
+    assert not any(hasattr(record, "action_date") for record in added_records)
+    session.flush.assert_awaited()
+    session.commit.assert_not_called()
+
+
+def test_create_habit_repeat_count_resolves_duration_from_scheduled_occurrences(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Result:
+        def scalars(self) -> list[object]:
+            return []
+
+    session = SimpleNamespace(
+        add=None,
+        execute=AsyncMock(return_value=Result()),
+        flush=AsyncMock(),
+        refresh=AsyncMock(),
+        commit=AsyncMock(),
+    )
+
+    def fake_add(record: object) -> None:
+        if getattr(record, "id", None) is None:
+            cast(Any, record).id = UUID("99999999-9999-9999-9999-999999999999")
+
+    async def fake_ensure_active_capacity(_: object, **__: object) -> None:
+        return None
+
+    async def fake_ensure_task_exists(_: object, __: UUID | None) -> None:
+        return None
+
+    async def fake_refresh_habit_expiration(_: object, *, habit_id: UUID | None = None) -> int:
+        assert habit_id == UUID("99999999-9999-9999-9999-999999999999")
+        return 0
+
+    session.add = fake_add
+    monkeypatch.setattr(habit_mutations, "ensure_active_capacity", fake_ensure_active_capacity)
+    monkeypatch.setattr(habit_mutations, "ensure_task_exists", fake_ensure_task_exists)
+    monkeypatch.setattr(habit_mutations, "refresh_habit_expiration", fake_refresh_habit_expiration)
+
+    habit = asyncio.run(
+        habits.create_habit(
+            cast(Any, session),
+            title="Weekend calls",
+            start_date=date(2026, 4, 9),
+            repeat_count=3,
+            cadence_frequency="weekly",
+            cadence_weekdays=["saturday", "sunday"],
+            target_per_cycle=1,
+        )
+    )
+
+    assert habit.duration_days == 10
+    assert habit.end_date == date(2026, 4, 18)
+    session.flush.assert_awaited()
+    session.commit.assert_not_called()
+
+
+def test_create_habit_end_date_resolves_inclusive_duration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Result:
+        def scalars(self) -> list[object]:
+            return []
+
+    session = SimpleNamespace(
+        add=None,
+        execute=AsyncMock(return_value=Result()),
+        flush=AsyncMock(),
+        refresh=AsyncMock(),
+        commit=AsyncMock(),
+    )
+
+    def fake_add(record: object) -> None:
+        if getattr(record, "id", None) is None:
+            cast(Any, record).id = UUID("99999999-9999-9999-9999-999999999999")
+
+    async def fake_ensure_active_capacity(_: object, **__: object) -> None:
+        return None
+
+    async def fake_ensure_task_exists(_: object, __: UUID | None) -> None:
+        return None
+
+    async def fake_refresh_habit_expiration(_: object, *, habit_id: UUID | None = None) -> int:
+        assert habit_id == UUID("99999999-9999-9999-9999-999999999999")
+        return 0
+
+    session.add = fake_add
+    monkeypatch.setattr(habit_mutations, "ensure_active_capacity", fake_ensure_active_capacity)
+    monkeypatch.setattr(habit_mutations, "ensure_task_exists", fake_ensure_task_exists)
+    monkeypatch.setattr(habit_mutations, "refresh_habit_expiration", fake_refresh_habit_expiration)
+
+    habit = asyncio.run(
+        habits.create_habit(
+            cast(Any, session),
+            title="Daily review",
+            start_date=date(2026, 4, 9),
+            end_date=date(2026, 4, 15),
+        )
+    )
+
+    assert habit.duration_days == 7
+    assert habit.end_date == date(2026, 4, 15)
+    session.flush.assert_awaited()
+    session.commit.assert_not_called()
+
+
 def test_create_habit_rejects_daily_quota_targets() -> None:
     with pytest.raises(habits.HabitValidationError):
         asyncio.run(
@@ -837,6 +994,36 @@ def test_create_habit_rejects_daily_quota_targets() -> None:
                 target_per_cycle=2,
             )
         )
+
+
+def test_iter_habit_scheduled_dates_uses_user_calendar_monthdays(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        habit_support,
+        "get_preferences_settings",
+        lambda: SimpleNamespace(
+            day_starts_at="00:00",
+            timezone="UTC",
+            week_starts_on="monday",
+            calendar_system="mayan_13_moon",
+            calendar_first_day_of_week=1,
+        ),
+    )
+
+    scheduled_dates = habit_support.iter_habit_scheduled_dates(
+        start_date=date(2026, 7, 26),
+        end_date=date(2026, 8, 25),
+        cadence_frequency="monthly",
+        cadence_weekdays=None,
+        cadence_monthdays=[1, 15],
+    )
+
+    assert scheduled_dates == [
+        date(2026, 7, 26),
+        date(2026, 8, 9),
+        date(2026, 8, 23),
+    ]
 
 
 def test_update_habit_can_clear_task_without_committing(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -876,6 +1063,42 @@ def test_update_habit_can_clear_task_without_committing(monkeypatch: pytest.Monk
     assert updated_habit.task_id is None
     session.flush.assert_awaited_once()
     session.refresh.assert_awaited_once_with(habit)
+    session.commit.assert_not_called()
+
+
+def test_update_habit_rejects_zero_target_per_cycle(monkeypatch: pytest.MonkeyPatch) -> None:
+    habit = SimpleNamespace(
+        id=UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        title="Weekly Exercise",
+        description=None,
+        start_date=date(2026, 4, 9),
+        duration_days=21,
+        cadence_frequency="weekly",
+        cadence_weekdays=["monday"],
+        cadence_monthdays=None,
+        target_per_cycle=1,
+        status="active",
+        task_id=None,
+    )
+    session = SimpleNamespace(flush=AsyncMock(), refresh=AsyncMock(), commit=AsyncMock())
+
+    async def fake_get_habit(_: object, *, habit_id: UUID) -> object:
+        assert habit_id == UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+        return habit
+
+    monkeypatch.setattr(habit_mutations, "get_habit", fake_get_habit)
+
+    with pytest.raises(habits.HabitValidationError):
+        asyncio.run(
+            habits.update_habit(
+                cast(Any, session),
+                habit_id=UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+                target_per_cycle=0,
+            )
+        )
+
+    session.flush.assert_not_awaited()
+    session.refresh.assert_not_awaited()
     session.commit.assert_not_called()
 
 
@@ -941,6 +1164,52 @@ def test_build_habit_stats_payload_uses_monthly_cycle_targets(
     assert stats["progress_percentage"] == 100.0
     assert stats["current_cycle_start"] == date(2026, 4, 1)
     assert stats["current_cycle_end"] == date(2026, 4, 30)
+
+
+def test_build_habit_stats_payload_uses_selected_calendar_month_cycles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        habit_support,
+        "get_operational_date",
+        lambda value=None: date(2026, 8, 10),
+    )
+    monkeypatch.setattr(
+        habit_support,
+        "get_week_bounds",
+        lambda reference_date: (date(2026, 8, 9), date(2026, 8, 15)),
+    )
+    monkeypatch.setattr(
+        habit_support,
+        "get_preferences_settings",
+        lambda: SimpleNamespace(
+            day_starts_at="00:00",
+            timezone="UTC",
+            week_starts_on="monday",
+            calendar_system="mayan_13_moon",
+            calendar_first_day_of_week=1,
+        ),
+    )
+
+    habit = SimpleNamespace(
+        id=UUID("cccccccc-cccc-cccc-cccc-cccccccccccc"),
+        start_date=date(2026, 7, 26),
+        cadence_frequency="monthly",
+        cadence_weekdays=None,
+        cadence_monthdays=[1, 15],
+        target_per_cycle=2,
+    )
+    actions = [
+        SimpleNamespace(action_date=date(2026, 7, 26), status="done"),
+        SimpleNamespace(action_date=date(2026, 8, 9), status="done"),
+    ]
+
+    stats = habit_support.build_habit_stats_payload(cast(Any, habit), cast(Any, actions))
+
+    assert stats["cadence_monthdays"] == (1, 15)
+    assert stats["completed_cycles"] == 1
+    assert stats["current_cycle_start"] == date(2026, 7, 26)
+    assert stats["current_cycle_end"] == date(2026, 8, 22)
 
 
 def test_habit_task_associations_require_active_tasks(

--- a/tests/test_web_cli.py
+++ b/tests/test_web_cli.py
@@ -1775,6 +1775,83 @@ def test_web_habit_update_null_fields_translate_to_clear_flags(
     assert captured["clear_task"] is True
 
 
+def test_web_habit_create_passes_repeat_count_and_cadence_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("fastapi")
+
+    from lifeos_web.routers import habits
+    from lifeos_web.schemas import HabitCreate
+
+    captured: dict[str, object] = {}
+
+    async def fake_create_habit(_session: object, **kwargs: object) -> object:
+        captured.update(kwargs)
+        return SimpleNamespace(id=UUID("22222222-2222-2222-2222-222222222222"))
+
+    monkeypatch.setattr(habits.habit_services, "create_habit", fake_create_habit)
+    monkeypatch.setattr(
+        habits,
+        "_habit_model_payload",
+        lambda habit: {"id": str(habit.id)},
+    )
+
+    asyncio.run(
+        habits.create_habit(
+            HabitCreate(
+                title="Weekend calls",
+                start_date=date(2026, 4, 9),
+                repeat_count=3,
+                cadence_frequency="weekly",
+                cadence_weekdays=["saturday", "sunday"],
+                target_per_cycle=1,
+            ),
+            cast(AsyncSession, object()),
+        )
+    )
+
+    assert captured["duration_days"] is None
+    assert captured["repeat_count"] == 3
+    assert captured["end_date"] is None
+    assert captured["cadence_frequency"] == "weekly"
+    assert captured["cadence_weekdays"] == ["saturday", "sunday"]
+    assert captured["target_per_cycle"] == 1
+
+
+def test_web_habit_update_passes_end_date(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("fastapi")
+
+    from lifeos_web.routers import habits
+    from lifeos_web.schemas import HabitUpdate
+
+    captured: dict[str, object] = {}
+
+    async def fake_update_habit(_session: object, **kwargs: object) -> object:
+        captured.update(kwargs)
+        return SimpleNamespace(id=UUID("22222222-2222-2222-2222-222222222222"))
+
+    monkeypatch.setattr(habits.habit_services, "update_habit", fake_update_habit)
+    monkeypatch.setattr(
+        habits,
+        "_habit_model_payload",
+        lambda habit: {"id": str(habit.id)},
+    )
+
+    asyncio.run(
+        habits.update_habit(
+            UUID("55555555-5555-5555-5555-555555555555"),
+            HabitUpdate(end_date=date(2026, 5, 1)),
+            cast(AsyncSession, object()),
+        )
+    )
+
+    assert captured["duration_days"] is None
+    assert captured["repeat_count"] is None
+    assert captured["end_date"] == date(2026, 5, 1)
+
+
 def test_web_habit_action_update_null_notes_maps_to_clear_notes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_web_cli.py
+++ b/tests/test_web_cli.py
@@ -1871,7 +1871,7 @@ def test_web_habit_update_passes_end_date(
     assert captured["end_date"] == date(2026, 5, 1)
 
 
-def test_web_habit_actions_by_date_filters_active_habits(
+def test_web_habit_actions_by_date_uses_lifecycle_aware_action_query(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     pytest.importorskip("fastapi")
@@ -1897,7 +1897,7 @@ def test_web_habit_actions_by_date_filters_active_habits(
         )
     )
 
-    assert captured["habit_status"] == "active"
+    assert "habit_status" not in captured
     assert captured["date_values"] == (date(2026, 4, 9),)
     assert response.items == []
 

--- a/tests/test_web_cli.py
+++ b/tests/test_web_cli.py
@@ -1871,6 +1871,37 @@ def test_web_habit_update_passes_end_date(
     assert captured["end_date"] == date(2026, 5, 1)
 
 
+def test_web_habit_actions_by_date_filters_active_habits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("fastapi")
+
+    from lifeos_web.routers import habits
+
+    captured: dict[str, object] = {}
+
+    async def fake_list_habit_actions(_session: object, **kwargs: object) -> list[object]:
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(
+        habits.habit_action_services,
+        "list_habit_actions",
+        fake_list_habit_actions,
+    )
+
+    response = asyncio.run(
+        habits.list_actions_by_date(
+            date(2026, 4, 9),
+            cast(AsyncSession, object()),
+        )
+    )
+
+    assert captured["habit_status"] == "active"
+    assert captured["date_values"] == (date(2026, 4, 9),)
+    assert response.items == []
+
+
 def test_web_habit_action_update_null_notes_maps_to_clear_notes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_web_cli.py
+++ b/tests/test_web_cli.py
@@ -1405,6 +1405,25 @@ def test_web_timelog_rejects_partial_date_filter() -> None:
     )
 
 
+def test_web_timelog_latest_end_time_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("fastapi")
+
+    from lifeos_web.routers import timelogs
+
+    async def fake_get_latest_timelog_end_time(_session: object) -> datetime | None:
+        return datetime(2026, 7, 4, 16, 30, tzinfo=timezone.utc)
+
+    monkeypatch.setattr(
+        timelogs.timelog_services,
+        "get_latest_timelog_end_time",
+        fake_get_latest_timelog_end_time,
+    )
+
+    response = asyncio.run(timelogs.get_latest_timelog_end_time(cast(AsyncSession, object())))
+
+    assert response == {"end_time": "2026-07-04T16:30:00+00:00"}
+
+
 def test_web_timelog_payload_exposes_linked_task_summary() -> None:
     pytest.importorskip("fastapi")
 

--- a/web/src/components/AdvancedSearchPanel.tsx
+++ b/web/src/components/AdvancedSearchPanel.tsx
@@ -10,6 +10,7 @@ import Card from "@/layouts/Card";
 import { useDefaultInboxVision } from "@/hooks/queries/useDefaultInboxVision";
 import { dateStringToISO, formatDateInTimezone } from "@/utils/datetime";
 import { FormField, TextInput } from "./forms";
+import { FORM_LABEL_COMPACT_CLASS } from "./forms/styles";
 import type { UUID } from "@/types/primitive";
 
 interface AdvancedSearchParams {
@@ -208,7 +209,7 @@ const AdvancedSearchPanel: React.FC<AdvancedSearchPanelProps> = ({
           <div>
             <label
               htmlFor="start-date"
-              className="block text-base font-medium mb-1"
+              className={FORM_LABEL_COMPACT_CLASS}
             >
               {t("timeLog.advancedSearch.startDateRequired")}
             </label>
@@ -233,7 +234,7 @@ const AdvancedSearchPanel: React.FC<AdvancedSearchPanelProps> = ({
           <div>
             <label
               htmlFor="end-date"
-              className="block text-base font-medium mb-1"
+              className={FORM_LABEL_COMPACT_CLASS}
             >
               {t("timeLog.advancedSearch.endDate")}
             </label>

--- a/web/src/components/AreaManagerModal.tsx
+++ b/web/src/components/AreaManagerModal.tsx
@@ -11,6 +11,7 @@ import ActionButton, {
 import ConfirmDialog from "./ConfirmDialog";
 import EnumSelect from "./selects/EnumSelect";
 import { FormField, TextInput, TextArea, Checkbox } from "./forms";
+import { FORM_LABEL_COMPACT_CLASS } from "./forms/styles";
 import { useAreaManagerController } from "@/features/areas/controller/useAreaManagerController";
 
 interface AreaManagerModalProps {
@@ -236,7 +237,7 @@ const AreaManagerModal: React.FC<AreaManagerModalProps> = ({
             </FormField>
 
             <div>
-              <label className="block text-base font-medium text-base-content mb-1">
+              <label className={FORM_LABEL_COMPACT_CLASS}>
                 {t("areaManager.color")}
               </label>
               <div className="flex space-x-2 mb-2">

--- a/web/src/components/BatchEditModal.tsx
+++ b/web/src/components/BatchEditModal.tsx
@@ -14,6 +14,7 @@ import { useToast } from "@/contexts/ToastContext";
 import TaskSelector from "./selects/TaskSelector";
 import { ALL_TASK_STATUSES } from "@/utils/constants";
 import { FormField, TextInput } from "./forms";
+import { FORM_LABEL_CLASS } from "./forms/styles";
 import type { UUID } from "@/types/primitive";
 
 interface BatchEditModalProps {
@@ -346,7 +347,7 @@ const BatchEditModal: React.FC<BatchEditModalProps> = ({
 
       {/* Edit Mode Selection */}
       <div className="mb-6">
-        <label className="block text-base font-medium text-base-content mb-3">
+        <label className={`${FORM_LABEL_CLASS} mb-3`}>
           {t("batchEdit.editType.label")}
         </label>
         <div className="flex gap-2">
@@ -379,7 +380,7 @@ const BatchEditModal: React.FC<BatchEditModalProps> = ({
         {editMode === "people" && (
           <div className="space-y-4">
             <div>
-              <label className="block text-base font-medium text-base-content mb-2">
+              <label className={`${FORM_LABEL_CLASS} mb-2`}>
                 {t("batchEdit.modes.label")}
               </label>
               <div className="flex gap-2">
@@ -423,7 +424,7 @@ const BatchEditModal: React.FC<BatchEditModalProps> = ({
         {editMode === "title" && (
           <div className="space-y-4">
             <div>
-              <label className="block text-base font-medium text-base-content mb-2">
+              <label className={`${FORM_LABEL_CLASS} mb-2`}>
                 {t("batchEdit.modes.label")}
               </label>
               <div className="flex gap-2">
@@ -486,7 +487,7 @@ const BatchEditModal: React.FC<BatchEditModalProps> = ({
         {editMode === "task" && (
           <div className="space-y-4">
             <div>
-              <label className="block text-base font-medium text-base-content mb-2">
+              <label className={`${FORM_LABEL_CLASS} mb-2`}>
                 {t("batchEdit.modes.label")}
               </label>
               <div className="flex gap-2">
@@ -532,7 +533,7 @@ const BatchEditModal: React.FC<BatchEditModalProps> = ({
         {editMode === "area" && (
           <div className="space-y-4">
             <div>
-              <label className="block text-base font-medium text-base-content mb-2">
+              <label className={`${FORM_LABEL_CLASS} mb-2`}>
                 {t("batchEdit.modes.label")}
               </label>
               <div className="flex gap-2">

--- a/web/src/components/InlineQuickTimeEntry.tsx
+++ b/web/src/components/InlineQuickTimeEntry.tsx
@@ -24,6 +24,7 @@ import ActionButton, { FormActions } from "./ActionButton";
 import { Icon } from "./icons";
 import TaskSelector from "./selects/TaskSelector";
 import { TextInput } from "./forms";
+import { FORM_LABEL_COMPACT_CLASS } from "./forms/styles";
 import {
   getNearestFiveMinuteTime,
   hhmmOnDateToISO,
@@ -846,7 +847,7 @@ export default function InlineQuickTimeEntry({
           <div className="flex-shrink-0 w-full lg:w-auto mt-4">
             <label
               htmlFor={`${idPrefix}-start-time`}
-              className="block text-base font-medium text-base-content mb-1"
+              className={FORM_LABEL_COMPACT_CLASS}
             >
               {t("eventModal.fields.startTime")}
             </label>
@@ -868,7 +869,7 @@ export default function InlineQuickTimeEntry({
           <div className="flex-shrink-0 w-full lg:w-auto  mt-4">
             <label
               htmlFor={`${idPrefix}-end-time`}
-              className="block text-base font-medium text-base-content mb-1"
+              className={FORM_LABEL_COMPACT_CLASS}
             >
               {t("eventModal.fields.endTime")}
             </label>
@@ -890,7 +891,7 @@ export default function InlineQuickTimeEntry({
           <div className="flex-shrink-0 w-full lg:w-auto  mt-4">
             <label
               htmlFor={`${idPrefix}-duration`}
-              className="flex items-center justify-between gap-2 text-base font-medium text-base-content mb-1"
+              className={`${FORM_LABEL_COMPACT_CLASS} flex items-center justify-between gap-2`}
             >
               <span>{t("timeLog.table.duration")}</span>
               <span className="text-sm text-base-content/70 whitespace-nowrap">
@@ -920,7 +921,7 @@ export default function InlineQuickTimeEntry({
           <div className="flex-1  mt-4">
             <label
               htmlFor={`${idPrefix}-title`}
-              className="block text-base font-medium text-base-content mb-1"
+              className={FORM_LABEL_COMPACT_CLASS}
             >
               {t("quickTimeEntry.activity.label")}
             </label>

--- a/web/src/components/PersonDetailModal.tsx
+++ b/web/src/components/PersonDetailModal.tsx
@@ -14,6 +14,7 @@ import UnifiedTag from "./UnifiedTag";
 import ActionButton from "./ActionButton";
 import { ActionButtonGroup } from "./ActionButton";
 import { TextInput } from "./forms";
+import { FORM_LABEL_MUTED_CLASS } from "./forms/styles";
 import { usePersonAnniversaries } from "@/hooks/queries/usePersonAnniversaries";
 import { useToast } from "@/contexts/ToastContext";
 
@@ -97,7 +98,7 @@ const PersonDetailModal: React.FC<PersonDetailModalProps> = ({
       <div className="space-y-4">
         {person.name && (
           <div>
-            <label className="block text-base font-medium text-base-content/70">
+            <label className={FORM_LABEL_MUTED_CLASS}>
               {t("personDetail.name")}
             </label>
             <p className="text-base">{person.name}</p>
@@ -109,7 +110,7 @@ const PersonDetailModal: React.FC<PersonDetailModalProps> = ({
           person.nicknames &&
           person.nicknames.length > 0 && (
             <div>
-              <label className="block text-base font-medium text-base-content/70">
+              <label className={FORM_LABEL_MUTED_CLASS}>
                 {t("personDetail.nicknames")}
               </label>
               <div className="flex flex-wrap gap-1 mt-1">
@@ -125,7 +126,7 @@ const PersonDetailModal: React.FC<PersonDetailModalProps> = ({
         {/* Show primary nickname for PersonSummary type */}
         {"primary_nickname" in person && person.primary_nickname && (
           <div>
-            <label className="block text-base font-medium text-base-content/70">
+            <label className={FORM_LABEL_MUTED_CLASS}>
               {t("personDetail.primaryNickname")}
             </label>
             <div className="mt-1">
@@ -138,7 +139,7 @@ const PersonDetailModal: React.FC<PersonDetailModalProps> = ({
 
         {person.birth_date && (
           <div>
-            <label className="block text-base font-medium text-base-content/70">
+            <label className={FORM_LABEL_MUTED_CLASS}>
               {t("personDetail.birthDate")}
             </label>
             <p className="text-base">{person.birth_date}</p>
@@ -147,7 +148,7 @@ const PersonDetailModal: React.FC<PersonDetailModalProps> = ({
 
         {(locationTags.length > 0 || person.location) && (
           <div>
-            <label className="block text-base font-medium text-base-content/70">
+            <label className={FORM_LABEL_MUTED_CLASS}>
               {t("personDetail.location")}
             </label>
             <div className="flex flex-wrap gap-1 mt-1">
@@ -168,7 +169,7 @@ const PersonDetailModal: React.FC<PersonDetailModalProps> = ({
 
         {relationshipTags.length > 0 && (
           <div>
-            <label className="block text-base font-medium text-base-content/70">
+            <label className={FORM_LABEL_MUTED_CLASS}>
               {t("personDetail.relationshipTags")}
             </label>
             <div className="flex flex-wrap gap-1 mt-1">
@@ -184,7 +185,7 @@ const PersonDetailModal: React.FC<PersonDetailModalProps> = ({
         {/* Show anniversaries only for Person type */}
         <div className="space-y-2">
           <div className="flex items-center justify-between">
-            <label className="block text-base font-medium text-base-content/70">
+            <label className={FORM_LABEL_MUTED_CLASS}>
               {t("personDetail.anniversaries")}
             </label>
             <ActionButton

--- a/web/src/components/PlannedEventModal.tsx
+++ b/web/src/components/PlannedEventModal.tsx
@@ -14,6 +14,7 @@ import { plannedEventsApi } from "@/services/api/plannedEvents";
 import ModalBase from "@/layouts/ModalBase";
 import RecurrenceSelector from "./RecurrenceSelector";
 import { FormField, TextInput, Checkbox, RadioGroup } from "./forms";
+import { FORM_LABEL_SPACED_CLASS } from "./forms/styles";
 import DateTimeSelector from "./forms/DateTimeSelector";
 
 import TaskSelector from "./selects/TaskSelector";
@@ -616,7 +617,7 @@ export default function PlannedEventModal({
             <div>
               <label
                 htmlFor="start-time-selector"
-                className="block text-sm sm:text-base font-medium text-base-content mb-1 sm:mb-2"
+                className={FORM_LABEL_SPACED_CLASS}
               >
                 {t("eventModal.fields.startTime")}{" "}
                 <span className="text-error">*</span>
@@ -649,7 +650,7 @@ export default function PlannedEventModal({
               <div>
                 <label
                   htmlFor="end-time-selector"
-                  className="block text-sm sm:text-base font-medium text-base-content mb-1 sm:mb-2"
+                  className={FORM_LABEL_SPACED_CLASS}
                 >
                   {t("eventModal.fields.endTime")}
                 </label>

--- a/web/src/components/QuickTemplateEditorModal.tsx
+++ b/web/src/components/QuickTemplateEditorModal.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import ModalBase from "@/layouts/ModalBase";
 import { FormActions } from "./ActionButton";
 import { TextInput } from "./forms";
+import { FORM_LABEL_COMPACT_CLASS } from "./forms/styles";
 import AreaSelect from "./selects/AreaSelect";
 import PersonSelector from "./selects/PersonSelector";
 import type { UUID } from "@/types/primitive";
@@ -113,7 +114,7 @@ const QuickTemplateEditorModal = ({
           <div>
             <label
               htmlFor="quick-template-title"
-              className="block text-sm font-medium text-base-content mb-1"
+              className={FORM_LABEL_COMPACT_CLASS}
             >
               {t("quickTemplatesManager.activityDescription")}
             </label>
@@ -139,7 +140,7 @@ const QuickTemplateEditorModal = ({
           <div>
             <label
               htmlFor="quick-template-duration"
-              className="block text-sm font-medium text-base-content mb-1"
+              className={FORM_LABEL_COMPACT_CLASS}
             >
               {t("quickTemplatesManager.durationOptional")}
             </label>

--- a/web/src/components/RecurrenceSelector.tsx
+++ b/web/src/components/RecurrenceSelector.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import EnumSelect from "./selects/EnumSelect";
 import { Checkbox, TextInput } from "./forms";
+import { FORM_LABEL_COMPACT_CLASS, FORM_LABEL_CLASS } from "./forms/styles";
 
 interface CustomRecurrenceConfig {
   frequency: "DAILY" | "WEEKLY" | "MONTHLY" | "YEARLY";
@@ -339,7 +340,7 @@ export default function RecurrenceSelector({
             <div>
               <label
                 htmlFor="interval"
-                className="block text-sm font-medium text-base-content mb-1"
+                className={FORM_LABEL_COMPACT_CLASS}
               >
                 {t("target.interval")}
               </label>
@@ -363,7 +364,7 @@ export default function RecurrenceSelector({
           {/* Weekly Configuration */}
           {customConfig.frequency === "WEEKLY" && (
             <div>
-              <label className="block text-sm font-medium text-base-content mb-2">
+              <label className={`${FORM_LABEL_CLASS} mb-2`}>
                 选择星期
               </label>
               <div className="flex flex-wrap gap-2">
@@ -399,7 +400,7 @@ export default function RecurrenceSelector({
           {/* Monthly Configuration */}
           {customConfig.frequency === "MONTHLY" && (
             <div>
-              <label className="block text-sm font-medium text-base-content mb-2">
+              <label className={`${FORM_LABEL_CLASS} mb-2`}>
                 重复方式
               </label>
               <div className="space-y-2">
@@ -418,7 +419,7 @@ export default function RecurrenceSelector({
                     }}
                     className="mr-2"
                   />
-                  <span className="text-base">按日期：每月</span>
+                  <span className="text-sm">按日期：每月</span>
                   <TextInput
                     id="monthDay"
                     name="monthDay"
@@ -438,7 +439,7 @@ export default function RecurrenceSelector({
                     className="mx-1 w-16"
                     disabled={!customConfig.monthDay}
                   />
-                  <span className="text-base">日</span>
+                  <span className="text-sm">日</span>
                 </label>
 
                 <label className="flex items-center">
@@ -455,7 +456,7 @@ export default function RecurrenceSelector({
                     }}
                     className="mr-2"
                   />
-                  <span className="text-base">按星期：每月</span>
+                  <span className="text-sm">按星期：每月</span>
                   <div className="mx-1 min-w-[110px]">
                     <EnumSelect
                       id="monthly-occurrence"

--- a/web/src/components/TimeEntryModal.tsx
+++ b/web/src/components/TimeEntryModal.tsx
@@ -15,6 +15,7 @@ import ModalBase from "@/layouts/ModalBase";
 import { FormActions } from "./ActionButton";
 import AreaSelect from "./selects/AreaSelect";
 import { TextInput } from "./forms";
+import { FORM_LABEL_SPACED_CLASS } from "./forms/styles";
 import { useModalState } from "@/hooks/useModalState";
 import { useToast } from "@/contexts/ToastContext";
 import { usePreferenceWithBootstrap } from "@/hooks/queries/usePreferenceWithBootstrap";
@@ -445,7 +446,7 @@ const TimeEntryModal = ({
         <div className="mb-4">
           <label
             htmlFor="title"
-            className="block text-base font-medium text-base-content mb-2"
+            className={FORM_LABEL_SPACED_CLASS}
           >
             {t("timeLog.modal.activity")} *
           </label>
@@ -466,7 +467,7 @@ const TimeEntryModal = ({
           <div>
             <label
               htmlFor="start_time"
-              className="block text-base font-medium text-base-content mb-2"
+              className={FORM_LABEL_SPACED_CLASS}
             >
               {t("eventModal.fields.startTime")}
             </label>
@@ -483,7 +484,7 @@ const TimeEntryModal = ({
           <div>
             <label
               htmlFor="end_time"
-              className="block text-base font-medium text-base-content mb-2"
+              className={FORM_LABEL_SPACED_CLASS}
             >
               {t("timeLog.modal.endTimeRequired")}
             </label>

--- a/web/src/components/forms/Checkbox.tsx
+++ b/web/src/components/forms/Checkbox.tsx
@@ -5,6 +5,7 @@ import React, {
   useImperativeHandle,
   useRef,
 } from "react";
+import { FORM_DESCRIPTION_CLASS, FORM_LABEL_CLASS } from "./styles";
 
 type NativeCheckboxProps = Omit<
   React.InputHTMLAttributes<HTMLInputElement>,
@@ -198,15 +199,12 @@ const Checkbox = forwardRef<CheckboxRef, CheckboxProps>(
 
       return (
         <div className="flex flex-col gap-1">
-          <span className="text-sm font-medium text-base-content">
+          <span className={FORM_LABEL_CLASS}>
             {label}
             {required && <span className="text-error ml-1">*</span>}
           </span>
           {description && (
-            <span
-              id={descriptionId}
-              className="text-xs sm:text-sm text-base-content/70"
-            >
+            <span id={descriptionId} className={FORM_DESCRIPTION_CLASS}>
               {description}
             </span>
           )}

--- a/web/src/components/forms/Checkbox.tsx
+++ b/web/src/components/forms/Checkbox.tsx
@@ -198,7 +198,7 @@ const Checkbox = forwardRef<CheckboxRef, CheckboxProps>(
 
       return (
         <div className="flex flex-col gap-1">
-          <span className="text-sm sm:text-base font-medium text-base-content">
+          <span className="text-sm font-medium text-base-content">
             {label}
             {required && <span className="text-error ml-1">*</span>}
           </span>

--- a/web/src/components/forms/CheckboxGroup.tsx
+++ b/web/src/components/forms/CheckboxGroup.tsx
@@ -288,7 +288,7 @@ const CheckboxGroup = forwardRef<CheckboxGroupRef, CheckboxGroupProps>(
         {label && (
           <legend
             id={legendId}
-            className="text-sm sm:text-base font-medium text-base-content"
+            className="text-sm font-medium text-base-content"
           >
             {label}
             {required && <span className="text-error ml-1">*</span>}

--- a/web/src/components/forms/CheckboxGroup.tsx
+++ b/web/src/components/forms/CheckboxGroup.tsx
@@ -1,6 +1,7 @@
 import React, { forwardRef, useId, useImperativeHandle, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import Checkbox from "./Checkbox";
+import { FORM_DESCRIPTION_CLASS, FORM_LABEL_CLASS } from "./styles";
 
 interface CheckboxOption {
   /** 选项值 */
@@ -288,7 +289,7 @@ const CheckboxGroup = forwardRef<CheckboxGroupRef, CheckboxGroupProps>(
         {label && (
           <legend
             id={legendId}
-            className="text-sm font-medium text-base-content"
+            className={FORM_LABEL_CLASS}
           >
             {label}
             {required && <span className="text-error ml-1">*</span>}
@@ -296,10 +297,7 @@ const CheckboxGroup = forwardRef<CheckboxGroupRef, CheckboxGroupProps>(
         )}
 
         {description && (
-          <p
-            id={descriptionId}
-            className="text-xs sm:text-sm text-base-content/70"
-          >
+          <p id={descriptionId} className={FORM_DESCRIPTION_CLASS}>
             {description}
           </p>
         )}

--- a/web/src/components/forms/DateTimeSelector.tsx
+++ b/web/src/components/forms/DateTimeSelector.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { formatDateTime } from "@/utils/datetime";
 import { normalizeTimezone, zonedDateTimeToUtc } from "@/utils/datetime";
 import TextInput from "./TextInput";
+import { FORM_LABEL_COMPACT_CLASS } from "./styles";
 
 interface DateTimeSelectorProps {
   /** Current ISO datetime string */
@@ -209,7 +210,7 @@ export default function DateTimeSelector({
       <div>
         <label
           htmlFor={dateId}
-          className="block text-sm font-medium text-base-content mb-1"
+          className={FORM_LABEL_COMPACT_CLASS}
         >
           {t("common.date")}
         </label>
@@ -228,7 +229,7 @@ export default function DateTimeSelector({
         <div>
           <label
             htmlFor={timeId}
-            className="block text-sm font-medium text-base-content mb-1"
+            className={FORM_LABEL_COMPACT_CLASS}
           >
             {t("common.time")}
           </label>

--- a/web/src/components/forms/FormField.tsx
+++ b/web/src/components/forms/FormField.tsx
@@ -1,4 +1,8 @@
 import React from "react";
+import {
+  FORM_DESCRIPTION_CLASS,
+  FORM_LABEL_SPACED_CLASS,
+} from "./styles";
 
 interface FormFieldProps {
   label?: string;
@@ -34,7 +38,7 @@ const FormField: React.FC<FormFieldProps> = ({
     ? "space-y-2 border border-error rounded-lg p-2"
     : "space-y-2";
 
-  const labelClasses = `block text-sm font-medium text-base-content mb-1 sm:mb-2 ${labelClassName}`;
+  const labelClasses = `${FORM_LABEL_SPACED_CLASS} ${labelClassName}`;
 
   return (
     <div className={containerClasses}>
@@ -52,7 +56,7 @@ const FormField: React.FC<FormFieldProps> = ({
         ))}
 
       {description && (
-        <div className="text-xs sm:text-sm text-base-content/70">{description}</div>
+        <div className={FORM_DESCRIPTION_CLASS}>{description}</div>
       )}
 
       <div className={contentClassName}>{children}</div>

--- a/web/src/components/forms/FormField.tsx
+++ b/web/src/components/forms/FormField.tsx
@@ -34,7 +34,7 @@ const FormField: React.FC<FormFieldProps> = ({
     ? "space-y-2 border border-error rounded-lg p-2"
     : "space-y-2";
 
-  const labelClasses = `block text-sm sm:text-base font-medium text-base-content mb-1 sm:mb-2 ${labelClassName}`;
+  const labelClasses = `block text-sm font-medium text-base-content mb-1 sm:mb-2 ${labelClassName}`;
 
   return (
     <div className={containerClasses}>
@@ -52,7 +52,7 @@ const FormField: React.FC<FormFieldProps> = ({
         ))}
 
       {description && (
-        <div className="text-sm text-base-content/70">{description}</div>
+        <div className="text-xs sm:text-sm text-base-content/70">{description}</div>
       )}
 
       <div className={contentClassName}>{children}</div>

--- a/web/src/components/forms/RadioGroup.tsx
+++ b/web/src/components/forms/RadioGroup.tsx
@@ -1,4 +1,5 @@
 import React, { useId, useMemo, useRef, useState } from "react";
+import { FORM_DESCRIPTION_CLASS, FORM_LABEL_CLASS } from "./styles";
 
 type RadioGroupValue = string;
 
@@ -104,13 +105,13 @@ export default function RadioGroup({
       {label ? (
         <legend
           id={legendId}
-          className="text-sm font-medium text-base-content"
+          className={FORM_LABEL_CLASS}
         >
           {label}
         </legend>
       ) : null}
       {description ? (
-        <div id={descriptionId} className="text-sm text-base-content/70">
+        <div id={descriptionId} className={FORM_DESCRIPTION_CLASS}>
           {description}
         </div>
       ) : null}
@@ -178,7 +179,7 @@ export default function RadioGroup({
                     .join(" ")}
                 />
                 <div className="space-y-1">
-                  <div className="font-medium text-sm sm:text-base text-base-content">
+                  <div className="font-medium text-sm text-base-content">
                     {option.label}
                   </div>
                   {option.description ? (

--- a/web/src/components/forms/RadioGroup.tsx
+++ b/web/src/components/forms/RadioGroup.tsx
@@ -104,7 +104,7 @@ export default function RadioGroup({
       {label ? (
         <legend
           id={legendId}
-          className="text-sm sm:text-base font-medium text-base-content"
+          className="text-sm font-medium text-base-content"
         >
           {label}
         </legend>

--- a/web/src/components/forms/SegmentedControl.tsx
+++ b/web/src/components/forms/SegmentedControl.tsx
@@ -1,4 +1,5 @@
 import React, { useId, useMemo, useRef, useState } from "react";
+import { FORM_LABEL_CLASS } from "./styles";
 
 type SegmentedValue = string;
 
@@ -89,7 +90,7 @@ export default function SegmentedControl({
       {label ? (
         <legend
           id={legendId}
-          className="text-sm font-medium text-base-content"
+          className={FORM_LABEL_CLASS}
         >
           {label}
         </legend>

--- a/web/src/components/forms/SegmentedControl.tsx
+++ b/web/src/components/forms/SegmentedControl.tsx
@@ -89,7 +89,7 @@ export default function SegmentedControl({
       {label ? (
         <legend
           id={legendId}
-          className="text-sm sm:text-base font-medium text-base-content"
+          className="text-sm font-medium text-base-content"
         >
           {label}
         </legend>

--- a/web/src/components/forms/TextArea.tsx
+++ b/web/src/components/forms/TextArea.tsx
@@ -21,7 +21,7 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
   ) => {
     const sizeClasses = {
       sm: "h-16 text-xs",
-      md: "h-20 sm:h-24 lg:h-28 text-sm sm:text-base",
+      md: "h-20 sm:h-24 lg:h-28 text-sm",
       lg: "h-32 text-base sm:text-lg",
     } as const;
 

--- a/web/src/components/forms/TextInput.tsx
+++ b/web/src/components/forms/TextInput.tsx
@@ -17,7 +17,7 @@ const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
   ({ className = "", size = "md", type = "text", ...rest }, ref) => {
     const sizeClasses = {
       sm: "h-8 text-xs",
-      md: "h-10 sm:h-12 text-sm sm:text-base",
+      md: "h-10 sm:h-12 text-sm",
       lg: "h-14 text-base sm:text-lg",
     } as const;
 

--- a/web/src/components/forms/index.ts
+++ b/web/src/components/forms/index.ts
@@ -4,5 +4,6 @@ export { default as InputGroup } from "./InputGroup";
 export { default as TextInput } from "./TextInput";
 export { default as TextArea } from "./TextArea";
 export { default as Checkbox } from "./Checkbox";
+export { default as CheckboxGroup } from "./CheckboxGroup";
 export { default as RadioGroup } from "./RadioGroup";
 export { default as SegmentedControl } from "./SegmentedControl";

--- a/web/src/components/forms/styles.ts
+++ b/web/src/components/forms/styles.ts
@@ -1,0 +1,7 @@
+export const FORM_LABEL_CLASS = "block text-sm font-medium text-base-content";
+export const FORM_LABEL_MUTED_CLASS =
+  "block text-sm font-medium text-base-content/70";
+export const FORM_LABEL_COMPACT_CLASS = `${FORM_LABEL_CLASS} mb-1`;
+export const FORM_LABEL_SPACED_CLASS = `${FORM_LABEL_CLASS} mb-1 sm:mb-2`;
+export const FORM_DESCRIPTION_CLASS = "text-xs sm:text-sm text-base-content/70";
+export const SELECT_LABEL_TEXT_CLASS = "label-text text-sm";

--- a/web/src/components/habits/HabitFormModal.tsx
+++ b/web/src/components/habits/HabitFormModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import ModalBase from "@/layouts/ModalBase";
 
@@ -12,14 +12,24 @@ import { logger } from "@/utils/core";
 import TaskSelector from "@/components/selects/TaskSelector";
 import { DeleteButton, FormActions } from "@/components/ActionButton";
 import EnumSelect from "@/components/selects/EnumSelect";
-import { FormField, TextInput, TextArea } from "@/components/forms";
 import {
-  HABIT_STATUS_FILTER_OPTIONS,
-  HABIT_DURATION_OPTIONS,
+  CheckboxGroup,
+  FormField,
+  SegmentedControl,
+  TextArea,
+  TextInput,
+} from "@/components/forms";
+import {
   ACTIVE_TASK_STATUSES,
+  HABIT_STATUS_FILTER_OPTIONS,
 } from "@/utils/constants";
 import type { UUID } from "@/types/primitive";
-import { getTodayDateString } from "@/utils/datetime";
+import {
+  addDays,
+  formatDateKey,
+  getTodayDateString,
+  parseDateStringToLocalDate,
+} from "@/utils/datetime";
 
 interface HabitFormModalProps {
   open: boolean;
@@ -38,6 +48,39 @@ interface HabitPrefill {
   task_id?: UUID | null;
 }
 
+type HabitCadenceFrequency = "daily" | "weekly" | "monthly" | "yearly";
+type HabitEndMode = "repeat_count" | "until_date";
+
+const WEEKDAY_OPTIONS = [
+  { value: "monday", labelKey: "weekdays.monday" },
+  { value: "tuesday", labelKey: "weekdays.tuesday" },
+  { value: "wednesday", labelKey: "weekdays.wednesday" },
+  { value: "thursday", labelKey: "weekdays.thursday" },
+  { value: "friday", labelKey: "weekdays.friday" },
+  { value: "saturday", labelKey: "weekdays.saturday" },
+  { value: "sunday", labelKey: "weekdays.sunday" },
+] as const;
+
+function getHabitEndDate(startDate: string, durationDays: number): string {
+  const parsedStart = parseDateStringToLocalDate(startDate);
+  if (Number.isNaN(parsedStart.getTime())) return startDate;
+  return formatDateKey(addDays(parsedStart, Math.max(durationDays, 1) - 1));
+}
+
+function parseMonthdays(value: string): number[] | null {
+  const parts = value
+    .split(/[\s,]+/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+  if (parts.length === 0) return null;
+
+  const days = parts.map((part) => Number(part));
+  if (days.some((day) => !Number.isInteger(day) || day < 1 || day > 31)) {
+    return [];
+  }
+  return Array.from(new Set(days)).sort((a, b) => a - b);
+}
+
 export function HabitFormModal({
   open,
   onClose,
@@ -47,10 +90,18 @@ export function HabitFormModal({
   onUpdateHabit,
   onRequestDelete,
 }: HabitFormModalProps) {
+  const today = getTodayDateString();
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
-  const [startDate, setStartDate] = useState(getTodayDateString());
-  const [durationDays, setDurationDays] = useState<number>(7);
+  const [startDate, setStartDate] = useState(today);
+  const [cadenceFrequency, setCadenceFrequency] =
+    useState<HabitCadenceFrequency>("daily");
+  const [cadenceWeekdays, setCadenceWeekdays] = useState<string[]>([]);
+  const [cadenceMonthdaysText, setCadenceMonthdaysText] = useState("");
+  const [targetPerCycle, setTargetPerCycle] = useState(1);
+  const [endMode, setEndMode] = useState<HabitEndMode>("repeat_count");
+  const [repeatCount, setRepeatCount] = useState(100);
+  const [endDate, setEndDate] = useState(getHabitEndDate(today, 100));
   const [selectedTaskId, setSelectedTaskId] = useState<UUID | null>(null);
   const [status, setStatus] = useState<string>("active");
   const [loading, setLoading] = useState(false);
@@ -62,32 +113,76 @@ export function HabitFormModal({
   const isEditMode = !!habitToEdit;
   const taskFilterStatus = useMemo(() => ACTIVE_TASK_STATUSES, []);
 
-  // Initialize form data when habitToEdit changes
+  const weekdayOptions = useMemo(
+    () =>
+      WEEKDAY_OPTIONS.map((option) => ({
+        value: option.value,
+        label: t(option.labelKey),
+      })),
+    [t],
+  );
+
+  const cadenceOptions = useMemo(
+    () => [
+      { value: "daily", label: t("habitForm.cadence.daily") },
+      { value: "weekly", label: t("habitForm.cadence.weekly") },
+      { value: "monthly", label: t("habitForm.cadence.monthly") },
+      { value: "yearly", label: t("habitForm.cadence.yearly") },
+    ],
+    [t],
+  );
+
   useEffect(() => {
     setTaskSelectionTouched(false);
     if (habitToEdit) {
+      const nextFrequency =
+        (habitToEdit.cadence_frequency as HabitCadenceFrequency | null) ??
+        "daily";
       setTitle(habitToEdit.title);
       setDescription(habitToEdit.description || "");
       setStartDate(habitToEdit.start_date);
-      setDurationDays(habitToEdit.duration_days);
+      setCadenceFrequency(nextFrequency);
+      setCadenceWeekdays(habitToEdit.cadence_weekdays ?? []);
+      setCadenceMonthdaysText((habitToEdit.cadence_monthdays ?? []).join(","));
+      setTargetPerCycle(habitToEdit.target_per_cycle ?? 1);
+      setRepeatCount(habitToEdit.duration_days);
+      setEndDate(getHabitEndDate(habitToEdit.start_date, habitToEdit.duration_days));
+      setEndMode(nextFrequency === "daily" ? "repeat_count" : "until_date");
       setSelectedTaskId(habitToEdit.task_id || null);
       setStatus(habitToEdit.status);
-    } else if (prefillHabit) {
+      return;
+    }
+
+    if (prefillHabit) {
+      const nextToday = getTodayDateString();
       setTitle(prefillHabit.title);
       setDescription(prefillHabit.description || "");
-      setStartDate(getTodayDateString());
-      setDurationDays(prefillHabit.duration_days);
+      setStartDate(nextToday);
+      setCadenceFrequency("daily");
+      setCadenceWeekdays([]);
+      setCadenceMonthdaysText("");
+      setTargetPerCycle(1);
+      setEndMode("repeat_count");
+      setRepeatCount(prefillHabit.duration_days);
+      setEndDate(getHabitEndDate(nextToday, prefillHabit.duration_days));
       setSelectedTaskId(prefillHabit.task_id || null);
       setStatus("active");
-    } else {
-      // Reset form for create mode
-      setTitle("");
-      setDescription("");
-      setStartDate(getTodayDateString());
-      setDurationDays(7);
-      setSelectedTaskId(null);
-      setStatus("active");
+      return;
     }
+
+    const nextToday = getTodayDateString();
+    setTitle("");
+    setDescription("");
+    setStartDate(nextToday);
+    setCadenceFrequency("daily");
+    setCadenceWeekdays([]);
+    setCadenceMonthdaysText("");
+    setTargetPerCycle(1);
+    setEndMode("repeat_count");
+    setRepeatCount(100);
+    setEndDate(getHabitEndDate(nextToday, 100));
+    setSelectedTaskId(null);
+    setStatus("active");
   }, [habitToEdit, prefillHabit]);
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -103,20 +198,56 @@ export function HabitFormModal({
       return;
     }
 
+    const normalizedRepeatCount = Math.floor(Number(repeatCount));
+    if (endMode === "repeat_count" && normalizedRepeatCount <= 0) {
+      setError(t("habitForm.validation.repeatCountRequired"));
+      return;
+    }
+
+    if (endMode === "until_date") {
+      if (!endDate) {
+        setError(t("habitForm.validation.endDateRequired"));
+        return;
+      }
+      if (endDate < startDate) {
+        setError(t("habitForm.validation.endDateAfterStart"));
+        return;
+      }
+    }
+
+    const parsedMonthdays =
+      cadenceFrequency === "monthly" ? parseMonthdays(cadenceMonthdaysText) : null;
+    if (Array.isArray(parsedMonthdays) && parsedMonthdays.length === 0) {
+      setError(t("habitForm.validation.monthdaysInvalid"));
+      return;
+    }
+
+    const normalizedTarget = Math.max(1, Math.floor(Number(targetPerCycle) || 1));
+    const cadenceFields = {
+      cadence_frequency: cadenceFrequency,
+      cadence_weekdays: cadenceFrequency === "weekly" ? cadenceWeekdays : null,
+      cadence_monthdays: cadenceFrequency === "monthly" ? parsedMonthdays : null,
+      target_per_cycle: cadenceFrequency === "daily" ? 1 : normalizedTarget,
+    };
+    const endFields =
+      endMode === "repeat_count"
+        ? { repeat_count: normalizedRepeatCount, end_date: null }
+        : { end_date: endDate, repeat_count: null };
+
     setLoading(true);
     setError(null);
 
     try {
       if (isEditMode && habitToEdit && onUpdateHabit) {
-        // Edit mode
         const shouldSendTaskId = !isEditMode || taskSelectionTouched;
         const nextTaskId = selectedTaskId ?? null;
         const updateData: HabitUpdate = {
           title: title.trim(),
           description: description.trim() || undefined,
           start_date: startDate,
-          duration_days: durationDays,
-          status: status,
+          status,
+          ...cadenceFields,
+          ...endFields,
         };
         if (shouldSendTaskId) {
           updateData.task_id = nextTaskId;
@@ -125,14 +256,14 @@ export function HabitFormModal({
         await onUpdateHabit(habitToEdit.id, updateData);
         toast.showSuccess(t("habitForm.messages.updateSuccess"));
       } else if (!isEditMode && onCreateHabit) {
-        // Create mode
         const nextTaskId = selectedTaskId ?? null;
         const habitData: HabitCreate = {
           title: title.trim(),
           description: description.trim() || undefined,
           start_date: startDate,
-          duration_days: durationDays,
           task_id: nextTaskId,
+          ...cadenceFields,
+          ...endFields,
         };
 
         await onCreateHabit(habitData);
@@ -141,7 +272,6 @@ export function HabitFormModal({
         throw new Error("Missing required mutation functions");
       }
 
-      // 操作成功后关闭模态框
       onClose();
     } catch (err) {
       const action = isEditMode
@@ -157,11 +287,17 @@ export function HabitFormModal({
 
   const handleClose = () => {
     if (!loading) {
-      // 重置表单状态
+      const nextToday = getTodayDateString();
       setTitle("");
       setDescription("");
-      setStartDate(getTodayDateString());
-      setDurationDays(7);
+      setStartDate(nextToday);
+      setCadenceFrequency("daily");
+      setCadenceWeekdays([]);
+      setCadenceMonthdaysText("");
+      setTargetPerCycle(1);
+      setEndMode("repeat_count");
+      setRepeatCount(100);
+      setEndDate(getHabitEndDate(nextToday, 100));
       setSelectedTaskId(null);
       setStatus("active");
       setError(null);
@@ -287,24 +423,132 @@ export function HabitFormModal({
           />
         </FormField>
 
-        {/* Duration and Status in responsive grid layout */}
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4">
           <div className="space-y-1 sm:space-y-2">
             <EnumSelect
-              id="habit-form-duration"
-              value={String(durationDays)}
+              id="habit-form-cadence-frequency"
+              value={cadenceFrequency}
               onChange={(value) => {
-                if (value) {
-                  setDurationDays(parseInt(value));
+                const nextFrequency = (value || "daily") as HabitCadenceFrequency;
+                setCadenceFrequency(nextFrequency);
+                if (nextFrequency === "daily") {
+                  setTargetPerCycle(1);
                 }
               }}
               disabled={loading}
-              options={HABIT_DURATION_OPTIONS}
-              label={`${t("habitForm.fields.duration")} *`}
+              options={cadenceOptions}
+              label={`${t("habitForm.fields.cadenceFrequency")} *`}
             />
           </div>
 
-          {/* Status field - only show in edit mode */}
+          <FormField
+            label={t("habitForm.fields.targetPerCycle")}
+            htmlFor="targetPerCycle"
+            required={cadenceFrequency !== "daily"}
+          >
+            <TextInput
+              id="targetPerCycle"
+              name="targetPerCycle"
+              type="number"
+              min={1}
+              value={String(cadenceFrequency === "daily" ? 1 : targetPerCycle)}
+              onChange={(e) => setTargetPerCycle(Number(e.target.value) || 1)}
+              disabled={loading || cadenceFrequency === "daily"}
+              required={cadenceFrequency !== "daily"}
+            />
+          </FormField>
+        </div>
+
+        {cadenceFrequency === "weekly" && (
+          <CheckboxGroup
+            idPrefix="habit-form-weekdays"
+            name="habit-weekdays"
+            value={cadenceWeekdays}
+            options={weekdayOptions}
+            onChange={setCadenceWeekdays}
+            disabled={loading}
+            label={t("habitForm.fields.weekdays")}
+            direction="horizontal"
+            columns={4}
+            size="sm"
+          />
+        )}
+
+        {cadenceFrequency === "monthly" && (
+          <FormField
+            label={t("habitForm.fields.monthdays")}
+            htmlFor="monthdays"
+            description={t("habitForm.fields.monthdaysHint")}
+          >
+            <TextInput
+              id="monthdays"
+              name="monthdays"
+              type="text"
+              inputMode="numeric"
+              value={cadenceMonthdaysText}
+              onChange={(e) => setCadenceMonthdaysText(e.target.value)}
+              placeholder={t("habitForm.fields.monthdaysPlaceholder")}
+              disabled={loading}
+            />
+          </FormField>
+        )}
+
+        <SegmentedControl
+          name="habit-end-mode"
+          label={t("habitForm.fields.endMode")}
+          value={endMode}
+          onChange={(value) => setEndMode(value as HabitEndMode)}
+          disabled={loading}
+          options={[
+            {
+              value: "repeat_count",
+              label: t("habitForm.endMode.repeatCount"),
+            },
+            {
+              value: "until_date",
+              label: t("habitForm.endMode.untilDate"),
+            },
+          ]}
+          size="sm"
+        />
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4">
+          {endMode === "repeat_count" ? (
+            <FormField
+              label={t("habitForm.fields.repeatCount")}
+              htmlFor="repeatCount"
+              required
+            >
+              <TextInput
+                id="repeatCount"
+                name="repeatCount"
+                type="number"
+                min={1}
+                value={String(repeatCount)}
+                onChange={(e) => setRepeatCount(Number(e.target.value) || 1)}
+                disabled={loading}
+                required
+              />
+            </FormField>
+          ) : (
+            <FormField
+              label={t("habitForm.fields.endDate")}
+              htmlFor="endDate"
+              required
+            >
+              <TextInput
+                id="endDate"
+                name="endDate"
+                type="date"
+                value={endDate}
+                min={startDate}
+                onChange={(e) => setEndDate(e.target.value)}
+                disabled={loading}
+                required
+              />
+            </FormField>
+          )}
+
           {isEditMode && (
             <div className="space-y-1 sm:space-y-2">
               <EnumSelect

--- a/web/src/components/habits/HabitFormModal.tsx
+++ b/web/src/components/habits/HabitFormModal.tsx
@@ -400,7 +400,7 @@ export function HabitFormModal({
             }}
             placeholder={t("task.selectTaskPlaceholder")}
             disabled={loading}
-            className="text-sm sm:text-base"
+            className="text-sm"
             filterStatus={taskFilterStatus}
             idPrefix="habit-form"
           />

--- a/web/src/components/notes/NotesSidebar.tsx
+++ b/web/src/components/notes/NotesSidebar.tsx
@@ -78,7 +78,7 @@ export function NotesSidebar({
               value={searchKeyword}
               onChange={(e) => onSearchKeywordChange(e.target.value)}
               placeholder={t("notesSidebar.searchPlaceholder")}
-              className="text-base"
+              className="text-sm"
             />
           </div>
           <div className="flex gap-2">

--- a/web/src/components/planning/TaskCreationPanel.tsx
+++ b/web/src/components/planning/TaskCreationPanel.tsx
@@ -69,7 +69,7 @@ export const TaskCreationPanel: React.FC<TaskCreationPanelProps> = ({
             onChange={(event) => onTaskContentChange(event.target.value)}
             placeholder={t("planning.createTask.contentPlaceholder")}
             disabled={isCreatingTask}
-            className="text-base disabled:opacity-50 disabled:cursor-not-allowed"
+            className="text-sm disabled:opacity-50 disabled:cursor-not-allowed"
             onKeyDown={(event) => {
               if (event.key === "Enter" && !event.shiftKey) {
                 event.preventDefault();

--- a/web/src/components/planning/TaskGroupHeader.tsx
+++ b/web/src/components/planning/TaskGroupHeader.tsx
@@ -97,7 +97,7 @@ export const TaskGroupHeader: React.FC<TaskGroupHeaderProps> = ({
                 }
               }}
               options={statusFilterOptions}
-              className="text-sm sm:text-base min-w-28 max-w-48"
+              className="text-sm min-w-28 max-w-48"
               autoWidth
             />
             <EnumSelect
@@ -110,7 +110,7 @@ export const TaskGroupHeader: React.FC<TaskGroupHeaderProps> = ({
               }}
               options={visionFilterOptions}
               placeholder={t("planning.filters.vision.label")}
-              className="text-sm sm:text-base min-w-36 max-w-72"
+              className="text-sm min-w-36 max-w-72"
               autoWidth
             />
           </div>

--- a/web/src/components/selects/AsyncEntityMultiSelect.tsx
+++ b/web/src/components/selects/AsyncEntityMultiSelect.tsx
@@ -580,7 +580,7 @@ const AsyncEntityMultiSelect = forwardRef<
     <div ref={containerRef} className={containerClassName}>
       {showLabel && label && (
         <label htmlFor={inputId} className="label">
-          <span className="label-text">{label}</span>
+          <span className="label-text text-sm">{label}</span>
         </label>
       )}
 

--- a/web/src/components/selects/AsyncEntityMultiSelect.tsx
+++ b/web/src/components/selects/AsyncEntityMultiSelect.tsx
@@ -11,6 +11,7 @@ import {
 } from "react";
 import { useDropdownSurface } from "./useDropdownSurface";
 import type { EntityOption, SelectSize } from "./AsyncEntitySelect";
+import { SELECT_LABEL_TEXT_CLASS } from "@/components/forms/styles";
 
 export type MultiSelectOption = EntityOption;
 
@@ -580,7 +581,7 @@ const AsyncEntityMultiSelect = forwardRef<
     <div ref={containerRef} className={containerClassName}>
       {showLabel && label && (
         <label htmlFor={inputId} className="label">
-          <span className="label-text text-sm">{label}</span>
+          <span className={SELECT_LABEL_TEXT_CLASS}>{label}</span>
         </label>
       )}
 

--- a/web/src/components/selects/AsyncEntitySelect.tsx
+++ b/web/src/components/selects/AsyncEntitySelect.tsx
@@ -11,6 +11,7 @@ import {
 } from "react";
 import { useDropdownSurface } from "./useDropdownSurface";
 import { asSelectorString, type SelectorValue } from "./selectorTypes";
+import { SELECT_LABEL_TEXT_CLASS } from "@/components/forms/styles";
 
 export interface EntityOption {
   id: string;
@@ -571,7 +572,7 @@ const AsyncEntitySelect = forwardRef<HTMLInputElement, AsyncEntitySelectProps>(
       <div ref={containerRef} className={containerClassName}>
         {showLabel && label && (
           <label htmlFor={inputId} className="label">
-            <span className="label-text text-sm">{label}</span>
+            <span className={SELECT_LABEL_TEXT_CLASS}>{label}</span>
           </label>
         )}
 

--- a/web/src/components/selects/AsyncEntitySelect.tsx
+++ b/web/src/components/selects/AsyncEntitySelect.tsx
@@ -571,7 +571,7 @@ const AsyncEntitySelect = forwardRef<HTMLInputElement, AsyncEntitySelectProps>(
       <div ref={containerRef} className={containerClassName}>
         {showLabel && label && (
           <label htmlFor={inputId} className="label">
-            <span className="label-text">{label}</span>
+            <span className="label-text text-sm">{label}</span>
           </label>
         )}
 

--- a/web/src/components/selects/EnumSelect.tsx
+++ b/web/src/components/selects/EnumSelect.tsx
@@ -41,7 +41,7 @@ const EnumSelect: React.FC<EnumSelectProps> = ({
   placeholder,
   disabled,
   size = "sm",
-  className = "text-sm sm:text-base w-full",
+  className = "text-sm w-full",
   idPrefix = "enum-select",
   label,
   showLabel = true,

--- a/web/src/components/selects/TaskSelector.tsx
+++ b/web/src/components/selects/TaskSelector.tsx
@@ -125,7 +125,7 @@ const TaskSelectorOverride: React.FC<TaskSelectorProps> = ({
     <div className={`relative form-control ${className}`}>
       {showLabel && effectiveLabel && (
         <label htmlFor={`${idPrefix}-override`} className="label">
-          <span className="label-text">{effectiveLabel}</span>
+          <span className="label-text text-sm">{effectiveLabel}</span>
         </label>
       )}
 
@@ -318,7 +318,7 @@ const TaskSelectorManaged: React.FC<TaskSelectorProps> = ({
     <div className={`relative form-control ${className}`}>
       {showLabel && effectiveLabel && (
         <label htmlFor={`${idPrefix}-input`} className="label">
-          <span className="label-text">{effectiveLabel}</span>
+          <span className="label-text text-sm">{effectiveLabel}</span>
         </label>
       )}
 

--- a/web/src/components/selects/TaskSelector.tsx
+++ b/web/src/components/selects/TaskSelector.tsx
@@ -15,6 +15,7 @@ import { useVisions } from "@/hooks/queries/useVisions";
 import { tasksApi } from "@/services/api/tasks";
 import { tasksKeys } from "@/services/api/queryKeys";
 import { ACTIVE_TASK_STATUSES } from "@/utils/constants";
+import { SELECT_LABEL_TEXT_CLASS } from "@/components/forms/styles";
 import type { UUID } from "@/types/primitive";
 import { logger } from "@/utils/core";
 
@@ -125,7 +126,7 @@ const TaskSelectorOverride: React.FC<TaskSelectorProps> = ({
     <div className={`relative form-control ${className}`}>
       {showLabel && effectiveLabel && (
         <label htmlFor={`${idPrefix}-override`} className="label">
-          <span className="label-text text-sm">{effectiveLabel}</span>
+          <span className={SELECT_LABEL_TEXT_CLASS}>{effectiveLabel}</span>
         </label>
       )}
 
@@ -318,7 +319,7 @@ const TaskSelectorManaged: React.FC<TaskSelectorProps> = ({
     <div className={`relative form-control ${className}`}>
       {showLabel && effectiveLabel && (
         <label htmlFor={`${idPrefix}-input`} className="label">
-          <span className="label-text text-sm">{effectiveLabel}</span>
+          <span className={SELECT_LABEL_TEXT_CLASS}>{effectiveLabel}</span>
         </label>
       )}
 

--- a/web/src/components/selects/VisionSelector.tsx
+++ b/web/src/components/selects/VisionSelector.tsx
@@ -179,7 +179,9 @@ const VisionSelector: React.FC<VisionSelectorProps> = React.memo(
         />
         {hasError && (
           <div className="label">
-            <span className="label-text-alt text-error">{errorMessage}</span>
+            <span className="label-text-alt text-xs text-error">
+              {errorMessage}
+            </span>
           </div>
         )}
       </div>

--- a/web/src/components/settings/SettingItem.tsx
+++ b/web/src/components/settings/SettingItem.tsx
@@ -4,6 +4,7 @@ import EnumSelect from "@/components/selects/EnumSelect";
 import Checkbox from "@/components/forms/Checkbox";
 import CheckboxGroup from "@/components/forms/CheckboxGroup";
 import TextInput from "@/components/forms/TextInput";
+import { FORM_LABEL_CLASS } from "@/components/forms/styles";
 import ErrorDisplay from "@/components/ErrorDisplay";
 import type { SettingItemConfig } from "./types";
 import type { PreferenceWithBootstrapReturn } from "@/hooks/queries/usePreferenceWithBootstrap";
@@ -255,7 +256,7 @@ const SettingItem: React.FC<SettingItemProps> = ({
         !config.hideLabel && (
           <div
             id={`${getControlId()}-label`}
-            className="block text-base font-medium"
+            className={FORM_LABEL_CLASS}
           >
             {config.label}
           </div>

--- a/web/src/components/tasks/TaskEditModalView.tsx
+++ b/web/src/components/tasks/TaskEditModalView.tsx
@@ -6,6 +6,7 @@ import TaskSelector from "@/components/selects/TaskSelector";
 import EnumSelect from "@/components/selects/EnumSelect";
 import PersonSelector from "@/components/selects/PersonSelector";
 import { FormField, TextArea, TextInput } from "@/components/forms";
+import { FORM_LABEL_COMPACT_CLASS } from "@/components/forms/styles";
 import ActionButton, {
   ActionButtonGroup,
   FormActions,
@@ -364,7 +365,7 @@ export const TaskEditModalView: React.FC<TaskEditModalViewProps> = ({
               <div className="mt-0 sm:mt-2">
                 <label
                   htmlFor={planningCycleYearId}
-                  className="block text-sm font-medium text-base-content mb-1"
+                  className={FORM_LABEL_COMPACT_CLASS}
                 >
                   {t("taskForm.planning.startLabels.year")}
                 </label>
@@ -385,7 +386,7 @@ export const TaskEditModalView: React.FC<TaskEditModalViewProps> = ({
                 <div className="mt-0 sm:mt-2">
                   <label
                     htmlFor={planningCycleStartDateId}
-                    className="block text-sm font-medium text-base-content mb-1"
+                    className={FORM_LABEL_COMPACT_CLASS}
                   >
                     {formData.planning_cycle_type === "year" &&
                       t("taskForm.planning.startLabels.year")}

--- a/web/src/features/timeLog/bulkImport/TimeLogBulkImportPanel.tsx
+++ b/web/src/features/timeLog/bulkImport/TimeLogBulkImportPanel.tsx
@@ -308,6 +308,9 @@ const TimeLogBulkImportPanel: React.FC<TimeLogBulkImportPanelProps> = ({
         latestTimelogEndTime,
       ).time,
   );
+  const [isStartDateCustomized, setIsStartDateCustomized] = useState(false);
+  const [isFirstStartTimeCustomized, setIsFirstStartTimeCustomized] =
+    useState(false);
   const [rawInput, setRawInput] = useState("");
   const [rows, setRows] = useState<EditableRow[]>([]);
   const [globalErrors, setGlobalErrors] = useState<BulkImportMessage[]>([]);
@@ -333,9 +336,13 @@ const TimeLogBulkImportPanel: React.FC<TimeLogBulkImportPanelProps> = ({
   );
 
   useEffect(() => {
-    setStartDateInput(defaultStart.date);
-    setFirstStartTime(defaultStart.time);
-  }, [defaultStart]);
+    if (!isStartDateCustomized) {
+      setStartDateInput(defaultStart.date);
+    }
+    if (!isFirstStartTimeCustomized) {
+      setFirstStartTime(defaultStart.time);
+    }
+  }, [defaultStart, isFirstStartTimeCustomized, isStartDateCustomized]);
 
   const baseDateString = useMemo(
     () =>
@@ -619,7 +626,10 @@ const TimeLogBulkImportPanel: React.FC<TimeLogBulkImportPanelProps> = ({
             <TextInput
               type="date"
               value={startDateInput}
-              onChange={(event) => setStartDateInput(event.target.value)}
+              onChange={(event) => {
+                setIsStartDateCustomized(true);
+                setStartDateInput(event.target.value);
+              }}
             />
           </div>
           <div>
@@ -629,7 +639,10 @@ const TimeLogBulkImportPanel: React.FC<TimeLogBulkImportPanelProps> = ({
             <TextInput
               type="time"
               value={firstStartTime}
-              onChange={(event) => setFirstStartTime(event.target.value)}
+              onChange={(event) => {
+                setIsFirstStartTimeCustomized(true);
+                setFirstStartTime(event.target.value);
+              }}
             />
           </div>
         </div>

--- a/web/src/features/timeLog/controller/useTimeLogData.ts
+++ b/web/src/features/timeLog/controller/useTimeLogData.ts
@@ -1,6 +1,9 @@
 import { useState, useCallback, useEffect } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { invalidateTimelogList } from "@/services/api/cacheInvalidation/timelogs";
+import {
+  invalidateTimelogLatestEndTime,
+  invalidateTimelogList,
+} from "@/services/api/cacheInvalidation/timelogs";
 import { timelogsApi } from "@/services/api/timelogs";
 import { processTimeEntries, type ProcessedEntry } from "@/utils/datetime";
 import { logger } from "@/utils/core";
@@ -145,6 +148,7 @@ export const useTimeLogData = ({
     onSuccess: () => {
       toast.showSuccess("时间日志删除成功！");
       invalidateTimelogList(queryClient, singleDayListFilters);
+      invalidateTimelogLatestEndTime(queryClient);
     },
     onError: (err: Error) => {
       logger.error("Failed to delete entry:", err);
@@ -168,6 +172,7 @@ export const useTimeLogData = ({
         setIsSelectMode(false);
       }
       invalidateTimelogList(queryClient, singleDayListFilters);
+      invalidateTimelogLatestEndTime(queryClient);
     },
     onError: (err: Error) => {
       logger.error("Failed to batch delete entries:", err);

--- a/web/src/hooks/queries/useHabits.ts
+++ b/web/src/hooks/queries/useHabits.ts
@@ -11,6 +11,7 @@ import { habitsKeys } from "@/services/api/queryKeys";
 import type { UUID } from "@/types/primitive";
 import {
   invalidateHabitActions,
+  invalidateHabitActionsByDate,
   invalidateHabitStats,
   invalidateHabitsLists,
   removeHabitDetailCache,
@@ -91,7 +92,10 @@ export function useHabits(filters: UseHabitsFilters = {}): UseHabitsReturn {
     mutationFn: (habit: HabitCreate) => habitsApi.create(habit),
     onSuccess: async (created) => {
       setHabitDetailCache(queryClient, created);
-      await invalidateHabitsLists(queryClient);
+      await Promise.all([
+        invalidateHabitsLists(queryClient),
+        invalidateHabitActionsByDate(queryClient),
+      ]);
     },
     onError: (err: Error) => {
       console.error("Create habit failed", err.message);
@@ -107,6 +111,8 @@ export function useHabits(filters: UseHabitsFilters = {}): UseHabitsReturn {
       await Promise.all([
         invalidateHabitsLists(queryClient),
         invalidateHabitStats(queryClient, updated.id),
+        invalidateHabitActions(queryClient, updated.id),
+        invalidateHabitActionsByDate(queryClient),
       ]);
     },
     onError: (err: Error) => {
@@ -124,6 +130,7 @@ export function useHabits(filters: UseHabitsFilters = {}): UseHabitsReturn {
         invalidateHabitsLists(queryClient),
         invalidateHabitStats(queryClient, habitId),
         invalidateHabitActions(queryClient, habitId),
+        invalidateHabitActionsByDate(queryClient),
       ]);
     },
     onError: (err: Error) => {
@@ -144,6 +151,7 @@ export function useHabits(filters: UseHabitsFilters = {}): UseHabitsReturn {
     }) => habitsApi.updateAction(habitId, actionId, actionUpdate),
     onSuccess: (_, { habitId }) => {
       void invalidateHabitActions(queryClient, habitId);
+      void invalidateHabitActionsByDate(queryClient);
       void invalidateHabitStats(queryClient, habitId);
     },
     onError: (err: Error) => {

--- a/web/src/hooks/useTimelogMutations.ts
+++ b/web/src/hooks/useTimelogMutations.ts
@@ -6,6 +6,7 @@ import {
   type QueryLike,
 } from "@/services/api/queryPredicates";
 import {
+  invalidateTimelogLatestEndTime,
   invalidateTimelogLists,
   invalidateTimelogsAdvancedSearch,
   removeTimelogDetailCache,
@@ -53,6 +54,7 @@ export function useTimelogMutations() {
   const scheduleTimelogRefresh = (context: string) => {
     void Promise.all([
       invalidateTimelogLists(queryClient),
+      invalidateTimelogLatestEndTime(queryClient),
       invalidateTimelogsAdvancedSearch(queryClient),
     ]).catch((error) => {
       logger.warn(context, error);

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -1763,19 +1763,34 @@
       "descriptionPlaceholder": "Describe the purpose and goals of this habit...",
       "startDateHint": "Please select the start date for this habit",
       "duration": "Duration (Days)",
+      "cadenceFrequency": "Repeats",
+      "targetPerCycle": "Required per cycle",
+      "weekdays": "Weekdays",
+      "monthdays": "Month days",
+      "monthdaysHint": "Leave empty for any day in the selected calendar month.",
+      "monthdaysPlaceholder": "For example: 1,15,28",
+      "endMode": "Ends",
+      "repeatCount": "Repeat count",
+      "endDate": "End date",
       "status": "Habit Status"
     },
-    "durationOptions": {
-      "7": "7 days",
-      "14": "14 days",
-      "21": "21 days",
-      "100": "100 days",
-      "365": "365 days",
-      "1000": "1000 days"
+    "cadence": {
+      "daily": "Daily",
+      "weekly": "Weekly",
+      "monthly": "Monthly",
+      "yearly": "Yearly"
+    },
+    "endMode": {
+      "repeatCount": "After count",
+      "untilDate": "On date"
     },
     "validation": {
       "titleRequired": "Please enter habit title",
-      "startDateRequired": "Please select start date"
+      "startDateRequired": "Please select start date",
+      "repeatCountRequired": "Please enter a repeat count greater than zero",
+      "endDateRequired": "Please select an end date",
+      "endDateAfterStart": "End date must be on or after start date",
+      "monthdaysInvalid": "Month days must be numbers from 1 to 31"
     },
     "messages": {
       "createSuccess": "Habit created successfully",

--- a/web/src/locales/zh/common.json
+++ b/web/src/locales/zh/common.json
@@ -1763,19 +1763,34 @@
       "descriptionPlaceholder": "描述这个习惯的意义和目标...",
       "startDateHint": "请选择习惯的开始日期",
       "duration": "持续天数",
+      "cadenceFrequency": "循环方式",
+      "targetPerCycle": "每周期需完成",
+      "weekdays": "每周日期",
+      "monthdays": "每月日期",
+      "monthdaysHint": "留空表示所选历法月内任意日期都可记录。",
+      "monthdaysPlaceholder": "例如：1,15,28",
+      "endMode": "结束方式",
+      "repeatCount": "重复次数",
+      "endDate": "截止日期",
       "status": "习惯状态"
     },
-    "durationOptions": {
-      "7": "7天",
-      "14": "14天",
-      "21": "21天",
-      "100": "100天",
-      "365": "365天",
-      "1000": "1000天"
+    "cadence": {
+      "daily": "每天",
+      "weekly": "每周",
+      "monthly": "每月",
+      "yearly": "每年"
+    },
+    "endMode": {
+      "repeatCount": "按次数",
+      "untilDate": "到日期"
     },
     "validation": {
       "titleRequired": "请输入习惯标题",
-      "startDateRequired": "请选择开始日期"
+      "startDateRequired": "请选择开始日期",
+      "repeatCountRequired": "请输入大于 0 的重复次数",
+      "endDateRequired": "请选择截止日期",
+      "endDateAfterStart": "截止日期不能早于开始日期",
+      "monthdaysInvalid": "每月日期必须是 1 到 31 的数字"
     },
     "messages": {
       "createSuccess": "习惯创建成功",

--- a/web/src/pages/FinancePage.tsx
+++ b/web/src/pages/FinancePage.tsx
@@ -6,6 +6,7 @@ import ActionButton, { CreateNewButton } from "@/components/ActionButton";
 import ConfirmDialog from "@/components/ConfirmDialog";
 import ErrorDisplay from "@/components/ErrorDisplay";
 import { FormField, TextInput } from "@/components/forms";
+import { SELECT_LABEL_TEXT_CLASS } from "@/components/forms/styles";
 import LoadingSpinner from "@/components/LoadingSpinner";
 import AssetSelect from "@/components/selects/AssetSelect";
 import ToolbarContainer from "@/components/ToolbarContainer";
@@ -1289,7 +1290,9 @@ function FinanceNodeFormModal({
           />
         </FormField>
         <label className="form-control">
-          <span className="label-text">{t("finance.tree.parent")}</span>
+          <span className={SELECT_LABEL_TEXT_CLASS}>
+            {t("finance.tree.parent")}
+          </span>
           <select
             className="select select-bordered select-sm"
             value={parentId}

--- a/web/src/pages/TimeLogPage.tsx
+++ b/web/src/pages/TimeLogPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import type {
   Timelog,
@@ -34,6 +35,8 @@ import { useQueryMode } from "@/hooks/useQueryMode";
 import TimeLogBulkImportPanel from "@/features/timeLog/bulkImport/TimeLogBulkImportPanel";
 import { createModalSessionId } from "@/utils/session";
 import { SelectorSpecialValue } from "@/components/selects/selectorTypes";
+import { timelogsApi } from "@/services/api/timelogs";
+import { timelogsKeys } from "@/services/api/queryKeys";
 
 const TimeLogPage = () => {
   const { t } = useTranslation();
@@ -113,7 +116,13 @@ const TimeLogPage = () => {
     });
   }, [activeTimelogForNotes]);
 
-  const latestTimelogEndTime = useMemo(() => {
+  const latestTimelogEndTimeQuery = useQuery({
+    queryKey: timelogsKeys.latestEndTime(),
+    queryFn: () => timelogsApi.fetchLatestEndTime(),
+    staleTime: 30 * 1000,
+  });
+
+  const currentEntriesLatestEndTime = useMemo(() => {
     let latestMs = Number.NEGATIVE_INFINITY;
     let latestEnd: string | null = null;
 
@@ -129,6 +138,9 @@ const TimeLogPage = () => {
 
     return latestEnd;
   }, [processedEntries]);
+
+  const latestTimelogEndTime =
+    latestTimelogEndTimeQuery.data?.end_time ?? currentEntriesLatestEndTime;
 
   // Request concurrency guards - removed as it's now handled in the hook
 

--- a/web/src/pages/VisionsPage.tsx
+++ b/web/src/pages/VisionsPage.tsx
@@ -52,7 +52,7 @@ const VisionPage: React.FC = () => {
               onChange={(value) => setStatusFilter(value as string)}
               options={VISION_STATUS_FILTER_OPTIONS}
               autoWidth
-              className="text-sm sm:text-base min-w-[140px]"
+              className="text-sm min-w-[140px]"
               id="vision-status-filter"
             />
           </div>

--- a/web/src/services/api/__tests__/timelogs.test.ts
+++ b/web/src/services/api/__tests__/timelogs.test.ts
@@ -10,6 +10,30 @@ describe("timelogsApi", () => {
     vi.restoreAllMocks();
   });
 
+  it("fetches the latest timelog end time", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          end_time: "2026-07-04T16:30:00+00:00",
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    const response = await timelogsApi.fetchLatestEndTime();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(localUrl(ENDPOINTS.TIMELOGS.LATEST_END_TIME));
+    expect(init.method).toBe("GET");
+    expect(response).toEqual({
+      end_time: "2026-07-04T16:30:00+00:00",
+    });
+  });
+
   it("fetches ranges with exact UTC window boundaries", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(

--- a/web/src/services/api/cacheInvalidation/__tests__/habits.test.ts
+++ b/web/src/services/api/cacheInvalidation/__tests__/habits.test.ts
@@ -1,0 +1,55 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  invalidateHabitActions,
+  invalidateHabitActionsByDate,
+} from "@/services/api/cacheInvalidation/habits";
+import { habitsKeys } from "@/services/api/queryKeys";
+import type { QueryLike } from "@/services/api/queryPredicates";
+
+describe("habit cache invalidation helpers", () => {
+  let invalidateQueriesMock: ReturnType<typeof vi.fn>;
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    invalidateQueriesMock = vi.fn().mockResolvedValue(undefined);
+    queryClient = {
+      invalidateQueries: invalidateQueriesMock,
+    } as unknown as QueryClient;
+  });
+
+  it("invalidates only action queries for one habit", () => {
+    invalidateHabitActions(queryClient, "habit-1");
+
+    expect(invalidateQueriesMock).toHaveBeenCalledTimes(1);
+    const [{ predicate }] = invalidateQueriesMock.mock.calls[0] as [
+      { predicate: (query: QueryLike) => boolean },
+    ];
+
+    expect(
+      predicate({ queryKey: habitsKeys.actions("habit-1", { page: 1 }) }),
+    ).toBe(true);
+    expect(
+      predicate({ queryKey: habitsKeys.actions("habit-2", { page: 1 }) }),
+    ).toBe(false);
+    expect(predicate({ queryKey: habitsKeys.actionsByDate("2026-07-04") }))
+      .toBe(false);
+  });
+
+  it("invalidates habit actions grouped by date", () => {
+    invalidateHabitActionsByDate(queryClient);
+
+    expect(invalidateQueriesMock).toHaveBeenCalledTimes(1);
+    const [{ predicate }] = invalidateQueriesMock.mock.calls[0] as [
+      { predicate: (query: QueryLike) => boolean },
+    ];
+
+    expect(predicate({ queryKey: habitsKeys.actionsByDate("2026-07-04") }))
+      .toBe(true);
+    expect(
+      predicate({ queryKey: habitsKeys.actions("habit-1", { page: 1 }) }),
+    ).toBe(false);
+    expect(predicate({ queryKey: habitsKeys.list({}) })).toBe(false);
+  });
+});

--- a/web/src/services/api/cacheInvalidation/habits.ts
+++ b/web/src/services/api/cacheInvalidation/habits.ts
@@ -2,6 +2,7 @@ import type { QueryClient } from "@tanstack/react-query";
 
 import { habitsKeys } from "@/services/api/queryKeys";
 import {
+  isHabitsActionsByDateQuery,
   isHabitsActionsQuery,
   isHabitsListQuery,
   type QueryLike,
@@ -34,6 +35,11 @@ export const invalidateHabitActions = (queryClient: QueryClient, id: UUID) =>
         key[2] === id
       );
     },
+  });
+
+export const invalidateHabitActionsByDate = (queryClient: QueryClient) =>
+  queryClient.invalidateQueries({
+    predicate: (query) => isHabitsActionsByDateQuery(query as QueryLike),
   });
 
 export const setHabitDetailCache = (queryClient: QueryClient, habit: Habit) => {

--- a/web/src/services/api/cacheInvalidation/timelogs.ts
+++ b/web/src/services/api/cacheInvalidation/timelogs.ts
@@ -16,6 +16,12 @@ export const invalidateTimelogLists = (queryClient: QueryClient) =>
     predicate: (query) => isTimelogsListQuery(query as QueryLike),
   });
 
+export const invalidateTimelogLatestEndTime = (queryClient: QueryClient) =>
+  queryClient.invalidateQueries({
+    queryKey: timelogsKeys.latestEndTime(),
+    exact: true,
+  });
+
 export const invalidateTimelogList = (
   queryClient: QueryClient,
   filters: TimelogListFilters,

--- a/web/src/services/api/endpoints.ts
+++ b/web/src/services/api/endpoints.ts
@@ -35,6 +35,7 @@ export const ENDPOINTS = {
   },
   TIMELOGS: {
     BASE: `${API_V1}/timelogs/`,
+    LATEST_END_TIME: `${API_V1}/timelogs/latest-end-time`,
     BY_ID: (id: string) => `${API_V1}/timelogs/${id}`,
     BATCH_UPDATE: `${API_V1}/timelogs/batch-update`,
     TEMPLATES: {

--- a/web/src/services/api/habits.ts
+++ b/web/src/services/api/habits.ts
@@ -11,6 +11,10 @@ export interface Habit {
   description?: string | null;
   start_date: string;
   duration_days: number;
+  cadence_frequency?: string | null;
+  cadence_weekdays?: string[] | null;
+  cadence_monthdays?: number[] | null;
+  target_per_cycle?: number | null;
   status: string;
   stats?: HabitStats | null;
   task_id?: UUID | null;
@@ -21,7 +25,13 @@ export interface HabitCreate {
   title: string;
   description?: string;
   start_date: string;
-  duration_days: number;
+  duration_days?: number;
+  end_date?: string | null;
+  repeat_count?: number | null;
+  cadence_frequency?: string | null;
+  cadence_weekdays?: string[] | null;
+  cadence_monthdays?: number[] | null;
+  target_per_cycle?: number | null;
   task_id?: UUID | null;
 }
 
@@ -30,6 +40,12 @@ export interface HabitUpdate {
   description?: string;
   start_date?: string;
   duration_days?: number;
+  end_date?: string | null;
+  repeat_count?: number | null;
+  cadence_frequency?: string | null;
+  cadence_weekdays?: string[] | null;
+  cadence_monthdays?: number[] | null;
+  target_per_cycle?: number | null;
   status?: string;
   task_id?: UUID | null;
 }

--- a/web/src/services/api/queryKeys.ts
+++ b/web/src/services/api/queryKeys.ts
@@ -231,6 +231,7 @@ export const timelogsKeys = {
     sort_order?: "asc" | "desc";
     timezone?: string;
   }) => [...timelogsKeys.lists(), filters] as const,
+  latestEndTime: () => [...timelogsKeys.all, "latest-end-time"] as const,
   details: () => [...timelogsKeys.all, "detail"] as const,
   detail: (id: UUID) => [...timelogsKeys.details(), id] as const,
   advancedSearch: (filters: {

--- a/web/src/services/api/queryPredicates.ts
+++ b/web/src/services/api/queryPredicates.ts
@@ -121,6 +121,15 @@ export const isHabitsActionsQuery = (query: QueryLike): boolean => {
   );
 };
 
+export const isHabitsActionsByDateQuery = (query: QueryLike): boolean => {
+  if (!Array.isArray(query.queryKey)) return false;
+  return (
+    query.queryKey.length >= 3 &&
+    query.queryKey[0] === "habits" &&
+    query.queryKey[1] === "actions-by-date"
+  );
+};
+
 export const isAreasListQuery = (query: QueryLike): boolean => {
   if (!Array.isArray(query.queryKey)) return false;
   return (

--- a/web/src/services/api/timelogs.ts
+++ b/web/src/services/api/timelogs.ts
@@ -119,6 +119,10 @@ export type TimelogListResponse = ListResponse<
 
 export type TimelogAdvancedSearchResponse = TimelogListResponse;
 
+export interface LatestTimelogEndTimeResponse {
+  end_time: string | null;
+}
+
 const TIMELOG_PAGE_SIZE = 500;
 const MAX_TIMELOG_RANGE_PAGES = 100;
 
@@ -140,6 +144,11 @@ function toTimelogPayload(
 }
 
 export const timelogsApi = {
+  fetchLatestEndTime: () =>
+    http.get<LatestTimelogEndTimeResponse>(
+      ENDPOINTS.TIMELOGS.LATEST_END_TIME,
+    ),
+
   fetchRange: async (start: string, end: string, trackingMethod?: string) => {
     const items: Timelog[] = [];
     let firstResponse: TimelogListResponse | null = null;

--- a/web/src/utils/constants.ts
+++ b/web/src/utils/constants.ts
@@ -130,16 +130,6 @@ export const VISION_STATUS_FILTER_OPTIONS = [
 // All available vision statuses for filtering
 export const ALL_VISION_STATUSES = ["active", "archived", "fruit"];
 
-// Habit duration options for form dropdowns
-export const HABIT_DURATION_OPTIONS = [
-  { value: "7", label: t("habitForm.durationOptions.7") },
-  { value: "14", label: t("habitForm.durationOptions.14") },
-  { value: "21", label: t("habitForm.durationOptions.21") },
-  { value: "100", label: t("habitForm.durationOptions.100") },
-  { value: "365", label: t("habitForm.durationOptions.365") },
-  { value: "1000", label: t("habitForm.durationOptions.1000") },
-];
-
 export const HABIT_EDITABLE_DAYS = 10000;
 export const MAX_HABIT_ACTION_WINDOW_DAYS = 100;
 


### PR DESCRIPTION
## 背景

本 PR 针对习惯循环方式扩展：习惯不应只支持固定持续天数，还需要支持按重复次数结束、按截止日期结束，并在 Web 创建/编辑入口支持更多循环方式。

Closes #208

## 变更

- Web 习惯创建/编辑表单支持 daily、weekly、monthly、yearly 循环方式。
- Weekly 支持选择每周 1 个或多个星期几；Monthly 支持选择历法月内 1 个或多个日期。
- 结束方式支持“重复次数”和“截止日期”；Web 新建默认重复 100 次，对齐原“按天 100 天”的实际语义。
- 后端 create/update API 支持 `repeat_count` 与 `end_date`，并解析为现有 `duration_days` 窗口以保持数据模型兼容。
- 习惯的周、月、年周期统计和月内日期匹配按用户选择的历法设置演算。
- CLI 支持 `--monthdays` / `--clear-monthdays`，并补充相关帮助文案和测试。
- 修复 Web 表单与多个模态框内 label / 控件文本字号不一致的问题，收敛为一致的表单排版规则。
- 修复 Timelog 批量导入默认起始日期和首条开始时间未继承最新记录结束时间的问题。
- 修复编辑 habit 后相关 action 信息未主动刷新，以及 planning 中 habit action 的生命周期判断：暂停、过期或完成当天之前的合理 action 仍显示，从状态变更当天起不再显示。
- 清理 Web 旧固定时长下拉常量及未引用翻译键，收敛月份日期解析和 `target_per_cycle=0` 校验问题。

## 审查结论

- PR 与 `#208` 的关系准确，保留 `Closes #208`。
- 本轮死代码审查未发现高确信可删除的未使用代码；新增共享表单样式常量、query predicate、cache invalidation helper、API endpoint 与 habit recurrence helper 均有调用或测试覆盖。
- 未按死代码处理当前未直接接线但属于应用层/接入层边界的符号。

## 验证

- `bash ./scripts/dead_code_check.sh`：通过
- `git diff --check main...HEAD`：通过
- `bash ./scripts/web_validate.sh`：通过，65 个测试文件 / 237 tests passed
- `uv run pytest tests/test_domain_services_tasks_and_habits.py -k "status_changed_date or stops_after_status_change or discrete_target_dates or list_and_count_habit_actions_pass"`：4 passed
- `uv run pytest tests/test_web_cli.py -k "habit_actions_by_date_uses_lifecycle or habit_update_passes_end_date"`：2 passed
- `bash ./scripts/doctor.sh`：通过，含 PostgreSQL CLI integration coverage，13 passed
