### PR TITLE
enhance: Close vision experience loop

### DIFF
--- a/src/lifeos_cli/db/services/task_mutations.py
+++ b/src/lifeos_cli/db/services/task_mutations.py
@@ -29,6 +29,7 @@ from lifeos_cli.db.services.task_support import (
     validate_task_status,
     validate_task_status_change,
 )
+from lifeos_cli.db.services.visions import sync_vision_experience_for_vision_ids
 
 
 @dataclass(frozen=True)
@@ -161,7 +162,9 @@ async def move_task(
     target_parent_task_id = (
         cast(UUID | None, new_parent_task_id) if parent_change_requested else task.parent_task_id
     )
-    if new_vision_id is not None and new_vision_id != old_vision_id:
+    parent_changed = parent_change_requested and target_parent_task_id != old_parent_task_id
+    vision_changed = target_vision_id != old_vision_id
+    if new_vision_id is not None and vision_changed:
         await ensure_vision_exists(session, new_vision_id)
 
     if target_parent_task_id == task.id:
@@ -178,7 +181,7 @@ async def move_task(
     if new_display_order is not None:
         task.display_order = new_display_order
     updated_descendants: tuple[Task, ...] = ()
-    if target_vision_id != old_vision_id:
+    if vision_changed:
         task.vision_id = target_vision_id
         updated_descendants = await _update_descendant_visions(
             session,
@@ -198,6 +201,11 @@ async def move_task(
     ]
     for recompute_root_id in deduplicate_preserving_order(recompute_roots):
         await recompute_totals_upwards(session, recompute_root_id)
+    if parent_changed or vision_changed:
+        await sync_vision_experience_for_vision_ids(
+            session,
+            vision_ids=deduplicate_preserving_order([old_vision_id, target_vision_id]),
+        )
     await session.flush()
     await session.refresh(task)
     return TaskMoveResult(task=task, updated_descendants=updated_descendants)
@@ -314,6 +322,7 @@ async def update_task(
         if old_parent_task_id is not None:
             await recompute_totals_upwards(session, old_parent_task_id)
         await recompute_totals_upwards(session, task.id)
+        await sync_vision_experience_for_vision_ids(session, vision_ids=[task.vision_id])
     await session.flush()
     await session.refresh(task)
     return await _build_task_view(session, task)
@@ -329,11 +338,13 @@ async def delete_task(session: AsyncSession, *, task_id: UUID) -> None:
     if task is None:
         raise TaskNotFoundError(f"Task {task_id} was not found")
     old_parent_task_id = task.parent_task_id
+    old_vision_id = task.vision_id
     subtree = await load_task_subtree(session, root_task_id=task_id)
     for subtree_task in subtree:
         subtree_task.soft_delete()
     if old_parent_task_id is not None:
         await recompute_totals_upwards(session, old_parent_task_id)
+    await sync_vision_experience_for_vision_ids(session, vision_ids=[old_vision_id])
     await session.flush()
 
 

--- a/src/lifeos_cli/db/services/timelogs.py
+++ b/src/lifeos_cli/db/services/timelogs.py
@@ -58,6 +58,7 @@ from lifeos_cli.db.services.timelog_support import (
     validate_timelog_title,
     validate_tracking_method,
 )
+from lifeos_cli.db.services.visions import sync_vision_experience_for_task_ids
 
 
 @dataclass(frozen=True)
@@ -161,6 +162,14 @@ async def _recompute_timelog_dependents(
         old_task_id=change.previous.task_id,
         new_task_id=change.current.task_id,
     )
+    await sync_vision_experience_for_task_ids(
+        session,
+        task_ids=[
+            task_id
+            for task_id in (change.previous.task_id, change.current.task_id)
+            if task_id is not None
+        ],
+    )
     await recompute_timelog_stats_groupby_area_after_change(
         session,
         old_start_time=change.previous.start_time,
@@ -246,6 +255,10 @@ async def _flush_and_recompute_batch_timelog_dependents(
 
     for task_id in dict.fromkeys(affected_task_ids):
         await recompute_totals_upwards(session, task_id)
+    await sync_vision_experience_for_task_ids(
+        session,
+        task_ids=deduplicate_preserving_order(affected_task_ids),
+    )
 
     local_dates = tuple(sorted(affected_dates))
     if local_dates:

--- a/src/lifeos_cli/db/services/visions.py
+++ b/src/lifeos_cli/db/services/visions.py
@@ -106,11 +106,6 @@ def resolve_experience_rate_for_vision(vision: Vision) -> int:
     )
 
 
-def _apply_effective_experience_rate(vision: Vision, effective_rate: int) -> None:
-    if vision.experience_rate_per_hour is None:
-        vision.experience_rate_per_hour = effective_rate
-
-
 async def _ensure_area_exists(session: AsyncSession, area_id: UUID | None) -> None:
     if area_id is None:
         return
@@ -128,6 +123,78 @@ async def _load_active_tasks_for_vision(session: AsyncSession, vision_id: UUID) 
         .order_by(Task.display_order.asc(), Task.created_at.asc(), Task.id.asc())
     )
     return list((await session.execute(stmt)).scalars())
+
+
+async def _load_active_vision_ids_for_tasks(
+    session: AsyncSession,
+    *,
+    task_ids: list[UUID],
+) -> list[UUID]:
+    unique_task_ids = deduplicate_preserving_order(task_ids)
+    if not unique_task_ids:
+        return []
+    rows = await session.execute(
+        select(Task.vision_id).where(
+            Task.id.in_(unique_task_ids),
+            Task.deleted_at.is_(None),
+        )
+    )
+    return deduplicate_preserving_order([vision_id for vision_id in rows.scalars().all()])
+
+
+async def sync_vision_experience_for_vision_ids(
+    session: AsyncSession,
+    *,
+    vision_ids: list[UUID],
+) -> tuple[UUID, ...]:
+    """Synchronize derived experience for active visions."""
+    unique_vision_ids = deduplicate_preserving_order(vision_ids)
+    if not unique_vision_ids:
+        return ()
+    rows = await session.execute(
+        select(Vision).where(
+            Vision.id.in_(unique_vision_ids),
+            Vision.deleted_at.is_(None),
+        )
+    )
+    visions_by_id = {vision.id: vision for vision in rows.scalars().all()}
+    synced_ids: list[UUID] = []
+    for vision_id in unique_vision_ids:
+        vision = visions_by_id.get(vision_id)
+        if vision is None:
+            continue
+        tasks = await _load_active_tasks_for_vision(session, vision.id)
+        vision.sync_experience_with_actual_effort(
+            experience_rate_per_hour=resolve_experience_rate_for_vision(vision),
+            tasks=tasks,
+        )
+        synced_ids.append(vision.id)
+    await session.flush()
+    return tuple(synced_ids)
+
+
+async def sync_vision_experience_for_task_ids(
+    session: AsyncSession,
+    *,
+    task_ids: list[UUID],
+) -> tuple[UUID, ...]:
+    """Synchronize derived vision experience for active tasks' visions."""
+    vision_ids = await _load_active_vision_ids_for_tasks(session, task_ids=task_ids)
+    return await sync_vision_experience_for_vision_ids(session, vision_ids=vision_ids)
+
+
+async def sync_default_rate_vision_experience(session: AsyncSession) -> tuple[UUID, ...]:
+    """Synchronize visions that inherit the global default experience rate."""
+    rows = await session.execute(
+        select(Vision.id).where(
+            Vision.experience_rate_per_hour.is_(None),
+            Vision.deleted_at.is_(None),
+        )
+    )
+    return await sync_vision_experience_for_vision_ids(
+        session,
+        vision_ids=list(rows.scalars().all()),
+    )
 
 
 async def _build_vision_view(
@@ -288,6 +355,8 @@ async def update_vision(
         vision.experience_rate_per_hour = None
     elif experience_rate_per_hour is not None:
         vision.experience_rate_per_hour = validate_vision_experience_rate(experience_rate_per_hour)
+    if clear_experience_rate or experience_rate_per_hour is not None:
+        await sync_vision_experience_for_vision_ids(session, vision_ids=[vision.id])
     if clear_people:
         await sync_entity_people(
             session, entity_id=vision.id, entity_type="vision", desired_person_ids=[]
@@ -333,8 +402,6 @@ async def add_experience_to_vision(
         raise VisionNotFoundError(f"Vision {vision_id} was not found")
     if vision.status != "active":
         raise ValueError("Can only add experience to active visions")
-    effective_rate = resolve_experience_rate_for_vision(vision)
-    _apply_effective_experience_rate(vision, effective_rate)
     vision.add_experience(validate_experience_points(experience_points))
     await session.flush()
     await session.refresh(vision)
@@ -354,11 +421,9 @@ async def sync_vision_experience(
     )
     if vision is None:
         raise VisionNotFoundError(f"Vision {vision_id} was not found")
-    effective_rate = resolve_experience_rate_for_vision(vision)
-    _apply_effective_experience_rate(vision, effective_rate)
     tasks = await _load_active_tasks_for_vision(session, vision.id)
     vision.sync_experience_with_actual_effort(
-        experience_rate_per_hour=effective_rate,
+        experience_rate_per_hour=resolve_experience_rate_for_vision(vision),
         tasks=tasks,
     )
     await session.flush()
@@ -383,6 +448,7 @@ async def recompute_vision_task_efforts(
     root_task_ids = tuple(task.id for task in tasks if task.parent_task_id is None)
     for root_task_id in root_task_ids:
         await recompute_subtree_totals(session, root_task_id)
+    await sync_vision_experience_for_vision_ids(session, vision_ids=[vision.id])
     await session.flush()
     return VisionEffortRecomputeResult(vision_id=vision.id, recomputed_roots=root_task_ids)
 
@@ -457,8 +523,6 @@ async def harvest_vision(
         raise VisionNotReadyForHarvestError(
             "Vision is not ready for harvest (must be at final stage and active)"
         )
-    effective_rate = resolve_experience_rate_for_vision(vision)
-    _apply_effective_experience_rate(vision, effective_rate)
     vision.harvest()
     await session.flush()
     await session.refresh(vision)

--- a/src/lifeos_web/routers/preferences.py
+++ b/src/lifeos_web/routers/preferences.py
@@ -16,6 +16,8 @@ from lifeos_cli.config import (
     clear_config_cache,
     get_preferences_settings,
 )
+from lifeos_cli.db import session as db_session
+from lifeos_cli.db.services import visions as vision_services
 
 router = APIRouter(prefix="/preferences", tags=["preferences"])
 
@@ -191,6 +193,13 @@ def _preference_response(key: str) -> dict[str, Any]:
     return {"key": key, "value": value, "meta": meta}
 
 
+async def _sync_config_preference_dependents(key: str) -> None:
+    if key != "visions.experience_rate_per_hour":
+        return
+    async with db_session.session_scope() as session:
+        await vision_services.sync_default_rate_vision_experience(session)
+
+
 @router.get("/{key}")
 async def get_preference(key: str) -> dict[str, Any]:
     """Return local Web preference values."""
@@ -211,6 +220,7 @@ async def set_preference(key: str, payload: PreferenceUpdate) -> dict[str, Any]:
         except ConfigurationError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
         _set_process_config_override(key, payload.value)
+        await _sync_config_preference_dependents(key)
         response = _preference_response(key)
         if payload.module:
             response["meta"]["module"] = payload.module

--- a/src/lifeos_web/routers/visions.py
+++ b/src/lifeos_web/routers/visions.py
@@ -192,7 +192,7 @@ async def add_experience(
 
 @router.post("/{vision_id}/recompute-efforts")
 async def recompute_vision_efforts(vision_id: UUID, session: SessionDep) -> dict[str, object]:
-    """Recompute task effort totals for one vision."""
+    """Recompute task effort totals and derived experience for one vision."""
     try:
         result = await vision_services.recompute_vision_task_efforts(
             session,
@@ -204,6 +204,16 @@ async def recompute_vision_efforts(vision_id: UUID, session: SessionDep) -> dict
         "vision_id": str(result.vision_id),
         "recomputed_roots": [str(task_id) for task_id in result.recomputed_roots],
     }
+
+
+@router.post("/{vision_id}/sync-experience")
+async def sync_vision_experience(vision_id: UUID, session: SessionDep) -> dict[str, object]:
+    """Synchronize one vision's experience from current root task effort totals."""
+    try:
+        vision = await vision_services.sync_vision_experience(session, vision_id=vision_id)
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return _vision_payload(vision)
 
 
 @router.post("/{vision_id}/harvest")

--- a/tests/test_cli_integration_time.py
+++ b/tests/test_cli_integration_time.py
@@ -168,7 +168,7 @@ def test_real_cli_event_and_timelog_workflow(integration_context: IntegrationCon
     synced_vision_result = run_lifeos(integration_context, "vision", "show", vision_id)
     assert_ok(synced_vision_result)
     assert "experience_points: 39" in synced_vision_result.stdout
-    assert "experience_rate_per_hour: 60" in synced_vision_result.stdout
+    assert "experience_rate_per_hour: -" in synced_vision_result.stdout
     vision_with_tasks_result = run_lifeos(integration_context, "vision", "with-tasks", vision_id)
     assert_ok(vision_with_tasks_result)
     assert "  task_id\tstatus\tparent_task_id\tcontent" in vision_with_tasks_result.stdout

--- a/tests/test_domain_services_core.py
+++ b/tests/test_domain_services_core.py
@@ -449,6 +449,8 @@ def test_update_vision_can_clear_optional_fields(monkeypatch: pytest.MonkeyPatch
 
     monkeypatch.setattr(visions, "load_model_by_id", fake_load_vision)
     monkeypatch.setattr(visions, "_build_vision_view", _build_fake_vision_view)
+    sync_experience = AsyncMock()
+    monkeypatch.setattr(visions, "sync_vision_experience_for_vision_ids", sync_experience)
 
     updated_vision = asyncio.run(
         visions.update_vision(
@@ -463,6 +465,10 @@ def test_update_vision_can_clear_optional_fields(monkeypatch: pytest.MonkeyPatch
     assert updated_vision.description is None
     assert updated_vision.area_id is None
     assert updated_vision.experience_rate_per_hour is None
+    sync_experience.assert_awaited_once_with(
+        cast(Any, session),
+        vision_ids=[UUID("44444444-4444-4444-4444-444444444444")],
+    )
     session.flush.assert_awaited_once()
     session.commit.assert_not_called()
 
@@ -585,7 +591,7 @@ def test_sync_vision_experience_uses_root_task_effort(
         )
     )
 
-    assert synced.experience_rate_per_hour == 120
+    assert synced.experience_rate_per_hour is None
     assert synced.experience_points == 480
     assert synced.stage == 3
     session.flush.assert_awaited_once()

--- a/tests/test_domain_services_tasks_and_habits.py
+++ b/tests/test_domain_services_tasks_and_habits.py
@@ -137,8 +137,10 @@ def test_update_task_can_clear_parent_without_committing(
     monkeypatch.setattr(task_mutations, "_build_task_view", _identity_task_view)
     recompute_subtree = AsyncMock()
     recompute_upwards = AsyncMock()
+    sync_experience = AsyncMock()
     monkeypatch.setattr(task_mutations, "recompute_subtree_totals", recompute_subtree)
     monkeypatch.setattr(task_mutations, "recompute_totals_upwards", recompute_upwards)
+    monkeypatch.setattr(task_mutations, "sync_vision_experience_for_vision_ids", sync_experience)
 
     updated_task = asyncio.run(
         task_mutations.update_task(
@@ -155,6 +157,10 @@ def test_update_task_can_clear_parent_without_committing(
         UUID("22222222-2222-2222-2222-222222222222"),
     )
     recompute_upwards.assert_any_await(cast(Any, session), task.id)
+    sync_experience.assert_awaited_once_with(
+        cast(Any, session),
+        vision_ids=[UUID("11111111-1111-1111-1111-111111111111")],
+    )
     session.flush.assert_awaited_once()
     session.refresh.assert_awaited_once_with(task)
     session.commit.assert_not_called()
@@ -200,6 +206,7 @@ def test_move_task_updates_parent_vision_and_descendants(
 
     recompute_subtree = AsyncMock()
     recompute_upwards = AsyncMock()
+    sync_experience = AsyncMock()
     monkeypatch.setattr(task_mutations, "load_model_by_id", fake_load_task)
     monkeypatch.setattr(task_mutations, "ensure_vision_exists", fake_ensure_vision_exists)
     monkeypatch.setattr(task_mutations, "validate_parent_task", fake_validate_parent_task)
@@ -210,6 +217,7 @@ def test_move_task_updates_parent_vision_and_descendants(
     )
     monkeypatch.setattr(task_mutations, "recompute_subtree_totals", recompute_subtree)
     monkeypatch.setattr(task_mutations, "recompute_totals_upwards", recompute_upwards)
+    monkeypatch.setattr(task_mutations, "sync_vision_experience_for_vision_ids", sync_experience)
 
     result = asyncio.run(
         tasks.move_task(
@@ -228,6 +236,13 @@ def test_move_task_updates_parent_vision_and_descendants(
     assert task.vision_id == UUID("55555555-5555-5555-5555-555555555555")
     assert task.display_order == 7
     recompute_subtree.assert_awaited_once_with(cast(Any, session), task.id)
+    sync_experience.assert_awaited_once_with(
+        cast(Any, session),
+        vision_ids=[
+            UUID("22222222-2222-2222-2222-222222222222"),
+            UUID("55555555-5555-5555-5555-555555555555"),
+        ],
+    )
     recompute_upwards.assert_any_await(
         cast(Any, session),
         UUID("33333333-3333-3333-3333-333333333333"),
@@ -270,10 +285,12 @@ def test_move_task_preserves_parent_when_parent_change_is_not_requested(
 
     recompute_subtree = AsyncMock()
     recompute_upwards = AsyncMock()
+    sync_experience = AsyncMock()
     monkeypatch.setattr(task_mutations, "load_model_by_id", fake_load_task)
     monkeypatch.setattr(task_mutations, "validate_parent_task", fake_validate_parent_task)
     monkeypatch.setattr(task_mutations, "recompute_subtree_totals", recompute_subtree)
     monkeypatch.setattr(task_mutations, "recompute_totals_upwards", recompute_upwards)
+    monkeypatch.setattr(task_mutations, "sync_vision_experience_for_vision_ids", sync_experience)
 
     result = asyncio.run(
         tasks.move_task(
@@ -291,6 +308,7 @@ def test_move_task_preserves_parent_when_parent_change_is_not_requested(
         cast(Any, session),
         UUID("33333333-3333-3333-3333-333333333333"),
     )
+    sync_experience.assert_not_awaited()
     recompute_upwards.assert_any_await(cast(Any, session), task.id)
     assert recompute_upwards.await_count == 2
     session.flush.assert_awaited_once()
@@ -521,6 +539,7 @@ def test_delete_task_soft_deletes_subtree_without_committing(
 ) -> None:
     root_task = SimpleNamespace(
         id=UUID("11111111-1111-1111-1111-111111111111"),
+        vision_id=UUID("44444444-4444-4444-4444-444444444444"),
         parent_task_id=UUID("22222222-2222-2222-2222-222222222222"),
         soft_delete=Mock(),
     )
@@ -548,13 +567,19 @@ def test_delete_task_soft_deletes_subtree_without_committing(
         AsyncMock(return_value=[root_task, child_task]),
     )
     recompute_upwards = AsyncMock()
+    sync_experience = AsyncMock()
     monkeypatch.setattr(task_mutations, "recompute_totals_upwards", recompute_upwards)
+    monkeypatch.setattr(task_mutations, "sync_vision_experience_for_vision_ids", sync_experience)
 
     asyncio.run(task_mutations.delete_task(cast(Any, session), task_id=root_task.id))
 
     root_task.soft_delete.assert_called_once_with()
     child_task.soft_delete.assert_called_once_with()
     recompute_upwards.assert_awaited_once_with(cast(Any, session), root_task.parent_task_id)
+    sync_experience.assert_awaited_once_with(
+        cast(Any, session),
+        vision_ids=[UUID("44444444-4444-4444-4444-444444444444")],
+    )
     session.flush.assert_awaited_once()
     session.commit.assert_not_called()
 

--- a/tests/test_domain_services_time.py
+++ b/tests/test_domain_services_time.py
@@ -22,7 +22,7 @@ from lifeos_cli.db.models.event import Event
 from lifeos_cli.db.models.task import Task
 from lifeos_cli.db.models.timelog import Timelog
 from lifeos_cli.db.models.vision import Vision
-from lifeos_cli.db.services import events, task_effort, timelogs, visions
+from lifeos_cli.db.services import events, task_effort, task_mutations, timelogs, visions
 from lifeos_cli.db.session import configure_async_engine
 from tests.support import utc_datetime
 
@@ -155,6 +155,107 @@ def test_create_timelog_flushes_without_committing(monkeypatch: pytest.MonkeyPat
     assert timelog.end_time == utc_datetime(2026, 4, 10, 14, 0)
     assert session.flush.await_count == 2
     session.commit.assert_not_called()
+
+
+def test_timelog_mutations_sync_vision_experience() -> None:
+    async def scenario() -> None:
+        engine, session_factory = await _create_sqlite_session_factory()
+        try:
+            async with session_factory() as session:
+                vision = Vision(name="Build fitness", status="active")
+                session.add(vision)
+                await session.flush()
+                task = Task(
+                    vision_id=vision.id,
+                    content="Run",
+                    status="todo",
+                    priority=0,
+                    display_order=0,
+                )
+                session.add(task)
+                await session.flush()
+
+                created = await timelogs.create_timelog(
+                    session,
+                    payload=timelogs.TimelogCreateInput(
+                        title="Morning run",
+                        start_time=utc_datetime(2026, 4, 10, 11, 0),
+                        end_time=utc_datetime(2026, 4, 10, 11, 30),
+                        task_id=task.id,
+                    ),
+                )
+                await session.refresh(task)
+                await session.refresh(vision)
+
+                assert task.actual_effort_self == 30
+                assert task.actual_effort_total == 30
+                assert vision.experience_points == 30
+                assert vision.stage == 0
+
+                await timelogs.update_timelog(
+                    session,
+                    timelog_id=created.id,
+                    changes=timelogs.TimelogUpdateInput(
+                        end_time=utc_datetime(2026, 4, 10, 12, 0),
+                    ),
+                )
+                await session.refresh(task)
+                await session.refresh(vision)
+
+                assert task.actual_effort_self == 60
+                assert task.actual_effort_total == 60
+                assert vision.experience_points == 60
+
+                await timelogs.delete_timelog(session, timelog_id=created.id)
+                await session.refresh(task)
+                await session.refresh(vision)
+
+                assert task.actual_effort_self == 0
+                assert task.actual_effort_total == 0
+                assert vision.experience_points == 0
+        finally:
+            await engine.dispose()
+
+    asyncio.run(scenario())
+
+
+def test_task_delete_syncs_vision_experience() -> None:
+    async def scenario() -> None:
+        engine, session_factory = await _create_sqlite_session_factory()
+        try:
+            async with session_factory() as session:
+                vision = Vision(name="Build focus", status="active")
+                session.add(vision)
+                await session.flush()
+                task = Task(
+                    vision_id=vision.id,
+                    content="Deep work",
+                    status="todo",
+                    priority=0,
+                    display_order=0,
+                    actual_effort_self=120,
+                    actual_effort_total=120,
+                )
+                session.add(task)
+                await session.flush()
+
+                await visions.sync_vision_experience_for_vision_ids(
+                    session,
+                    vision_ids=[vision.id],
+                )
+                await session.refresh(vision)
+                assert vision.experience_points == 120
+                assert vision.stage == 1
+
+                await task_mutations.delete_task(session, task_id=task.id)
+                await session.refresh(vision)
+
+                assert vision.experience_points == 0
+                assert vision.stage == 0
+        finally:
+            await engine.dispose()
+
+    asyncio.run(scenario())
 
 
 def test_create_event_normalizes_offset_datetimes_to_utc(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1160,6 +1261,12 @@ def test_update_timelog_can_clear_optional_fields(monkeypatch: pytest.MonkeyPatc
         "recompute_timelog_stats_groupby_area_after_change",
         recompute_timelog_stats,
     )
+    sync_vision_experience = AsyncMock()
+    monkeypatch.setattr(
+        timelogs,
+        "sync_vision_experience_for_task_ids",
+        sync_vision_experience,
+    )
 
     updated_timelog = asyncio.run(
         timelogs.update_timelog(
@@ -1182,6 +1289,10 @@ def test_update_timelog_can_clear_optional_fields(monkeypatch: pytest.MonkeyPatc
     assert updated_timelog.notes is None
     assert updated_timelog.area_id is None
     assert updated_timelog.task_id is None
+    sync_vision_experience.assert_awaited_once_with(
+        cast(Any, session),
+        task_ids=[UUID("22222222-2222-2222-2222-222222222222")],
+    )
     recompute_task_effort.assert_awaited_once_with(
         cast(Any, session),
         old_task_id=UUID("22222222-2222-2222-2222-222222222222"),
@@ -1357,7 +1468,13 @@ def test_batch_timelog_dependent_recompute_deduplicates_affected_tasks(
     timestamp = utc_datetime(2026, 4, 9, 12, 0)
     session = SimpleNamespace(flush=AsyncMock())
     recompute_task = AsyncMock()
+    sync_vision_experience = AsyncMock()
     monkeypatch.setattr(timelogs, "recompute_totals_upwards", recompute_task)
+    monkeypatch.setattr(
+        timelogs,
+        "sync_vision_experience_for_task_ids",
+        sync_vision_experience,
+    )
 
     previous = timelogs._TimelogDependencySnapshot(
         task_id=None,
@@ -1383,3 +1500,4 @@ def test_batch_timelog_dependent_recompute_deduplicates_affected_tasks(
     )
 
     recompute_task.assert_awaited_once_with(cast(Any, session), task_id)
+    sync_vision_experience.assert_awaited_once_with(cast(Any, session), task_ids=[task_id])

--- a/tests/test_web_cli.py
+++ b/tests/test_web_cli.py
@@ -1710,6 +1710,50 @@ def test_web_vision_recompute_efforts_calls_service(monkeypatch: pytest.MonkeyPa
     }
 
 
+def test_web_vision_sync_experience_calls_service(monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("fastapi")
+
+    from lifeos_web.routers import visions
+
+    vision_id = UUID("55555555-5555-5555-5555-555555555555")
+    captured: dict[str, object] = {}
+
+    async def fake_sync_experience(_session: object, **kwargs: object) -> object:
+        captured.update(kwargs)
+        return SimpleNamespace(
+            id=vision_id,
+            name="Vision",
+            description=None,
+            status="active",
+            stage=1,
+            experience_points=120,
+            experience_rate_per_hour=None,
+            area_id=None,
+            created_at=datetime(2026, 6, 1, 13, 0, tzinfo=timezone.utc),
+            updated_at=datetime(2026, 6, 1, 13, 0, tzinfo=timezone.utc),
+            deleted_at=None,
+            people=(),
+            tasks=(),
+        )
+
+    monkeypatch.setattr(
+        visions.vision_services,
+        "sync_vision_experience",
+        fake_sync_experience,
+    )
+
+    response = asyncio.run(
+        visions.sync_vision_experience(
+            vision_id,
+            cast(AsyncSession, object()),
+        )
+    )
+
+    assert captured["vision_id"] == vision_id
+    assert response["experience_points"] == 120
+    assert response["experience_rate_per_hour"] is None
+
+
 def test_web_vision_update_area_id_passes_through(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -2930,6 +2974,7 @@ def test_web_vision_experience_preference_persists_to_cli_config(
 ) -> None:
     pytest.importorskip("fastapi")
 
+    from lifeos_web.routers import preferences as preferences_router
     from lifeos_web.routers.preferences import PreferenceUpdate, get_preference, set_preference
 
     config_path = install_test_config(
@@ -2937,6 +2982,16 @@ def test_web_vision_experience_preference_persists_to_cli_config(
         tmp_path=tmp_path,
         include_preferences=True,
         vision_experience_rate_per_hour=60,
+    )
+    sync_calls: list[str] = []
+
+    async def fake_sync_dependents(key: str) -> None:
+        sync_calls.append(key)
+
+    monkeypatch.setattr(
+        preferences_router,
+        "_sync_config_preference_dependents",
+        fake_sync_dependents,
     )
 
     updated = asyncio.run(
@@ -2951,6 +3006,7 @@ def test_web_vision_experience_preference_persists_to_cli_config(
     assert reloaded["value"] == 120
 
     assert "vision_experience_rate_per_hour = 120" in config_path.read_text(encoding="utf-8")
+    assert sync_calls == ["visions.experience_rate_per_hour"]
 
 
 def test_web_theme_preference_persists_to_cli_config(

--- a/web/src/components/VisionManager.tsx
+++ b/web/src/components/VisionManager.tsx
@@ -253,17 +253,17 @@ const VisionManager = forwardRef<VisionManagerHandle, VisionManagerProps>(
       [requestDeleteVision],
     );
 
-    // 重新计算愿景时间投入
+    // Recompute effort and derived experience for one vision.
     const handleRecomputeVisionEfforts = useCallback(
       async (vision: Vision) => {
         try {
-          // 调用API重新计算愿景时间投入
+          // The backend also syncs derived vision experience after effort recompute.
           await visionsApi.recomputeEfforts(vision.id);
 
-          // 重新加载愿景数据以显示更新后的时间投入
+          // Reload visions so updated effort-derived experience is visible.
           await loadVisions();
 
-          // 如果当前愿景已展开，也重新加载其任务数据
+          // Reload tasks too when this vision is already expanded.
           if (expandedVisions.has(vision.id)) {
             await loadVisionTasks(vision.id, true);
           }

--- a/web/src/services/api/__tests__/visions.test.ts
+++ b/web/src/services/api/__tests__/visions.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/i18n", () => ({
+  t: vi.fn(
+    (key: string, opts?: { defaultValue?: string }) =>
+      opts?.defaultValue ?? key,
+  ),
+}));
+
+import { ENDPOINTS } from "@/services/api/endpoints";
+import { visionsApi } from "@/services/api/visions";
+
+const localUrl = (path: string) => new URL(path, "http://localhost").toString();
+
+describe("visionsApi", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("syncs derived experience through the dedicated endpoint", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: "vision-1",
+          name: "Build focus",
+          status: "active",
+          stage: 1,
+          experience_points: 120,
+          experience_rate_per_hour: null,
+          created_at: "2026-07-07T12:00:00Z",
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    const response = await visionsApi.syncExperience("vision-1");
+
+    expect(response.experience_rate_per_hour).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(localUrl(ENDPOINTS.VISIONS.SYNC_EXPERIENCE("vision-1")));
+    expect(init.method).toBe("POST");
+  });
+});

--- a/web/src/services/api/endpoints.ts
+++ b/web/src/services/api/endpoints.ts
@@ -18,6 +18,8 @@ export const ENDPOINTS = {
     ADD_EXPERIENCE: (id: string) => `${API_V1}/visions/${id}/add-experience`,
     RECOMPUTE_EFFORTS: (id: string) =>
       `${API_V1}/visions/${id}/recompute-efforts`,
+    SYNC_EXPERIENCE: (id: string) =>
+      `${API_V1}/visions/${id}/sync-experience`,
     HARVEST: (id: string) => `${API_V1}/visions/${id}/harvest`,
     STATS: (id: string) => `${API_V1}/visions/${id}/stats`,
     EXPERIENCE_RATES: `${API_V1}/visions/experience-rates`,

--- a/web/src/services/api/visions.ts
+++ b/web/src/services/api/visions.ts
@@ -13,7 +13,7 @@ export interface Vision {
   status: string;
   stage: number;
   experience_points: number;
-  experience_rate_per_hour: number;
+  experience_rate_per_hour: number | null;
   created_at: string;
   people?: PersonSummary[];
   // Optional aggregated minutes for display (if backend adds later)
@@ -116,6 +116,10 @@ export const visionsApi = {
     return http.post<{ vision_id: UUID; recomputed_roots: UUID[] }>(
       ENDPOINTS.VISIONS.RECOMPUTE_EFFORTS(id),
     );
+  },
+
+  async syncExperience(id: UUID): Promise<Vision> {
+    return http.post<Vision>(ENDPOINTS.VISIONS.SYNC_EXPERIENCE(id));
   },
 
   async bulkUpdateExperienceRates(


### PR DESCRIPTION
## 背景

本 PR 补齐愿景经验从配置、愿景费率、任务实际耗时到前后端展示的闭环。原实现已有 `/config` 默认经验设置、愿景编辑页每小时经验值、`/visions` 阶段与经验展示，但时间开销变更后不会稳定驱动愿景经验自动同步，且继承默认费率时会把默认值写回愿景覆盖字段。

## 变更

- 新增愿景经验同步服务层入口，支持按愿景、按任务、按默认费率继承范围同步。
- timelog 创建、更新、删除和批量导入后，同事务内先重算任务实际耗时，再同步受影响愿景经验。
- 任务移动、父级变更、删除后，同步受影响愿景经验。
- 愿景每小时经验值设置或清除后，立即按最新有效费率重算经验。
- `/config` 修改 `visions.experience_rate_per_hour` 后，同步所有继承默认费率的愿景。
- Web 新增 `POST /visions/{vision_id}/sync-experience` 作为手动修复入口，前端 API 类型允许 `experience_rate_per_hour: null`。
- 清理当前分支引入的重复前端同步调用，避免后端重算已同步后再次发起同类请求。

## 验证

- `bash ./scripts/dead_code_check.sh`
- `bash ./scripts/doctor.sh`
- `bash ./scripts/web_validate.sh`
- `git diff --check`
- `npm run lint`
- `npm run typecheck:test`

Closes #212
