### PR TITLE
refactor(web): narrow task and person query boundaries

### DIFF
--- a/src/lifeos_cli/db/services/person_activity_queries.py
+++ b/src/lifeos_cli/db/services/person_activity_queries.py
@@ -1,0 +1,221 @@
+"""Person activity timeline query helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from lifeos_cli.db.models.association import Association
+from lifeos_cli.db.models.event import Event
+from lifeos_cli.db.models.note import Note
+from lifeos_cli.db.models.person_association import person_associations
+from lifeos_cli.db.models.task import Task
+from lifeos_cli.db.models.timelog import Timelog
+from lifeos_cli.db.models.vision import Vision
+
+
+@dataclass(frozen=True)
+class PersonActivity:
+    """One timestamped entity shown in a person's activity timeline."""
+
+    id: UUID
+    activity_type: str
+    title: str
+    description: str | None
+    activity_date: datetime
+    status: str | None = None
+    start_time: datetime | None = None
+    end_time: datetime | None = None
+    area_id: UUID | None = None
+
+
+@dataclass(frozen=True)
+class PersonActivityPage:
+    """A page of person activity results and derived timelog metadata."""
+
+    items: tuple[PersonActivity, ...]
+    total: int
+    timelog_count: int | None
+    timelog_total_minutes: int | None
+
+
+def _preview(value: str | None, *, limit: int = 160) -> str | None:
+    if value is None:
+        return None
+    normalized = " ".join(value.split())
+    if len(normalized) <= limit:
+        return normalized
+    return f"{normalized[: limit - 1]}..."
+
+
+async def _load_person_entity_ids(
+    session: AsyncSession,
+    *,
+    person_id: UUID,
+) -> dict[str, list[UUID]]:
+    rows = await session.execute(
+        select(
+            person_associations.c.entity_type,
+            person_associations.c.entity_id,
+        ).where(person_associations.c.person_id == person_id)
+    )
+    grouped: dict[str, list[UUID]] = {}
+    for entity_type, entity_id in rows.all():
+        grouped.setdefault(str(entity_type), []).append(entity_id)
+    return grouped
+
+
+async def _load_person_note_ids(session: AsyncSession, *, person_id: UUID) -> list[UUID]:
+    rows = await session.execute(
+        select(Association.source_id)
+        .distinct()
+        .where(
+            Association.source_model == "note",
+            Association.target_model == "person",
+            Association.target_id == person_id,
+            Association.link_type == "is_about",
+        )
+    )
+    return list(rows.scalars().all())
+
+
+async def _load_activity_items(
+    session: AsyncSession,
+    *,
+    person_id: UUID,
+    activity_filter: str | None,
+) -> list[PersonActivity]:
+    entity_ids = await _load_person_entity_ids(session, person_id=person_id)
+    items: list[PersonActivity] = []
+
+    if activity_filter in (None, "vision"):
+        vision_ids = entity_ids.get("vision", [])
+        if vision_ids:
+            vision_rows = await session.execute(
+                select(Vision).where(Vision.id.in_(vision_ids), Vision.deleted_at.is_(None))
+            )
+            items.extend(
+                PersonActivity(
+                    id=vision.id,
+                    activity_type="vision",
+                    title=vision.name,
+                    description=_preview(vision.description),
+                    activity_date=vision.updated_at,
+                    status=vision.status,
+                )
+                for vision in vision_rows.scalars()
+            )
+
+    if activity_filter in (None, "task"):
+        task_ids = entity_ids.get("task", [])
+        if task_ids:
+            task_rows = await session.execute(
+                select(Task).where(Task.id.in_(task_ids), Task.deleted_at.is_(None))
+            )
+            items.extend(
+                PersonActivity(
+                    id=task.id,
+                    activity_type="task",
+                    title=task.content,
+                    description=_preview(task.description),
+                    activity_date=task.updated_at,
+                    status=task.status,
+                )
+                for task in task_rows.scalars()
+            )
+
+    if activity_filter in (None, "planned_event"):
+        event_ids = entity_ids.get("event", [])
+        if event_ids:
+            event_rows = await session.execute(
+                select(Event).where(Event.id.in_(event_ids), Event.deleted_at.is_(None))
+            )
+            items.extend(
+                PersonActivity(
+                    id=event.id,
+                    activity_type="planned_event",
+                    title=event.title,
+                    description=_preview(event.description),
+                    activity_date=event.start_time,
+                    status=event.status,
+                )
+                for event in event_rows.scalars()
+            )
+
+    if activity_filter in (None, "timelog"):
+        timelog_ids = entity_ids.get("timelog", [])
+        if timelog_ids:
+            timelog_rows = await session.execute(
+                select(Timelog).where(Timelog.id.in_(timelog_ids), Timelog.deleted_at.is_(None))
+            )
+            items.extend(
+                PersonActivity(
+                    id=timelog.id,
+                    activity_type="timelog",
+                    title=timelog.title,
+                    description=None,
+                    activity_date=timelog.start_time,
+                    start_time=timelog.start_time,
+                    end_time=timelog.end_time,
+                    area_id=timelog.area_id,
+                )
+                for timelog in timelog_rows.scalars()
+            )
+
+    if activity_filter in (None, "note"):
+        note_ids = await _load_person_note_ids(session, person_id=person_id)
+        if note_ids:
+            note_rows = await session.execute(
+                select(Note).where(Note.id.in_(note_ids), Note.deleted_at.is_(None))
+            )
+            items.extend(
+                PersonActivity(
+                    id=note.id,
+                    activity_type="note",
+                    title=_preview(note.content) or "Note",
+                    description=None,
+                    activity_date=note.updated_at,
+                )
+                for note in note_rows.scalars()
+            )
+
+    return sorted(items, key=lambda item: item.activity_date.isoformat(), reverse=True)
+
+
+def _timelog_total_minutes(items: list[PersonActivity]) -> int:
+    total = 0
+    for item in items:
+        if item.activity_type != "timelog" or item.start_time is None or item.end_time is None:
+            continue
+        minutes = round((item.end_time - item.start_time).total_seconds() / 60)
+        if minutes > 0:
+            total += minutes
+    return total
+
+
+async def list_person_activities(
+    session: AsyncSession,
+    *,
+    person_id: UUID,
+    activity_filter: str | None,
+    limit: int,
+    offset: int,
+) -> PersonActivityPage:
+    """Load a page of activities while preserving the established timeline semantics."""
+    all_items = await _load_activity_items(
+        session,
+        person_id=person_id,
+        activity_filter=activity_filter,
+    )
+    return PersonActivityPage(
+        items=tuple(all_items[offset : offset + limit]),
+        total=len(all_items),
+        timelog_count=len(all_items) if activity_filter == "timelog" else None,
+        timelog_total_minutes=(
+            _timelog_total_minutes(all_items) if activity_filter == "timelog" else None
+        ),
+    )

