### PR TITLE
docs: clarify combined optional extras install

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,6 @@ Install the optional local Web API and Web UI runtime dependencies when you want
 uv tool install --upgrade "lifeos-cli[web]"
 ```
 
-```bash
-uv tool install --upgrade "lifeos-cli[web,postgres]"
-```
-
 `lifeos-cli` supports SQLite and PostgreSQL.
 
 - SQLite is the low-friction option for local, single-user setups.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ Install the optional local Web API and Web UI runtime dependencies when you want
 uv tool install --upgrade "lifeos-cli[web]"
 ```
 
+If you need both Web and PostgreSQL support, install both extras in the same tool command:
+
+```bash
+uv tool install --upgrade "lifeos-cli[web,postgres]"
+```
+
+For an existing `uv tool` installation, each `uv tool install --upgrade` run syncs the requested extras for that tool. Installing only `[postgres]` after `[web]` removes the Web dependencies.
+
 `lifeos-cli` supports SQLite and PostgreSQL.
 
 - SQLite is the low-friction option for local, single-user setups.
@@ -153,6 +161,7 @@ lifeos web serve --static-dir web/dist
 If your configured database URL uses PostgreSQL, install or run with both optional extras:
 
 ```bash
+uv tool install --upgrade "lifeos-cli[web,postgres]"
 uv run --extra web --extra postgres lifeos web serve
 ```
 

--- a/README.md
+++ b/README.md
@@ -95,13 +95,9 @@ Install the optional local Web API and Web UI runtime dependencies when you want
 uv tool install --upgrade "lifeos-cli[web]"
 ```
 
-If you need both Web and PostgreSQL support, install both extras in the same tool command:
-
 ```bash
 uv tool install --upgrade "lifeos-cli[web,postgres]"
 ```
-
-For an existing `uv tool` installation, each `uv tool install --upgrade` run syncs the requested extras for that tool. Installing only `[postgres]` after `[web]` removes the Web dependencies.
 
 `lifeos-cli` supports SQLite and PostgreSQL.
 

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -95,6 +95,14 @@ uv tool install --upgrade "lifeos-cli[postgres]"
 uv tool install --upgrade "lifeos-cli[web]"
 ```
 
+如果需要同时支持 Web 和 PostgreSQL，请在同一次 tool 安装命令里声明两个 extras：
+
+```bash
+uv tool install --upgrade "lifeos-cli[web,postgres]"
+```
+
+对于已有的 `uv tool` 安装，每次 `uv tool install --upgrade` 都会按这一次请求的 extras 同步该工具环境。先装 `[web]` 再只装 `[postgres]` 会移除 Web 依赖。
+
 `lifeos-cli` 支持 SQLite 和 PostgreSQL。
 
 - SQLite 适合本地、单用户、低门槛使用场景。
@@ -153,6 +161,7 @@ lifeos web serve --static-dir web/dist
 如果当前配置的数据库 URL 使用 PostgreSQL，需要同时安装或运行 `web` 和 `postgres` 两个可选依赖：
 
 ```bash
+uv tool install --upgrade "lifeos-cli[web,postgres]"
 uv run --extra web --extra postgres lifeos web serve
 ```
 

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -95,13 +95,9 @@ uv tool install --upgrade "lifeos-cli[postgres]"
 uv tool install --upgrade "lifeos-cli[web]"
 ```
 
-如果需要同时支持 Web 和 PostgreSQL，请在同一次 tool 安装命令里声明两个 extras：
-
 ```bash
 uv tool install --upgrade "lifeos-cli[web,postgres]"
 ```
-
-对于已有的 `uv tool` 安装，每次 `uv tool install --upgrade` 都会按这一次请求的 extras 同步该工具环境。先装 `[web]` 再只装 `[postgres]` 会移除 Web 依赖。
 
 `lifeos-cli` 支持 SQLite 和 PostgreSQL。
 

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -95,10 +95,6 @@ uv tool install --upgrade "lifeos-cli[postgres]"
 uv tool install --upgrade "lifeos-cli[web]"
 ```
 
-```bash
-uv tool install --upgrade "lifeos-cli[web,postgres]"
-```
-
 `lifeos-cli` 支持 SQLite 和 PostgreSQL。
 
 - SQLite 适合本地、单用户、低门槛使用场景。


### PR DESCRIPTION
## 摘要

- 明确需要同时启用 Web 与 PostgreSQL 时，应使用 `lifeos-cli[web,postgres]` 一次性安装组合 extras。
- 说明 `uv tool install --upgrade` 会按本次声明的 extras 同步工具环境，避免用户误以为顺序安装会累加 extras。
- 同步更新英文 README 与简体中文 README companion。

## 验证

- `git diff --check`
- 临时 venv 安装 `.[web,postgres]` 并导入 `fastapi`、`uvicorn`、`psycopg`
- `bash ./scripts/doctor.sh`

Closes #216