--- a/src/lifeos_cli/db/services/task_queries.py
+++ b/src/lifeos_cli/db/services/task_queries.py
@@ -15,9 +15,12 @@ from lifeos_cli.application.calendar_adapter import (
     get_calendar_period_range,
 )
 from lifeos_cli.config import ConfigurationError
+from lifeos_cli.db.models.association import Association
+from lifeos_cli.db.models.note import Note
 from lifeos_cli.db.models.person import Person
 from lifeos_cli.db.models.person_association import person_associations
 from lifeos_cli.db.models.task import Task
+from lifeos_cli.db.models.timelog import Timelog
 from lifeos_cli.db.models.vision import Vision
 from lifeos_cli.db.services.entity_people import load_people_for_entities
 from lifeos_cli.db.services.model_utils import load_view_by_id
@@ -276,6 +279,42 @@ async def _build_task_views(session: AsyncSession, tasks: list[Task]) -> list[Ta
         entity_type="task",
     )
     return [build_task_view(task, people=people_map.get(task.id, ())) for task in tasks]
+
+
+async def load_task_relation_counts(
+    session: AsyncSession,
+    *,
+    task_ids: list[UUID],
+) -> tuple[dict[UUID, int], dict[UUID, int]]:
+    """Load active note and timelog counts for a set of tasks."""
+    unique_task_ids = list(dict.fromkeys(task_ids))
+    if not unique_task_ids:
+        return {}, {}
+
+    note_rows = await session.execute(
+        select(Association.target_id, func.count(Association.id))
+        .join(Note, Note.id == Association.source_id)
+        .where(
+            Association.source_model == "note",
+            Association.target_model == "task",
+            Association.link_type == "relates_to",
+            Association.target_id.in_(unique_task_ids),
+            Note.deleted_at.is_(None),
+        )
+        .group_by(Association.target_id)
+    )
+    timelog_rows = await session.execute(
+        select(Timelog.task_id, func.count(Timelog.id))
+        .where(
+            Timelog.task_id.in_(unique_task_ids),
+            Timelog.deleted_at.is_(None),
+        )
+        .group_by(Timelog.task_id)
+    )
+    return (
+        {task_id: int(count) for task_id, count in note_rows.all()},
+        {task_id: int(count) for task_id, count in timelog_rows.all()},
+    )
 
 
 async def get_task(

--- a/src/lifeos_web/routers/persons.py
+++ b/src/lifeos_web/routers/persons.py
@@ -3,23 +3,16 @@
 from __future__ import annotations
 
 import math
-from datetime import date, datetime
+from datetime import date
 from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from lifeos_cli.db.models.association import Association
-from lifeos_cli.db.models.event import Event
-from lifeos_cli.db.models.note import Note
-from lifeos_cli.db.models.person_association import person_associations
-from lifeos_cli.db.models.task import Task
-from lifeos_cli.db.models.timelog import Timelog
-from lifeos_cli.db.models.vision import Vision
 from lifeos_cli.db.services import people as people_services
+from lifeos_cli.db.services import person_activity_queries
 from lifeos_cli.db.services.read_models import PersonView, TagSummaryView
 from lifeos_web.deps import get_db_session
 from lifeos_web.schemas import ListResponse, Pagination
@@ -81,192 +74,23 @@ def _person_payload(person: PersonView) -> dict[str, object]:
     }
 
 
-def _preview(value: str | None, *, limit: int = 160) -> str | None:
-    if value is None:
-        return None
-    normalized = " ".join(value.split())
-    if len(normalized) <= limit:
-        return normalized
-    return f"{normalized[: limit - 1]}..."
-
-
-def _activity_payload(
-    *,
-    entity_id: UUID,
-    activity_type: str,
-    title: str,
-    description: str | None,
-    activity_date: date | datetime,
-    status: str | None = None,
-    extra: dict[str, object] | None = None,
-) -> dict[str, object]:
+def _activity_payload(item: person_activity_queries.PersonActivity) -> dict[str, object]:
+    """Convert a person activity query result to the established JSON shape."""
     payload: dict[str, object] = {
-        "id": str(entity_id),
-        "type": activity_type,
-        "title": title,
-        "description": _preview(description),
-        "date": activity_date.isoformat(),
-        "status": status,
+        "id": str(item.id),
+        "type": item.activity_type,
+        "title": item.title,
+        "description": item.description,
+        "date": item.activity_date.isoformat(),
+        "status": item.status,
     }
-    if extra:
-        payload.update(extra)
+    if item.start_time is not None:
+        payload["start_time"] = item.start_time.isoformat()
+    if item.end_time is not None:
+        payload["end_time"] = item.end_time.isoformat()
+    if item.activity_type == "timelog":
+        payload["area_id"] = str(item.area_id) if item.area_id else None
     return payload
-
-
-def _timelog_total_minutes(items: list[dict[str, object]]) -> int:
-    total = 0
-    for item in items:
-        if item.get("type") != "timelog":
-            continue
-        start = item.get("start_time")
-        end = item.get("end_time")
-        if not isinstance(start, str) or not isinstance(end, str):
-            continue
-        try:
-            start_dt = datetime.fromisoformat(start)
-            end_dt = datetime.fromisoformat(end)
-        except ValueError:
-            continue
-        minutes = round((end_dt - start_dt).total_seconds() / 60)
-        if minutes > 0:
-            total += minutes
-    return total
-
-
-async def _load_person_entity_ids(
-    session: AsyncSession,
-    *,
-    person_id: UUID,
-) -> dict[str, list[UUID]]:
-    rows = await session.execute(
-        select(
-            person_associations.c.entity_type,
-            person_associations.c.entity_id,
-        ).where(person_associations.c.person_id == person_id)
-    )
-    grouped: dict[str, list[UUID]] = {}
-    for entity_type, entity_id in rows.all():
-        grouped.setdefault(str(entity_type), []).append(entity_id)
-    return grouped
-
-
-async def _load_person_note_ids(session: AsyncSession, *, person_id: UUID) -> list[UUID]:
-    rows = await session.execute(
-        select(Association.source_id)
-        .distinct()
-        .where(
-            Association.source_model == "note",
-            Association.target_model == "person",
-            Association.target_id == person_id,
-            Association.link_type == "is_about",
-        )
-    )
-    return list(rows.scalars().all())
-
-
-async def _load_activity_items(
-    session: AsyncSession,
-    *,
-    person_id: UUID,
-    activity_filter: str | None,
-) -> list[dict[str, object]]:
-    entity_ids = await _load_person_entity_ids(session, person_id=person_id)
-    items: list[dict[str, object]] = []
-
-    if activity_filter in (None, "vision"):
-        vision_ids = entity_ids.get("vision", [])
-        if vision_ids:
-            vision_rows = await session.execute(
-                select(Vision).where(Vision.id.in_(vision_ids), Vision.deleted_at.is_(None))
-            )
-            items.extend(
-                _activity_payload(
-                    entity_id=vision.id,
-                    activity_type="vision",
-                    title=vision.name,
-                    description=vision.description,
-                    activity_date=vision.updated_at,
-                    status=vision.status,
-                )
-                for vision in vision_rows.scalars()
-            )
-
-    if activity_filter in (None, "task"):
-        task_ids = entity_ids.get("task", [])
-        if task_ids:
-            task_rows = await session.execute(
-                select(Task).where(Task.id.in_(task_ids), Task.deleted_at.is_(None))
-            )
-            items.extend(
-                _activity_payload(
-                    entity_id=task.id,
-                    activity_type="task",
-                    title=task.content,
-                    description=task.description,
-                    activity_date=task.updated_at,
-                    status=task.status,
-                )
-                for task in task_rows.scalars()
-            )
-
-    if activity_filter in (None, "planned_event"):
-        planned_event_ids = entity_ids.get("event", [])
-        if planned_event_ids:
-            planned_event_rows = await session.execute(
-                select(Event).where(Event.id.in_(planned_event_ids), Event.deleted_at.is_(None))
-            )
-            items.extend(
-                _activity_payload(
-                    entity_id=planned_event_record.id,
-                    activity_type="planned_event",
-                    title=planned_event_record.title,
-                    description=planned_event_record.description,
-                    activity_date=planned_event_record.start_time,
-                    status=planned_event_record.status,
-                )
-                for planned_event_record in planned_event_rows.scalars()
-            )
-
-    if activity_filter in (None, "timelog"):
-        timelog_ids = entity_ids.get("timelog", [])
-        if timelog_ids:
-            timelog_rows = await session.execute(
-                select(Timelog).where(Timelog.id.in_(timelog_ids), Timelog.deleted_at.is_(None))
-            )
-            items.extend(
-                _activity_payload(
-                    entity_id=timelog.id,
-                    activity_type="timelog",
-                    title=timelog.title,
-                    description=None,
-                    activity_date=timelog.start_time,
-                    extra={
-                        "start_time": timelog.start_time.isoformat(),
-                        "end_time": timelog.end_time.isoformat(),
-                        "area_id": str(timelog.area_id) if timelog.area_id else None,
-                    },
-                )
-                for timelog in timelog_rows.scalars()
-            )
-
-    if activity_filter in (None, "note"):
-        note_ids = await _load_person_note_ids(session, person_id=person_id)
-        if note_ids:
-            note_rows = await session.execute(
-                select(Note).where(Note.id.in_(note_ids), Note.deleted_at.is_(None))
-            )
-            items.extend(
-                _activity_payload(
-                    entity_id=note.id,
-                    activity_type="note",
-                    title=_preview(note.content) or "Note",
-                    description=None,
-                    activity_date=note.updated_at,
-                )
-                for note in note_rows.scalars()
-            )
-
-    return sorted(items, key=lambda item: str(item["date"]), reverse=True)
 
 
 @router.get("/", response_model=ListResponse)
@@ -396,30 +220,27 @@ async def list_person_activities(
     if activity_filter not in {None, "vision", "task", "planned_event", "timelog", "note"}:
         raise HTTPException(status_code=400, detail=f"Unsupported activity type: {activity_filter}")
 
-    all_items = await _load_activity_items(
+    result = await person_activity_queries.list_person_activities(
         session,
         person_id=person_id,
         activity_filter=activity_filter,
+        limit=size,
+        offset=(page - 1) * size,
     )
-    start = (page - 1) * size
-    items = all_items[start : start + size]
-    total = len(all_items)
     return ListResponse(
-        items=items,
+        items=[_activity_payload(item) for item in result.items],
         pagination=Pagination(
             page=page,
             size=size,
-            total=total,
-            pages=math.ceil(total / size) if size else 0,
+            total=result.total,
+            pages=math.ceil(result.total / size) if size else 0,
         ),
         meta={
             "person_id": str(person_id),
             "person_name": person.name,
             "activity_type": activity_filter,
-            "timelog_count": total if activity_filter == "timelog" else None,
-            "timelog_total_minutes": (
-                _timelog_total_minutes(all_items) if activity_filter == "timelog" else None
-            ),
+            "timelog_count": result.timelog_count,
+            "timelog_total_minutes": result.timelog_total_minutes,
         },
     )
 

--- a/src/lifeos_web/routers/tasks.py
+++ b/src/lifeos_web/routers/tasks.py
@@ -8,12 +8,9 @@ from typing import Annotated, Any
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from lifeos_cli.db.models.association import Association
-from lifeos_cli.db.models.note import Note
-from lifeos_cli.db.models.timelog import Timelog
+from lifeos_cli.db.services import task_queries
 from lifeos_cli.db.services import tasks as task_services
 from lifeos_web.deps import get_db_session
 from lifeos_web.schemas import (
@@ -57,41 +54,6 @@ def _collect_task_tree_ids(tasks: list[Any]) -> list[UUID]:
     for task in tasks:
         visit(task)
     return task_ids
-
-
-async def _load_task_relation_counts(
-    session: AsyncSession,
-    task_ids: list[UUID],
-) -> tuple[dict[UUID, int], dict[UUID, int]]:
-    unique_task_ids = list(dict.fromkeys(task_ids))
-    if not unique_task_ids:
-        return {}, {}
-
-    note_rows = await session.execute(
-        select(Association.target_id, func.count(Association.id))
-        .join(Note, Note.id == Association.source_id)
-        .where(
-            Association.source_model == "note",
-            Association.target_model == "task",
-            Association.link_type == "relates_to",
-            Association.target_id.in_(unique_task_ids),
-            Note.deleted_at.is_(None),
-        )
-        .group_by(Association.target_id)
-    )
-    timelog_rows = await session.execute(
-        select(Timelog.task_id, func.count(Timelog.id))
-        .where(
-            Timelog.task_id.in_(unique_task_ids),
-            Timelog.deleted_at.is_(None),
-        )
-        .group_by(Timelog.task_id)
-    )
-
-    return (
-        {task_id: count for task_id, count in note_rows.all()},
-        {task_id: count for task_id, count in timelog_rows.all()},
-    )
 
 
 def _page_envelope(
@@ -221,9 +183,9 @@ async def list_tasks(
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
-    notes_count_by_task, timelogs_count_by_task = await _load_task_relation_counts(
+    notes_count_by_task, timelogs_count_by_task = await task_queries.load_task_relation_counts(
         session,
-        [row.id for row in rows],
+        task_ids=[row.id for row in rows],
     )
     return _page_envelope(
         items=[
@@ -288,9 +250,9 @@ async def get_vision_hierarchy(vision_id: UUID, session: SessionDep) -> dict[str
     except LookupError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     task_ids = _collect_task_tree_ids(list(hierarchy.root_tasks))
-    notes_count_by_task, timelogs_count_by_task = await _load_task_relation_counts(
+    notes_count_by_task, timelogs_count_by_task = await task_queries.load_task_relation_counts(
         session,
-        task_ids,
+        task_ids=task_ids,
     )
     return {
         "vision_id": str(hierarchy.vision_id),
@@ -321,9 +283,9 @@ async def get_task(task_id: UUID, session: SessionDep) -> dict[str, object]:
     task = await task_services.get_task(session, task_id=task_id)
     if task is None:
         raise HTTPException(status_code=404, detail=f"Task {task_id} was not found")
-    notes_count_by_task, timelogs_count_by_task = await _load_task_relation_counts(
+    notes_count_by_task, timelogs_count_by_task = await task_queries.load_task_relation_counts(
         session,
-        [task.id],
+        task_ids=[task.id],
     )
     return _task_list_payload(
         task,
@@ -414,9 +376,9 @@ async def get_task_with_subtasks(task_id: UUID, session: SessionDep) -> dict[str
     if task is None:
         raise HTTPException(status_code=404, detail=f"Task {task_id} was not found")
     task_ids = _collect_task_tree_ids([task])
-    notes_count_by_task, timelogs_count_by_task = await _load_task_relation_counts(
+    notes_count_by_task, timelogs_count_by_task = await task_queries.load_task_relation_counts(
         session,
-        task_ids,
+        task_ids=task_ids,
     )
     return _task_tree_payload(
         task,

--- a/tests/test_note_services.py
+++ b/tests/test_note_services.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import warnings
-from datetime import date
+from datetime import date, datetime, timezone
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock
@@ -21,6 +21,7 @@ from lifeos_cli.db.base import Base
 from lifeos_cli.db.models.habit import Habit
 from lifeos_cli.db.models.habit_action import HabitAction
 from lifeos_cli.db.models.task import Task
+from lifeos_cli.db.models.timelog import Timelog
 from lifeos_cli.db.models.vision import Vision
 from lifeos_cli.db.services import habit_actions, notes, people, tags
 
@@ -214,7 +215,7 @@ def test_habit_action_notes_are_stored_as_linked_notes() -> None:
     asyncio.run(run())
 
 
-def test_web_task_relation_counts_include_related_notes() -> None:
+def test_task_relation_counts_exclude_soft_deleted_records() -> None:
     pytest.importorskip("fastapi")
 
     from lifeos_cli.db.services.task_queries import load_task_relation_counts
@@ -231,9 +232,37 @@ def test_web_task_relation_counts_include_related_notes() -> None:
                 await session.flush()
                 await notes.create_note(
                     session,
-                    content="Task note",
+                    content="Active task note",
                     task_ids=[task.id],
                 )
+                deleted_note = await notes.create_note(
+                    session,
+                    content="Deleted task note",
+                    task_ids=[task.id],
+                )
+                await notes.delete_note(session, note_id=deleted_note.id)
+
+                timestamp = datetime(2026, 7, 18, 12, 0, tzinfo=timezone.utc)
+                deleted_timelog = Timelog(
+                    title="Deleted task timelog",
+                    start_time=timestamp,
+                    end_time=timestamp.replace(minute=30),
+                    task_id=task.id,
+                )
+                session.add_all(
+                    [
+                        Timelog(
+                            title="Active task timelog",
+                            start_time=timestamp,
+                            end_time=timestamp.replace(minute=30),
+                            task_id=task.id,
+                        ),
+                        deleted_timelog,
+                    ]
+                )
+                await session.flush()
+                deleted_timelog.soft_delete()
+                await session.flush()
 
                 note_counts, timelog_counts = await load_task_relation_counts(
                     session,
@@ -241,7 +270,7 @@ def test_web_task_relation_counts_include_related_notes() -> None:
                 )
 
                 assert note_counts == {task.id: 1}
-                assert timelog_counts == {}
+                assert timelog_counts == {task.id: 1}
         finally:
             await engine.dispose()
 

--- a/tests/test_note_services.py
+++ b/tests/test_note_services.py
@@ -217,7 +217,7 @@ def test_habit_action_notes_are_stored_as_linked_notes() -> None:
 def test_web_task_relation_counts_include_related_notes() -> None:
     pytest.importorskip("fastapi")
 
-    from lifeos_web.routers.tasks import _load_task_relation_counts
+    from lifeos_cli.db.services.task_queries import load_task_relation_counts
 
     async def run() -> None:
         engine, session_factory = await _create_sqlite_session_factory()
@@ -235,9 +235,9 @@ def test_web_task_relation_counts_include_related_notes() -> None:
                     task_ids=[task.id],
                 )
 
-                note_counts, timelog_counts = await _load_task_relation_counts(
+                note_counts, timelog_counts = await load_task_relation_counts(
                     session,
-                    [task.id],
+                    task_ids=[task.id],
                 )
 
                 assert note_counts == {task.id: 1}

--- a/tests/test_person_activity_queries.py
+++ b/tests/test_person_activity_queries.py
@@ -1,0 +1,61 @@
+"""Unit tests for person activity timeline queries."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from typing import cast
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from lifeos_cli.db.services import person_activity_queries
+
+
+def test_list_person_activities_paginates_and_calculates_timelog_metadata(
+    monkeypatch,
+) -> None:
+    timestamp = datetime(2026, 7, 2, 9, 0, tzinfo=timezone.utc)
+    activities = [
+        person_activity_queries.PersonActivity(
+            id=UUID("11111111-1111-1111-1111-111111111111"),
+            activity_type="timelog",
+            title="Deep work",
+            description=None,
+            activity_date=timestamp,
+            start_time=timestamp,
+            end_time=datetime(2026, 7, 2, 9, 30, tzinfo=timezone.utc),
+        ),
+        person_activity_queries.PersonActivity(
+            id=UUID("22222222-2222-2222-2222-222222222222"),
+            activity_type="timelog",
+            title="Review",
+            description=None,
+            activity_date=timestamp,
+            start_time=timestamp,
+            end_time=datetime(2026, 7, 2, 10, 0, tzinfo=timezone.utc),
+        ),
+    ]
+
+    async def fake_load_activity_items(
+        _session: object,
+        **_kwargs: object,
+    ) -> list[person_activity_queries.PersonActivity]:
+        return activities
+
+    monkeypatch.setattr(person_activity_queries, "_load_activity_items", fake_load_activity_items)
+
+    result = asyncio.run(
+        person_activity_queries.list_person_activities(
+            cast(AsyncSession, object()),
+            person_id=UUID("33333333-3333-3333-3333-333333333333"),
+            activity_filter="timelog",
+            limit=1,
+            offset=1,
+        )
+    )
+
+    assert result.items == (activities[1],)
+    assert result.total == 2
+    assert result.timelog_count == 2
+    assert result.timelog_total_minutes == 90

--- a/tests/test_web_cli.py
+++ b/tests/test_web_cli.py
@@ -417,8 +417,10 @@ def test_web_task_list_basic_payload_excludes_full_task_fields(
 
     async def fake_load_task_relation_counts(
         _session: object,
-        _task_ids: list[UUID],
+        *,
+        task_ids: list[UUID],
     ) -> tuple[dict[UUID, int], dict[UUID, int]]:
+        assert task_ids == [UUID("11111111-1111-1111-1111-111111111111")]
         return (
             {UUID("11111111-1111-1111-1111-111111111111"): 4},
             {UUID("11111111-1111-1111-1111-111111111111"): 5},
@@ -427,8 +429,8 @@ def test_web_task_list_basic_payload_excludes_full_task_fields(
     monkeypatch.setattr(tasks.task_services, "list_tasks", fake_list_tasks)
     monkeypatch.setattr(tasks.task_services, "count_tasks", fake_count_tasks)
     monkeypatch.setattr(
-        tasks,
-        "_load_task_relation_counts",
+        tasks.task_queries,
+        "load_task_relation_counts",
         fake_load_task_relation_counts,
     )
 
@@ -579,27 +581,30 @@ def test_web_person_payload_preserves_tag_categories() -> None:
 
 def test_web_person_timelog_activity_payload_exposes_timeline_fields() -> None:
     pytest.importorskip("fastapi")
-    from lifeos_web.routers.persons import _activity_payload, _timelog_total_minutes
+    from lifeos_cli.db.services.person_activity_queries import (
+        PersonActivity,
+        _timelog_total_minutes,
+    )
+    from lifeos_web.routers.persons import _activity_payload
 
     timestamp = datetime(2026, 7, 2, 9, 0, tzinfo=timezone.utc)
-    payload = _activity_payload(
-        entity_id=UUID("11111111-1111-1111-1111-111111111111"),
+    activity = PersonActivity(
+        id=UUID("11111111-1111-1111-1111-111111111111"),
         activity_type="timelog",
         title="Deep work",
         description=None,
         activity_date=timestamp,
-        extra={
-            "start_time": "2026-07-02T09:00:00+00:00",
-            "end_time": "2026-07-02T09:30:00+00:00",
-            "area_id": "22222222-2222-2222-2222-222222222222",
-        },
+        start_time=timestamp,
+        end_time=datetime(2026, 7, 2, 9, 30, tzinfo=timezone.utc),
+        area_id=UUID("22222222-2222-2222-2222-222222222222"),
     )
+    payload = _activity_payload(activity)
 
     assert payload["status"] is None
     assert payload["start_time"] == "2026-07-02T09:00:00+00:00"
     assert payload["end_time"] == "2026-07-02T09:30:00+00:00"
     assert payload["area_id"] == "22222222-2222-2222-2222-222222222222"
-    assert _timelog_total_minutes([payload]) == 30
+    assert _timelog_total_minutes([activity]) == 30
 
 
 def test_web_habit_action_payload_uses_slim_habit_summary(
@@ -878,15 +883,17 @@ def test_web_tasks_list_uses_count_for_pagination_and_query(
 
     async def fake_load_task_relation_counts(
         _session: object,
-        _task_ids: list[UUID],
+        *,
+        task_ids: list[UUID],
     ) -> tuple[dict[UUID, int], dict[UUID, int]]:
+        assert task_ids == [UUID("11111111-1111-1111-1111-111111111111")]
         return ({}, {})
 
     monkeypatch.setattr(task_router.task_services, "list_tasks", fake_list_tasks)
     monkeypatch.setattr(task_router.task_services, "count_tasks", fake_count_tasks)
     monkeypatch.setattr(
-        task_router,
-        "_load_task_relation_counts",
+        task_router.task_queries,
+        "load_task_relation_counts",
         fake_load_task_relation_counts,
     )
 
@@ -1504,7 +1511,7 @@ def test_web_person_note_activity_payload_avoids_duplicate_note_content(
 ) -> None:
     pytest.importorskip("fastapi")
 
-    from lifeos_web.routers import persons
+    from lifeos_cli.db.services import person_activity_queries
 
     note_id = UUID("11111111-1111-1111-1111-111111111111")
     person_id = UUID("22222222-2222-2222-2222-222222222222")
@@ -1538,18 +1545,18 @@ def test_web_person_note_activity_payload_avoids_duplicate_note_content(
             return FakeResult()
 
     monkeypatch.setattr(
-        persons,
+        person_activity_queries,
         "_load_person_entity_ids",
         fake_load_person_entity_ids,
     )
     monkeypatch.setattr(
-        persons,
+        person_activity_queries,
         "_load_person_note_ids",
         fake_load_person_note_ids,
     )
 
     activities = asyncio.run(
-        persons._load_activity_items(
+        person_activity_queries._load_activity_items(
             cast(AsyncSession, FakeSession()),
             person_id=person_id,
             activity_filter="note",
@@ -1557,14 +1564,13 @@ def test_web_person_note_activity_payload_avoids_duplicate_note_content(
     )
 
     assert activities == [
-        {
-            "id": str(note_id),
-            "type": "note",
-            "title": "Remember the meeting notes",
-            "description": None,
-            "date": timestamp.isoformat(),
-            "status": None,
-        }
+        person_activity_queries.PersonActivity(
+            id=note_id,
+            activity_type="note",
+            title="Remember the meeting notes",
+            description=None,
+            activity_date=timestamp,
+        )
     ]
 
 


### PR DESCRIPTION
## 概要

- 将 task router 的 note/timelog 关系计数查询移至现有 `task_queries` 模块。
- 新增按用例命名的 person activities 查询模块，承载跨实体读取、预览、排序、分页与 timelog 汇总。
- task/person router 不再直接执行 SQLAlchemy 查询，仍保留简单 payload 转换与 HTTP 适配。

## 收敛边界

- 继续使用既有 `TaskView`、`TaskWithSubtasks` 和 task 查询服务；未为列表、详情或层级新增包装 read model。
- anniversaries 保持既有的存在性检查与空集合语义，不创建占位查询模型。
- 不引入 Pydantic response contract；该工作仍由 #223 处理。

## 兼容性与验证

- 保持 endpoint、参数、状态码、JSON shape、软删除过滤、排序、分页与时间语义。
- `bash ./scripts/doctor.sh` 通过（725 个默认测试、13 个 PostgreSQL 集成测试、lint、mypy、死代码扫描、构建与依赖审计）。
- `bash ./scripts/web_validate.sh` 通过（前端构建、lint、72 个测试文件 / 246 个测试）。
- 已补充 task 关系计数的 SQLite 回归测试，确认软删除 note 与 timelog 均不计入结果。

## 提交

- `refactor(web): narrow task and person query boundaries`
- `test(web): cover soft-deleted task relation counts`

Closes #234
Related #229
